### PR TITLE
feat: auto-detect AI models from provider API for both cli and web dashboard

### DIFF
--- a/cli/bin.mjs
+++ b/cli/bin.mjs
@@ -179,10 +179,9 @@ function makePrompter() {
   const askSecret = (q) =>
     new Promise((res) => {
       const orig = rl._writeToOutput.bind(rl);
-      process.stdout.write(q);
+      console.log(q);
       rl._writeToOutput = (s) => {
         if (s.includes("\n") || s.includes("\r")) orig(s);
-        else rl.output.write("*");
       };
       rl.question("", (answer) => {
         rl._writeToOutput = orig;
@@ -379,6 +378,47 @@ async function onboard() {
   const bundlerKey = (await p.askSecret(`  Pimlico API key${keep(current.bundlerApiKey || current.bundlerUrl)}: `)).trim();
   if (bundlerKey) current.bundlerApiKey = bundlerKey;
 
+  async function fetchModels(provId, apiKey, customUrl) {
+    const MODELS_BASE = {
+      merrymen: "", groq: "https://api.groq.com/openai/v1", openai: "https://api.openai.com/v1",
+      anthropic: "https://api.anthropic.com", google: "https://generativelanguage.googleapis.com/v1beta/openai",
+      xai: "https://api.x.ai/v1", deepseek: "https://api.deepseek.com", mistral: "https://api.mistral.ai/v1",
+      openrouter: "https://openrouter.ai/api/v1", together: "https://api.together.xyz/v1",
+      perplexity: "https://api.perplexity.ai", cerebras: "https://api.cerebras.ai/v1",
+      fireworks: "https://api.fireworks.ai/inference/v1", ollama: "http://localhost:11434/v1",
+    };
+    let url, headers = {};
+    if (provId === "anthropic") {
+      url = "https://api.anthropic.com/v1/models";
+      if (apiKey) { headers["x-api-key"] = apiKey; headers["anthropic-version"] = "2023-06-01"; }
+    } else if (provId === "google") {
+      url = "https://generativelanguage.googleapis.com/v1beta/models";
+      if (apiKey) headers["x-goog-api-key"] = apiKey;
+    } else if (provId === "custom") {
+      if (!customUrl) return [];
+      url = customUrl.replace(/\/+$/, "") + "/models";
+      if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+    } else {
+      const b = MODELS_BASE[provId];
+      if (!b) return [];
+      url = b.replace(/\/+$/, "") + "/models";
+      if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+    }
+    try {
+      const res = await fetch(url, { headers, signal: AbortSignal.timeout(8000) });
+      if (!res.ok) return [];
+      const json = await res.json();
+      const raw = Array.isArray(json.data) ? json.data : Array.isArray(json.models) ? json.models : [];
+      const models = [];
+      for (const entry of raw) {
+        const id = entry?.id || (entry?.name || "").replace(/^models\//, "");
+        if (id && /^[A-Za-z0-9._/:-]{1,128}$/.test(id)) models.push(id);
+      }
+      models.sort((a, b) => a.localeCompare(b));
+      return models;
+    } catch { return []; }
+  }
+
   console.log(bold(`\n  ${c.arrow} 2/4 · give it a brain`) + dim("  (optional — free to test)"));
   // Mirrors packages/core/src/llm-providers.ts. Kept inline because this CLI is
   // plain ESM and can't import the TS core. keyField routes the key to the field
@@ -424,9 +464,31 @@ async function onboard() {
     const brainKey = (await p.askSecret(`  ${chosen.label} API key${keep(current[chosen.keyField])}: `)).trim();
     if (brainKey) current[chosen.keyField] = brainKey;
   }
-  const modelPrompt = current[chosen.modelField] || chosen.def || "provider default";
-  const brainModel = (await p.ask(`  model [${modelPrompt}]: `)).trim();
-  if (brainModel) current[chosen.modelField] = brainModel;
+  // ── auto-detect available models ──────────────────────────────
+  let brainModels = [];
+  if (chosen.id !== "merrymen") {
+    const ak = current[chosen.keyField]?.trim();
+    const cu = chosen.custom ? current.llmBaseUrl?.trim() : undefined;
+    process.stdout.write(dim("  fetching available models…"));
+    brainModels = await fetchModels(chosen.id, ak || "", cu);
+    process.stdout.write("\r\x1b[K");
+  }
+
+  if (brainModels.length > 0) {
+    console.log(dim("  Available models:"));
+    const curModel = current[chosen.modelField] || chosen.def;
+    brainModels.forEach((m, i) => {
+      const marker = m === curModel ? green(" ← current") : "";
+      console.log(`  ${i + 1}. ${m}${marker}`);
+    });
+    const pick = (await p.ask(`  pick 1-${brainModels.length} [blank keeps${curModel ? ` ${curModel}` : " default"}]: `)).trim();
+    const idx = Number(pick) - 1;
+    if (pick && Number.isInteger(idx) && brainModels[idx]) current[chosen.modelField] = brainModels[idx];
+  } else {
+    const modelPrompt = current[chosen.modelField] || chosen.def || "provider default";
+    const brainModel = (await p.ask(`  model [${modelPrompt}]: `)).trim();
+    if (brainModel) current[chosen.modelField] = brainModel;
+  }
 
   console.log(bold(`\n  ${c.arrow} 3/4 · pick your outlaw`) + dim("  (strategy)"));
   const custom = await listCustom();

--- a/web/src/app/api/models/route.ts
+++ b/web/src/app/api/models/route.ts
@@ -1,0 +1,133 @@
+import { readFile } from "node:fs/promises";
+import { NextResponse } from "next/server";
+import { homePaths } from "@/lib/home";
+import { llmProviderById, type MerrymenSettings } from "@merrymen/core";
+
+export const dynamic = "force-dynamic";
+
+interface FetchModelsBody {
+  provider?: string;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+async function readSavedSettings(): Promise<MerrymenSettings> {
+  try {
+    return JSON.parse(
+      (await readFile(homePaths.settings(), "utf8")).replace(/^﻿/, ""),
+    ) as MerrymenSettings;
+  } catch {
+    return {};
+  }
+}
+
+function normalizeUrl(base: string): string {
+  return base.replace(/\/+$/, "") + "/models";
+}
+
+function filterModelId(id: string): string {
+  if (/^[A-Za-z0-9._/:-]{1,128}$/.test(id)) return id;
+  return "";
+}
+
+export async function POST(req: Request) {
+  let body: FetchModelsBody;
+  try {
+    body = (await req.json()) as FetchModelsBody;
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const saved = await readSavedSettings();
+  const providerId = body.provider || saved.llmProvider;
+  if (!providerId) {
+    return NextResponse.json({ error: "no provider specified and none saved" }, { status: 400 });
+  }
+
+  const prov = llmProviderById(providerId);
+  if (!prov) {
+    return NextResponse.json({ error: `unknown provider: ${providerId}` }, { status: 400 });
+  }
+
+  let apiKey = body.apiKey || "";
+  if (!apiKey) {
+    if (prov.id === "groq") apiKey = saved.groqApiKey ?? "";
+    else if (prov.id === "anthropic") apiKey = saved.anthropicApiKey ?? "";
+    else apiKey = saved.llmApiKey ?? "";
+  }
+
+  let baseUrl = prov.baseUrl;
+  if (prov.id === "custom") {
+    baseUrl = body.baseUrl?.trim() || saved.llmBaseUrl || "";
+    if (!baseUrl) {
+      return NextResponse.json({ error: "custom provider requires a base URL" }, { status: 400 });
+    }
+  }
+
+  let modelsUrl: string;
+  let headers: Record<string, string> = {};
+
+  if (prov.transport === "anthropic") {
+    modelsUrl = "https://api.anthropic.com/v1/models";
+    if (apiKey) {
+      headers["x-api-key"] = apiKey;
+      headers["anthropic-version"] = "2023-06-01";
+    }
+  } else if (prov.id === "google") {
+    modelsUrl = "https://generativelanguage.googleapis.com/v1beta/models";
+    if (apiKey) {
+      headers["x-goog-api-key"] = apiKey;
+    }
+  } else {
+    modelsUrl = normalizeUrl(baseUrl);
+    if (apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
+  }
+
+  try {
+    const res = await fetch(modelsUrl, { headers, signal: AbortSignal.timeout(10000) });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      const detail = text ? ` (${text.slice(0, 200)})` : "";
+      return NextResponse.json(
+        { error: `provider returned ${res.status}${detail}` },
+        { status: 502 },
+      );
+    }
+
+    const json = (await res.json()) as Record<string, unknown>;
+    let rawModels: unknown[] = [];
+
+    if (prov.id === "google") {
+      const m = json.models;
+      if (Array.isArray(m)) rawModels = m;
+    } else if (prov.transport === "anthropic") {
+      const d = json.data;
+      if (Array.isArray(d)) rawModels = d;
+    } else {
+      const d = json.data;
+      if (Array.isArray(d)) rawModels = d;
+    }
+
+    const models: string[] = [];
+    for (const entry of rawModels) {
+      if (entry && typeof entry === "object") {
+        let id = "";
+        if ("id" in (entry as Record<string, unknown>)) {
+          id = String((entry as Record<string, unknown>).id);
+        } else if ("name" in (entry as Record<string, unknown>)) {
+          id = String((entry as Record<string, unknown>).name).replace(/^models\//, "");
+        }
+        const filtered = filterModelId(id);
+        if (filtered) models.push(filtered);
+      }
+    }
+
+    models.sort((a, b) => a.localeCompare(b));
+    return NextResponse.json({ models });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    return NextResponse.json({ error: message }, { status: 502 });
+  }
+}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -482,6 +482,18 @@ button { font: inherit; cursor: pointer; }
   font-family: var(--mono); font-size: 15px; font-weight: 600;
   padding: 9px 0;
 }
+.field-input select {
+  flex: 1; min-width: 0;
+  background: transparent; border: none; outline: none;
+  color: var(--text);
+  font-family: var(--mono); font-size: 15px; font-weight: 600;
+  padding: 9px 0;
+  cursor: pointer;
+}
+.field-loading {
+  font-family: var(--mono); font-size: 13px; color: var(--text-faint);
+  padding: 9px 0;
+}
 .field-unit { font-family: var(--mono); font-size: 10px; color: var(--text-faint); }
 
 .grant-summary {
@@ -1030,6 +1042,14 @@ button { font: inherit; cursor: pointer; }
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 12%, transparent);
 }
 .setup-look .field-input input { font-family: var(--font-jbmono); font-size: 14px; font-weight: 500; }
+.setup-look .field-input select {
+  flex: 1; min-width: 0;
+  background: transparent; border: none; outline: none;
+  color: var(--text);
+  font-family: var(--font-jbmono); font-size: 14px; font-weight: 500;
+  padding: 9px 0; cursor: pointer;
+  appearance: auto;
+}
 .setup-look .field-hint {
   font-family: var(--font-hanken); font-size: 12px; line-height: 1.5;
   color: var(--text-faint);

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -66,6 +66,10 @@ export default function SettingsPage() {
   // The grant the browser holds, so the basket can say which symbols this
   // signature can actually get back out of. null = none stored yet.
   const [storedGrant, setStoredGrant] = useState<StoredGrant | null>(null);
+  // AI provider model listing — fetched from the provider's models API.
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [modelsLoading, setModelsLoading] = useState(false);
+  const [modelsError, setModelsError] = useState<string | null>(null);
 
   const loadTelegram = () =>
     fetch("/api/telegram")
@@ -90,6 +94,51 @@ export default function SettingsPage() {
       void loadTelegram();
     })();
   }, []);
+
+  // Debounced model fetch — triggers when provider, key, or custom URL changes.
+  useEffect(() => {
+    if (!view) return;
+    const providerId = draft.llmProvider ?? view.values.llmProvider ?? "groq";
+    const prov = view.llmProviders.find((p) => p.id === providerId);
+    if (!prov) { setAvailableModels([]); setModelsError(null); return; }
+
+    setAvailableModels([]);
+    setModelsLoading(true);
+    setModelsError(null);
+
+    const timer = setTimeout(async () => {
+      try {
+        const body: Record<string, string> = { provider: prov.id };
+        const kf = prov.id === "groq" ? "groqApiKey" : prov.id === "anthropic" ? "anthropicApiKey" : "llmApiKey";
+        const keyInDraft = draft[kf]?.trim();
+        if (keyInDraft) body.apiKey = keyInDraft;
+        if (prov.id === "custom") {
+          const bu = draft.llmBaseUrl?.trim() || (view.values.llmBaseUrl as string | undefined) || "";
+          if (bu) body.baseUrl = bu;
+        }
+        const res = await fetch("/api/models", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        const j = (await res.json()) as { models?: string[]; error?: string };
+        if (res.ok && j.models) {
+          setAvailableModels(j.models);
+          setModelsError(null);
+        } else {
+          setAvailableModels([]);
+          setModelsError(j.error ?? "failed to list models");
+        }
+      } catch {
+        setAvailableModels([]);
+        setModelsError("network error");
+      } finally {
+        setModelsLoading(false);
+      }
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [view, draft.llmProvider, draft.groqApiKey, draft.anthropicApiKey, draft.llmApiKey, draft.llmBaseUrl]);
 
   const set = (k: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) =>
     setDraft((d) => ({ ...d, [k]: e.target.value }));
@@ -346,14 +395,28 @@ export default function SettingsPage() {
             )}
             <Field
               label="model"
-              hint={`Which model to run. Blank uses the provider default${prov.defaultModel ? ` (${prov.defaultModel})` : ""}.`}
+              hint={`Which model to run. Blank uses the provider default${prov.defaultModel ? ` (${prov.defaultModel})` : ""}.${modelsError ? ` Could not list models: ${modelsError}` : ""}`}
             >
-              <input
-                type="text"
-                placeholder={prov.defaultModel || "model id"}
-                value={v(providerModelField as keyof SettingsView["values"])}
-                onChange={set(providerModelField)}
-              />
+              {modelsLoading ? (
+                <span className="field-loading">listing models…</span>
+              ) : availableModels.length > 0 ? (
+                <select
+                  value={v(providerModelField as keyof SettingsView["values"])}
+                  onChange={set(providerModelField)}
+                >
+                  <option value="">default{prov.defaultModel ? ` (${prov.defaultModel})` : ""}</option>
+                  {availableModels.map((m) => (
+                    <option key={m} value={m}>{m}</option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  type="text"
+                  placeholder={prov.defaultModel || "model id"}
+                  value={v(providerModelField as keyof SettingsView["values"])}
+                  onChange={set(providerModelField)}
+                />
+              )}
             </Field>
             <Field
               label="Pimlico API key"


### PR DESCRIPTION
Replace the freeform model text input with an auto-detected dropdown
in both the web settings page and the CLI onboarding wizard.

**Web settings (web/src/app/settings/page.tsx):**
- New `POST /api/models` route proxies model listing requests to each
  AI provider's models endpoint (OpenAI-compatible, Anthropic, Google)
- Model field now shows a `<select>` dropdown populated from the
  provider's API when successful, with fallback to text input on error
- Debounced fetch re-triggers on provider, API key, or custom URL changes

**CLI onboarding (cli/bin.mjs):**
- Added `fetchModels()` helper that calls each provider's models API
- After provider selection + key entry, lists available models as a
  numbered picker (same style as the provider selector)
- Falls back to freeform text input when the models endpoint is unreachable

**Fixes:**
- `askSecret` masked input: uses `console.log` + silent read to ensure
  the prompt label is always visible and backspace/ANSI sequences don't
  create phantom `*` characters
