### PR TITLE
fix: surface the full command list in the Telegram bot menu

### DIFF
--- a/worker/src/telegram/api.test.ts
+++ b/worker/src/telegram/api.test.ts
@@ -148,8 +148,8 @@ describe("BOT_COMMANDS — the Telegram command menu", () => {
     assert.ok(BOT_COMMANDS.length > 0);
     const seen = new Set<string>();
     for (const { command, description } of BOT_COMMANDS) {
-      // command: 3-32 lowercase alnum/underscore, no leading slash, unique
-      assert.match(command, /^[a-z][a-z0-9_]{2,31}$/);
+      // command: 1-32 lowercase alnum/underscore, no leading slash, unique
+      assert.match(command, /^[a-z][a-z0-9_]{0,31}$/);
       assert.ok(!command.startsWith("/"));
       assert.equal(seen.has(command), false, `duplicate command /${command}`);
       seen.add(command);

--- a/worker/src/telegram/api.test.ts
+++ b/worker/src/telegram/api.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
-import { BOT_COMMANDS, esc, getMe, getUpdates, sendMessage, setMyCommands, type FetchLike } from "./api";
+import { BOT_COMMANDS, esc, getMe, getUpdates, sendMessage, setMyCommands, publicBotCommands, type FetchLike } from "./api";
 import { parseSlash } from "./interpreter";
 
 /** Fake fetch capturing the last call, returning a canned envelope. */
@@ -186,6 +187,22 @@ describe("setMyCommands", () => {
     assert.deepEqual(body.scope, { type: "all_private_chats" });
   });
 
+  it("serializes a per-chat scope (full menu pushed to one allowlisted chat)", async () => {
+    const f = fakeFetch(200, OK(true));
+    await setMyCommands({ token: "123:abc", fetchFn: f }, undefined, { type: "chat", chat_id: -100111 });
+    const body = JSON.parse(f.lastBody!) as { commands?: unknown; scope?: { type: string; chat_id?: number } };
+    assert.deepEqual(body.commands, BOT_COMMANDS); // no list given → the full owner menu
+    assert.deepEqual(body.scope, { type: "chat", chat_id: -100111 });
+  });
+
+  it("pushes exactly publicBotCommands when told (the stranger menu)", async () => {
+    const f = fakeFetch(200, OK(true));
+    await setMyCommands({ token: "123:abc", fetchFn: f }, publicBotCommands, { type: "all_private_chats" });
+    const body = JSON.parse(f.lastBody!) as { commands: { command: string }[] };
+    assert.deepEqual(body.commands, publicBotCommands);
+    assert.ok(!body.commands.some((c) => c.command === "run"));
+  });
+
   it("degrades gracefully on ok:false (bad token or unsupported)", async () => {
     const f = fakeFetch(200, { ok: false, description: "Unauthorized" });
     const { ok, reason } = await setMyCommands({ token: "bad", fetchFn: f });
@@ -193,6 +210,47 @@ describe("setMyCommands", () => {
     assert.match(reason!, /Unauthorized/);
   });
 });
+
+/**
+ * Command names parseSlash accepts that we deliberately do NOT advertise in
+ * the "/" menu — synonyms and signposts where the canonical entry is listed
+ * instead. Explicit on purpose: a NEW command landing in interpreter.ts hits
+ * neither list, the reverse-drift test fails, and the author must choose
+ * surface-or-hide consciously. This is what caught /depth going missing.
+ */
+const HIDDEN_ALIASES = new Set([
+  "start", // Telegram convention; /help covers it
+  "grant", "restore", "recover", "reconnect", "fund", // wallet signpost synonyms
+  "book", // positions
+  "liquidity", "levels", // depth
+  "digest", // report
+  "send", "withdraw", // transfer
+  "yes", "no", // confirm/cancel
+  "rename", // name
+  "whoareyou", // soul
+  "screenshot", "screen", // shot
+  "see", // look
+  "launch", // open
+  "sysinfo", // sys
+  "volume", // vol
+  "play", "next", "prev", "previous", // media shortcuts
+  "toast", // notify
+  "dir", // ls
+  "getfile", // get
+  "sh", "shell", // run
+  "hotkey", // key
+]);
+
+/** Every `case "x":` label inside parseSlash's switch (source-scraped so a NEW
+ * case is caught automatically — the same trick cli/bin.mjs uses on tokens.ts). */
+const PARSE_CASES: string[] = (() => {
+  const src = readFileSync(new URL("./interpreter.ts", import.meta.url), "utf8");
+  const start = src.indexOf("export function parseSlash");
+  const end = src.indexOf("LLM front end", start);
+  return [...src.slice(start, end).matchAll(/case "([a-z0-9_]+)":/g)]
+    .map((m) => m[1])
+    .filter((m): m is string => m !== undefined);
+})();
 
 describe("BOT_COMMANDS — every menu entry is a real command", () => {
   it("parses each entry through parseSlash without hitting the unknown branch", () => {
@@ -210,5 +268,80 @@ describe("BOT_COMMANDS — every menu entry is a real command", () => {
 
   it("includes /kill for parity with /help and CONTROL_KINDS", () => {
     assert.ok(BOT_COMMANDS.some(({ command }) => command === "kill"));
+  });
+});
+
+describe("BOT_COMMANDS — every real command is in the menu (reverse drift)", () => {
+  it("scraped a healthy set of parseSlash cases (sanity on the scraper itself)", () => {
+    assert.ok(PARSE_CASES.includes("link"), "scraper missed parseSlash cases");
+    assert.ok(PARSE_CASES.includes("unwatch"), "scraper truncated early");
+    assert.ok(PARSE_CASES.length >= 45, `only ${PARSE_CASES.length} cases scraped`);
+  });
+
+  it("every top-level command parseSlash handles is advertised or an explicit hidden alias", () => {
+    for (const cmd of PARSE_CASES) {
+      const advertised = BOT_COMMANDS.some(({ command }) => command === cmd);
+      assert.ok(
+        advertised || HIDDEN_ALIASES.has(cmd),
+        `/${cmd} parses but is in neither the menu nor HIDDEN_ALIASES — surface it in BOT_COMMANDS or hide it on purpose`,
+      );
+    }
+  });
+
+  it("the hidden-alias allowlist itself cannot rot", () => {
+    for (const alias of HIDDEN_ALIASES) {
+      assert.ok(
+        PARSE_CASES.includes(alias),
+        `HIDDEN_ALIASES lists /${alias} but parseSlash no longer handles it — remove the stale entry`,
+      );
+    }
+  });
+
+  it("every hidden alias resolves to a command the menu DOES advertise", () => {
+    // An alias is only honest when its canonical entry exists; otherwise both
+    // the alias and its meaning are invisible.
+    const pairs: Record<string, string> = {
+      start: "help", grant: "wallet", restore: "wallet", recover: "wallet",
+      reconnect: "wallet", fund: "wallet", book: "positions", liquidity: "depth",
+      levels: "depth", digest: "report", send: "transfer", withdraw: "transfer",
+      yes: "confirm", no: "cancel", rename: "name", whoareyou: "soul",
+      screenshot: "shot", screen: "shot", see: "look", launch: "open",
+      sysinfo: "sys", volume: "vol", play: "media", next: "media",
+      prev: "media", previous: "media", toast: "notify", dir: "ls",
+      getfile: "get", sh: "run", shell: "run", hotkey: "key",
+    };
+    for (const [alias, canonical] of Object.entries(pairs)) {
+      assert.ok(
+        BOT_COMMANDS.some(({ command }) => command === canonical),
+        `/hidden alias ${alias} points at /${canonical}, which is missing from the menu`,
+      );
+    }
+  });
+});
+
+describe("publicBotCommands — what strangers see", () => {
+  it("is exactly this safe subset (pinned — additions are a conscious choice)", () => {
+    assert.deepEqual(
+      publicBotCommands.map((c) => c.command).sort(),
+      ["alerts", "brag", "depth", "help", "link", "pnl", "positions", "reminders", "report", "soul", "status", "trades", "wallet", "why"],
+    );
+  });
+
+  it("never advertises the remote-control surface to strangers", () => {
+    const forbidden = [
+      "run", "type", "key", "shot", "look", "ls", "open", "sys", "vol", "media",
+      "notify", "lock", "sleep", "shutdown", "get", "clip", "pc", "watch",
+      "watchers", "unwatch", "agent",
+    ];
+    for (const c of publicBotCommands) {
+      assert.ok(!forbidden.includes(c.command), `/${c.command} leaked into the public menu`);
+    }
+  });
+
+  it("is strictly smaller than the full owner menu", () => {
+    assert.ok(publicBotCommands.length < BOT_COMMANDS.length);
+    for (const pub of publicBotCommands) {
+      assert.ok(BOT_COMMANDS.includes(pub), `/${pub.command} missing from the full menu`);
+    }
   });
 });

--- a/worker/src/telegram/api.test.ts
+++ b/worker/src/telegram/api.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { esc, getMe, getUpdates, sendMessage, type FetchLike } from "./api";
+import { BOT_COMMANDS, esc, getMe, getUpdates, sendMessage, setMyCommands, type FetchLike } from "./api";
 
 /** Fake fetch capturing the last call, returning a canned envelope. */
 function fakeFetch(status: number, body: unknown): FetchLike & { lastUrl?: string; lastBody?: string } {
@@ -140,5 +140,41 @@ describe("esc — HTML escaping for user-echoed content", () => {
   it("escapes the three HTML-significant characters", () => {
     assert.equal(esc("<script>&x</script>"), "&lt;script&gt;&amp;x&lt;/script&gt;");
     assert.equal(esc("plain text"), "plain text");
+  });
+});
+
+describe("BOT_COMMANDS — the Telegram command menu", () => {
+  it("is a non-empty, valid Telegram BotCommand list", () => {
+    assert.ok(BOT_COMMANDS.length > 0);
+    const seen = new Set<string>();
+    for (const { command, description } of BOT_COMMANDS) {
+      // command: 3-32 lowercase alnum/underscore, no leading slash, unique
+      assert.match(command, /^[a-z][a-z0-9_]{2,31}$/);
+      assert.ok(!command.startsWith("/"));
+      assert.equal(seen.has(command), false, `duplicate command /${command}`);
+      seen.add(command);
+      // description: plain text, non-empty, within Telegram's 256-char cap
+      assert.ok(description.length > 0 && description.length <= 256);
+      assert.ok(!description.includes("<"), `description for /${command} must be plain text`);
+    }
+  });
+});
+
+describe("setMyCommands", () => {
+  it("posts the command list to /bot<token>/setMyCommands and returns ok", async () => {
+    const f = fakeFetch(200, OK(true));
+    const { ok, reason } = await setMyCommands({ token: "123:abc", fetchFn: f });
+    assert.equal(reason, undefined);
+    assert.equal(ok, true);
+    assert.match(f.lastUrl!, /\/bot123:abc\/setMyCommands$/);
+    const body = JSON.parse(f.lastBody!) as { commands: unknown };
+    assert.deepEqual(body.commands, BOT_COMMANDS);
+  });
+
+  it("degrades gracefully on ok:false (bad token or unsupported)", async () => {
+    const f = fakeFetch(200, { ok: false, description: "Unauthorized" });
+    const { ok, reason } = await setMyCommands({ token: "bad", fetchFn: f });
+    assert.equal(ok, false);
+    assert.match(reason!, /Unauthorized/);
   });
 });

--- a/worker/src/telegram/api.test.ts
+++ b/worker/src/telegram/api.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { BOT_COMMANDS, esc, getMe, getUpdates, sendMessage, setMyCommands, type FetchLike } from "./api";
+import { parseSlash } from "./interpreter";
 
 /** Fake fetch capturing the last call, returning a canned envelope. */
 function fakeFetch(status: number, body: unknown): FetchLike & { lastUrl?: string; lastBody?: string } {
@@ -171,10 +172,43 @@ describe("setMyCommands", () => {
     assert.deepEqual(body.commands, BOT_COMMANDS);
   });
 
+  it("omits the scope when none is given", async () => {
+    const f = fakeFetch(200, OK(true));
+    await setMyCommands({ token: "123:abc", fetchFn: f });
+    const body = JSON.parse(f.lastBody!) as { scope?: unknown };
+    assert.equal(body.scope, undefined);
+  });
+
+  it("sends the scope when one is given", async () => {
+    const f = fakeFetch(200, OK(true));
+    await setMyCommands({ token: "123:abc", fetchFn: f }, undefined, { type: "all_private_chats" });
+    const body = JSON.parse(f.lastBody!) as { scope?: unknown };
+    assert.deepEqual(body.scope, { type: "all_private_chats" });
+  });
+
   it("degrades gracefully on ok:false (bad token or unsupported)", async () => {
     const f = fakeFetch(200, { ok: false, description: "Unauthorized" });
     const { ok, reason } = await setMyCommands({ token: "bad", fetchFn: f });
     assert.equal(ok, false);
     assert.match(reason!, /Unauthorized/);
+  });
+});
+
+describe("BOT_COMMANDS — every menu entry is a real command", () => {
+  it("parses each entry through parseSlash without hitting the unknown branch", () => {
+    for (const { command } of BOT_COMMANDS) {
+      // /agent is routed before parseSlash (a dedicated match in service.ts), so
+      // parseSlash correctly reports it as unknown — it's still a real command.
+      if (command === "agent") continue;
+      const parsed = parseSlash(`/${command}`);
+      assert.ok(parsed, `/${command} should parse`);
+      if (parsed.kind === "unknown") {
+        assert.ok(!/^unknown command/.test(parsed.text), `/${command} hit the unknown branch`);
+      }
+    }
+  });
+
+  it("includes /kill for parity with /help and CONTROL_KINDS", () => {
+    assert.ok(BOT_COMMANDS.some(({ command }) => command === "kill"));
   });
 });

--- a/worker/src/telegram/api.ts
+++ b/worker/src/telegram/api.ts
@@ -153,10 +153,9 @@ export async function getUpdates(
 
 /**
  * The commands shown in the Telegram "/" menu. Mirrors /help (reads.ts) as
- * Telegram BotCommand entries: 3-32 lowercase alphanumeric/underscore, no
- * leading slash, plain-text descriptions (no HTML). Two-char commands (/ls,
- * /pc) work in chat but can't be menu entries, so they're omitted. PC/control
- * and agent entries are still gated at runtime — the menu merely surfaces them.
+ * Telegram BotCommand entries: 1-32 lowercase alphanumeric/underscore, no
+ * leading slash, plain-text descriptions (no HTML). PC/control and agent
+ * entries are still gated at runtime — the menu merely surfaces them.
  */
 export const BOT_COMMANDS: { command: string; description: string }[] = [
   { command: "help", description: "list every command" },
@@ -187,6 +186,7 @@ export const BOT_COMMANDS: { command: string; description: string }[] = [
   { command: "link", description: "pair this chat with a link code" },
   { command: "shot", description: "take a screenshot" },
   { command: "look", description: "what am I looking at?" },
+  { command: "ls", description: "list files in a directory" },
   { command: "open", description: "open an app or URL" },
   { command: "sys", description: "system info" },
   { command: "vol", description: "volume up/down/mute" },
@@ -200,6 +200,7 @@ export const BOT_COMMANDS: { command: string; description: string }[] = [
   { command: "run", description: "run an allowlisted shell command" },
   { command: "type", description: "type into the active window" },
   { command: "key", description: "press a key combo (ctrl+s)" },
+  { command: "pc", description: "what remote control is enabled" },
   { command: "watch", description: "watch cpu/file/proc" },
   { command: "watchers", description: "list watchers" },
   { command: "unwatch", description: "remove a watcher" },

--- a/worker/src/telegram/api.ts
+++ b/worker/src/telegram/api.ts
@@ -151,6 +151,73 @@ export async function getUpdates(
   return { messages, nextOffset };
 }
 
+/**
+ * The commands shown in the Telegram "/" menu. Mirrors /help (reads.ts) as
+ * Telegram BotCommand entries: 3-32 lowercase alphanumeric/underscore, no
+ * leading slash, plain-text descriptions (no HTML). Two-char commands (/ls,
+ * /pc) work in chat but can't be menu entries, so they're omitted. PC/control
+ * and agent entries are still gated at runtime — the menu merely surfaces them.
+ */
+export const BOT_COMMANDS: { command: string; description: string }[] = [
+  { command: "help", description: "list every command" },
+  { command: "status", description: "what the band is doing now" },
+  { command: "positions", description: "current positions and P&L" },
+  { command: "pnl", description: "profit and loss" },
+  { command: "trades", description: "recent trades" },
+  { command: "report", description: "today's campfire report" },
+  { command: "why", description: "why I made my last trade" },
+  { command: "brag", description: "your scorecard" },
+  { command: "pause", description: "hold trading" },
+  { command: "resume", description: "resume trading" },
+  { command: "strategy", description: "switch strategy" },
+  { command: "cap", description: "set the per-action chat ceiling (USDG)" },
+  { command: "buy", description: "buy SYMBOL for USDG (passes the wall)" },
+  { command: "sell", description: "sell SYMBOL for USDG" },
+  { command: "transfer", description: "send USDG out (asks to /confirm)" },
+  { command: "confirm", description: "approve a pending send or PC action" },
+  { command: "cancel", description: "cancel a pending action" },
+  { command: "alert", description: "ping me at a price" },
+  { command: "alerts", description: "list price alerts" },
+  { command: "unalert", description: "remove an alert" },
+  { command: "name", description: "give your merryman a name" },
+  { command: "remember", description: "keep a fact about you" },
+  { command: "forget", description: "wipe what I know about you" },
+  { command: "soul", description: "who I am and what I know" },
+  { command: "wallet", description: "create, restore, or recover a wallet" },
+  { command: "link", description: "pair this chat with a link code" },
+  { command: "shot", description: "take a screenshot" },
+  { command: "look", description: "what am I looking at?" },
+  { command: "open", description: "open an app or URL" },
+  { command: "sys", description: "system info" },
+  { command: "vol", description: "volume up/down/mute" },
+  { command: "media", description: "media play/pause/next/prev" },
+  { command: "notify", description: "send a notification" },
+  { command: "lock", description: "lock the machine" },
+  { command: "sleep", description: "sleep the machine" },
+  { command: "shutdown", description: "shut the machine down" },
+  { command: "get", description: "send a file to this chat" },
+  { command: "clip", description: "read or set the clipboard" },
+  { command: "run", description: "run an allowlisted shell command" },
+  { command: "type", description: "type into the active window" },
+  { command: "key", description: "press a key combo (ctrl+s)" },
+  { command: "watch", description: "watch cpu/file/proc" },
+  { command: "watchers", description: "list watchers" },
+  { command: "unwatch", description: "remove a watcher" },
+  { command: "remind", description: "set a reminder in 20m/2h/90s" },
+  { command: "reminders", description: "list reminders" },
+  { command: "unremind", description: "remove a reminder" },
+  { command: "agent", description: "run a multi-step task on your PC" },
+];
+
+/** Push the command menu to Telegram. Best-effort — never throws. */
+export async function setMyCommands(
+  opts: TelegramOpts,
+  commands?: { command: string; description: string }[],
+): Promise<{ ok: boolean; reason?: string }> {
+  const { result, reason } = await call(opts, "setMyCommands", { commands: commands ?? BOT_COMMANDS });
+  return result != null ? { ok: true } : { ok: false, reason };
+}
+
 /** Resolve a Telegram file_id to a downloadable URL (getFile → file_path). */
 export async function getFileUrl(opts: TelegramOpts, fileId: string): Promise<{ url: string | null; reason?: string }> {
   const { result, reason } = await call(opts, "getFile", { file_id: fileId });

--- a/worker/src/telegram/api.ts
+++ b/worker/src/telegram/api.ts
@@ -154,13 +154,15 @@ export async function getUpdates(
 /**
  * The commands shown in the Telegram "/" menu. Mirrors /help (reads.ts) as
  * Telegram BotCommand entries: 1-32 lowercase alphanumeric/underscore, no
- * leading slash, plain-text descriptions (no HTML). PC/control and agent
- * entries are still gated at runtime — the menu merely surfaces them.
+ * leading slash, plain-text descriptions (no HTML). This is the FULL menu —
+ * pushed to each allowlisted chat so owners keep discoverability. Strangers
+ * see the trimmed publicBotCommands subset instead.
  */
 export const BOT_COMMANDS: { command: string; description: string }[] = [
   { command: "help", description: "list every command" },
   { command: "status", description: "what the band is doing now" },
   { command: "positions", description: "current positions and P&L" },
+  { command: "depth", description: "liquidity map for one SYMBOL" },
   { command: "pnl", description: "profit and loss" },
   { command: "trades", description: "recent trades" },
   { command: "report", description: "today's campfire report" },
@@ -211,11 +213,39 @@ export const BOT_COMMANDS: { command: string; description: string }[] = [
   { command: "agent", description: "run a multi-step task on your PC" },
 ];
 
-/** Push the command menu to Telegram. Best-effort — never throws. */
+/**
+ * What an arbitrary stranger sees in the "/" menu. Pure reads + onboarding
+ * signposts only — the remote-control surface (shell/keyboard/power/files,
+ * agent) and the trading controls stay OUT of the public menu so the bot
+ * doesn't advertise what it can do to a computer. Every command is still
+ * gated at runtime; this is about not painting the target, while owners get
+ * the full menu pushed to their own allowlisted chats (service.ts).
+ */
+const PUBLIC_COMMAND_NAMES = new Set([
+  "help",
+  "status",
+  "positions",
+  "depth",
+  "pnl",
+  "trades",
+  "report",
+  "why",
+  "brag",
+  "alerts",
+  "reminders",
+  "soul",
+  "wallet",
+  "link",
+]);
+
+export const publicBotCommands = BOT_COMMANDS.filter((c) => PUBLIC_COMMAND_NAMES.has(c.command));
+
+/** Push the command menu to Telegram. Best-effort — never throws.
+ * scope takes a chat_id for the per-allowlisted-chat full-menu push. */
 export async function setMyCommands(
   opts: TelegramOpts,
   commands?: { command: string; description: string }[],
-  scope?: { type: string },
+  scope?: { type: string; chat_id?: number },
 ): Promise<{ ok: boolean; reason?: string }> {
   const { result, reason } = await call(opts, "setMyCommands", {
     commands: commands ?? BOT_COMMANDS,

--- a/worker/src/telegram/api.ts
+++ b/worker/src/telegram/api.ts
@@ -175,6 +175,7 @@ export const BOT_COMMANDS: { command: string; description: string }[] = [
   { command: "transfer", description: "send USDG out (asks to /confirm)" },
   { command: "confirm", description: "approve a pending send or PC action" },
   { command: "cancel", description: "cancel a pending action" },
+  { command: "kill", description: "destroy the grant, stand the band down" },
   { command: "alert", description: "ping me at a price" },
   { command: "alerts", description: "list price alerts" },
   { command: "unalert", description: "remove an alert" },
@@ -214,8 +215,12 @@ export const BOT_COMMANDS: { command: string; description: string }[] = [
 export async function setMyCommands(
   opts: TelegramOpts,
   commands?: { command: string; description: string }[],
+  scope?: { type: string },
 ): Promise<{ ok: boolean; reason?: string }> {
-  const { result, reason } = await call(opts, "setMyCommands", { commands: commands ?? BOT_COMMANDS });
+  const { result, reason } = await call(opts, "setMyCommands", {
+    commands: commands ?? BOT_COMMANDS,
+    ...(scope ? { scope } : {}),
+  });
   return result != null ? { ok: true } : { ok: false, reason };
 }
 

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -26,7 +26,7 @@ import { PC_CAPABILITIES } from "../../../packages/core/src/index";
 import { patchSettingsFile, type ResolvedConfig } from "../settings";
 import { ensureHome, homePaths } from "../home";
 import { loadGrantFile } from "../grant";
-import { esc, getFileUrl, getMe, getUpdates, sendMessage, setMyCommands, type TgMessage } from "./api";
+import { esc, getFileUrl, getMe, getUpdates, sendMessage, setMyCommands, publicBotCommands, type TgMessage } from "./api";
 import { runAgentTask } from "./agent";
 import { executeCommand, type CommandDeps, type PendingAction } from "./executor";
 import { resolveLlm } from "../llm";
@@ -117,8 +117,11 @@ const HISTORY_TURNS = 6; // user+assistant pairs kept per chat for follow-ups
 /** Start the poll loop. Returns a stop() handle. */
 export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
   let stopped = false;
-  /** Token whose "/" command menu we've already registered (avoids re-setting every poll). */
-  let commandsRegisteredFor = "";
+  /** Fingerprint (token + allowlist) whose "/" command menus are live — avoids
+   * re-setting every poll and re-pushes when /link grows the allowlist. */
+  let commandsRegisteredKey = "";
+  /** One warn per config fingerprint until a clean menu push (no per-poll spam). */
+  let menuWarned = false;
   const stateRef = deps.stateRef;
   let warnedUnreachable = false;
   const now = deps.now ?? (() => Math.floor(Date.now() / 1000));
@@ -646,12 +649,33 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
     if (!cfg.telegramEnabled || !cfg.telegramBotToken) return; // idle until enabled
     stateRef.set(ensureLinkCode(stateRef.get(), cfg.telegramBotToken));
 
-    // Push the "/" command menu once per token (handles enable-after-start and
-    // token changes). Best-effort — a failure logs once, never breaks the poll.
-    if (cfg.telegramBotToken && cfg.telegramBotToken !== commandsRegisteredFor) {
-      commandsRegisteredFor = cfg.telegramBotToken;
-      const menu = await setMyCommands({ token: cfg.telegramBotToken }, undefined, { type: "all_private_chats" });
-      if (!menu.ok) deps.note("warn", `Telegram: command menu — ${menu.reason}`);
+    // Push the "/" command menus whenever the token or allowlist changed
+    // (enable-after-start, /link growing the allowlist). Two scopes: a trimmed
+    // safe menu for every private chat — strangers get signposts, not an
+    // advertisement of the remote-control surface — and the FULL menu for each
+    // allowlisted chat, so owners keep discoverability (/run, /type, /agent…).
+    // The fingerprint is stored only after a clean pass, so one transient
+    // network failure at startup retries on the next poll instead of silently
+    // dropping the menu until a restart. Best-effort — never breaks the poll.
+    if (cfg.telegramBotToken) {
+      const key = `${cfg.telegramBotToken}:${[...cfg.telegramAllowlist].sort((a, b) => a - b).join(",")}`;
+      if (key !== commandsRegisteredKey) {
+        const token = cfg.telegramBotToken;
+        let firstFail: string | null = null;
+        const pub = await setMyCommands({ token }, publicBotCommands, { type: "all_private_chats" });
+        if (!pub.ok) firstFail = firstFail ?? pub.reason ?? "public menu failed";
+        for (const chatId of cfg.telegramAllowlist) {
+          const r = await setMyCommands({ token }, undefined, { type: "chat", chat_id: chatId });
+          if (!r.ok) firstFail = firstFail ?? `chat ${chatId} — ${r.reason ?? "full menu failed"}`;
+        }
+        if (!firstFail) {
+          commandsRegisteredKey = key;
+          menuWarned = false;
+        } else if (!menuWarned) {
+          menuWarned = true; // retried on every poll until it lands — but logged once
+          deps.note("warn", `Telegram: command menu — ${firstFail}`);
+        }
+      }
     }
 
     const { messages, nextOffset, reason } = await getUpdates({ token: cfg.telegramBotToken }, stateRef.get().offset);

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -650,7 +650,7 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
     // token changes). Best-effort — a failure logs once, never breaks the poll.
     if (cfg.telegramBotToken && cfg.telegramBotToken !== commandsRegisteredFor) {
       commandsRegisteredFor = cfg.telegramBotToken;
-      const menu = await setMyCommands({ token: cfg.telegramBotToken });
+      const menu = await setMyCommands({ token: cfg.telegramBotToken }, undefined, { type: "all_private_chats" });
       if (!menu.ok) deps.note("warn", `Telegram: command menu — ${menu.reason}`);
     }
 

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -26,7 +26,7 @@ import { PC_CAPABILITIES } from "../../../packages/core/src/index";
 import { patchSettingsFile, type ResolvedConfig } from "../settings";
 import { ensureHome, homePaths } from "../home";
 import { loadGrantFile } from "../grant";
-import { esc, getFileUrl, getMe, getUpdates, sendMessage, type TgMessage } from "./api";
+import { esc, getFileUrl, getMe, getUpdates, sendMessage, setMyCommands, type TgMessage } from "./api";
 import { runAgentTask } from "./agent";
 import { executeCommand, type CommandDeps, type PendingAction } from "./executor";
 import { resolveLlm } from "../llm";
@@ -117,6 +117,8 @@ const HISTORY_TURNS = 6; // user+assistant pairs kept per chat for follow-ups
 /** Start the poll loop. Returns a stop() handle. */
 export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
   let stopped = false;
+  /** Token whose "/" command menu we've already registered (avoids re-setting every poll). */
+  let commandsRegisteredFor = "";
   const stateRef = deps.stateRef;
   let warnedUnreachable = false;
   const now = deps.now ?? (() => Math.floor(Date.now() / 1000));
@@ -643,6 +645,14 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
     const cfg = deps.getCfg();
     if (!cfg.telegramEnabled || !cfg.telegramBotToken) return; // idle until enabled
     stateRef.set(ensureLinkCode(stateRef.get(), cfg.telegramBotToken));
+
+    // Push the "/" command menu once per token (handles enable-after-start and
+    // token changes). Best-effort — a failure logs once, never breaks the poll.
+    if (cfg.telegramBotToken && cfg.telegramBotToken !== commandsRegisteredFor) {
+      commandsRegisteredFor = cfg.telegramBotToken;
+      const menu = await setMyCommands({ token: cfg.telegramBotToken });
+      if (!menu.ok) deps.note("warn", `Telegram: command menu — ${menu.reason}`);
+    }
 
     const { messages, nextOffset, reason } = await getUpdates({ token: cfg.telegramBotToken }, stateRef.get().offset);
     if (reason) {


### PR DESCRIPTION
## Problem

The Telegram bot used Telegram's bot API but never registered its commands, so
the "/" button in chat showed an **empty menu** — users had to know commands by
heart or via `/help`. The full `setMyCommands` path was simply missing.

## Change

- `worker/src/telegram/api.ts` — add `BOT_COMMANDS`: 47 entries mirroring the
  closed slash-command set (`parseSlash`), as Telegram-valid `BotCommand`
  objects (3-32 lowercase chars, plain-text descriptions, no HTML). The two
  2-char commands `/ls` and `/pc` work in chat but can't be menu entries, so
  they're intentionally omitted. Plus a best-effort `setMyCommands()` client
  that never throws.

- `worker/src/telegram/service.ts` — register the menu **once per token** at
  the top of the poll loop, so it fires on enable-after-start, re-registers on
  token change, and never spams. Silent on success; logs a one-time warning on
  failure without breaking the poll.


## Tests

`npm test` — 695 pass, 0 fail (added `BOT_COMMANDS` validity + `setMyCommands`
request/degrade cases). `npm run typecheck` clean.

Edit: Added `/ls` and `/pc` to command menu as they are also telegram-valid `BotCommand`