### PR TITLE
Unblock the first op: an undeployed policy contract, a flag that never shipped, and an unfinished sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@
 
 **Trading agents you never have to trust.** merrymen is a self-hosted band of
 agents for Robinhood Chain: your keys never leave your machine, and the caps that
-matter most — **per-trade size, ops per day, which assets, which contracts, and
-when the key dies** — are enforced by your account contract **on-chain**, not by
-promises. (The daily total and the drawdown breaker are enforced by the worker,
-not the chain; the chain-side ceiling is per-trade × ops/day until expiry. Said
-plainly because a project whose pitch is verification cannot round up.) Inside that wall your band works
+matter most — **per-trade size, which assets, which contracts, and when the key
+dies** — are enforced by your account contract **on-chain**, not by promises.
+(The daily total, the drawdown breaker and the trades-per-day count are enforced
+by the worker, not the chain, so the chain-side ceiling is per-trade until the
+key expires. Said plainly because a project whose pitch is verification cannot
+round up — and this list was itself wrong until 2026-08-30, when ops/day turned
+out to rest on a policy contract that is not deployed on this chain.) Inside that wall your band works
 Sherwood 24/7 — trading Stock Tokens, farming yield, LPing — while you name your
 merryman, chat with it and steer it from Telegram (it can even run your PC), and
 watch every trade on a local dashboard.
@@ -192,13 +194,19 @@ gone), and lets you fund it. **Pick your ground:**
   treat the account like a hot wallet — your caps are the seatbelt, start small.
   No faucet: send ETH (gas) + USDG (capital) from your own wallet or an exchange.
 
-Per-trade size, ops/day, the asset and contract allowlists, a zero native-ETH
-limit and the key's expiry are enforced **by the account contract on every
-operation**. The daily total and the drawdown breaker live in the worker — they
-tighten what the chain already allows, and a compromised worker could ignore
-them, which is why the chain-side ceiling is the honest number to plan against:
-per-trade × ops/day until expiry. The worker can tighten within the wall but can
-never widen it without a new signed grant.
+Per-trade size, the asset and contract allowlists, a zero native-ETH limit and
+the key's expiry are enforced **by the account contract on every operation**.
+The daily total, the drawdown breaker and the trades-per-day count live in the
+worker — they tighten what the chain already allows, and a compromised worker
+could ignore them, which is why the chain-side ceiling is the honest number to
+plan against: **per-trade size, until the key expires**. The worker can tighten
+within the wall but can never widen it without a new signed grant.
+
+Trades-per-day was on the on-chain list here until 2026-08-30. It rested on
+ZeroDev's rate-limit policy, and `eth_getCode` shows that contract has no code on
+Robinhood Chain — mainnet or testnet — while the timestamp and call policies both
+do. A policy pointing at an empty address is not a bound, so it was removed and
+this sentence corrected rather than left to flatter the design.
 
 > **Going live is one key.** To sign real trades, paste a free [Pimlico](https://dashboard.pimlico.io)
 > API key in `/settings` — merrymen builds the bundler URL for your wallet's chain

--- a/packages/core/src/wall.ts
+++ b/packages/core/src/wall.ts
@@ -1,7 +1,7 @@
 import { erc20Abi, parseAbi, type Address } from "viem";
 import { PolicyFlags } from "@zerodev/permissions";
 import { CallPolicyVersion, ParamCondition, toCallPolicy } from "@zerodev/permissions/policies";
-import { toRateLimitPolicy, toTimestampPolicy } from "@zerodev/permissions/policies";
+import { toTimestampPolicy } from "@zerodev/permissions/policies";
 import { UNISWAP_SWAP_ROUTER_ABI, PERMIT2_ABI, UNIVERSAL_ROUTER_ABI, V4SELFSWAP_ABI, PONS_SELFTRADE_ABI } from "./abis";
 import { MORPHO, RIALTO, UNISWAP } from "./protocols";
 import { CASH, STOCK_TOKENS, TRADEABLE_SYMBOLS, USDG_DECIMALS, isValidCustomToken, type CustomToken } from "./tokens";
@@ -78,6 +78,34 @@ export function usdgUnits(value: number): bigint {
  * they're re-signed. See the header note about the fleet running a mix.
  */
 export const WALL_POLICY_FLAG = PolicyFlags.NOT_FOR_VALIDATE_SIG;
+
+/**
+ * THE SINGLETONS EVERY GRANT DEPENDS ON, so their absence can be a REFUSAL
+ * rather than a mystery.
+ *
+ * A ZeroDev policy is an address plus its data: `getPolicyInfoInBytes()` is
+ * `concat([policyFlag, policyAddress])`, and the addresses come from
+ * @zerodev/permissions' own constants — defaults for a deployment the library
+ * assumes exists. On Robinhood Chain one of them did not, and nothing here
+ * checked, so the grant sealed a pointer into empty space and the failure
+ * surfaced as a UserOp that would not validate, with no message naming a cause.
+ *
+ * This repo already knows the discipline. index.ts refuses to trust the
+ * drawdown breaker unless its address has CODE on the grant chain, because
+ * otherwise the read "silently fails open while the user believes they're
+ * protected". The wall's own policy contracts had no such check — which is
+ * exactly why an undeployed singleton survived every test in the suite.
+ *
+ * Duplicated as literals ON PURPOSE. Re-exporting the package's constants would
+ * make this list track whatever the library ships next, and the point of a
+ * probe is to assert what THIS code sealed. If a version bump moves an address,
+ * the probe must fail loudly rather than follow it.
+ */
+export const WALL_POLICY_CONTRACTS: readonly { name: string; address: Address }[] = [
+  { name: "TimestampPolicy", address: "0xB9f8f524bE6EcD8C945b1b87f9ae5C192FdCE20F" as Address },
+  { name: "CallPolicy V0_0_4", address: "0x9a52283276A0ec8740DF50bF01B28A80D880eaf2" as Address },
+  { name: "ECDSA signer", address: "0x6A6F069E2a08c2468e7724Ab3250CdBFBA14D4FF" as Address },
+];
 
 /**
  * The only contracts a token approval may ever name as spender.
@@ -668,8 +696,40 @@ export function buildWallPolicies(args: {
   const policies = [
     // Hard expiry — the key dies even if every other control fails.
     toTimestampPolicy({ validAfter: now, validUntil: expiresAt }),
-    // Bounded ops per day, so a runaway loop cannot spam trades.
-    toRateLimitPolicy({ count: args.caps.maxOpsPerDay, interval: 86_400 }),
+    // THE RATE LIMIT POLICY IS GONE, because it was never there.
+    //
+    // `toRateLimitPolicy({count: maxOpsPerDay, interval: 86_400})` used to sit
+    // on this line. Its `policyAddress` defaults to RATE_LIMIT_POLICY_CONTRACT
+    // in @zerodev/permissions — and that address has NO CODE on Robinhood
+    // Chain. Measured 2026-08-30 with eth_getCode against both live RPCs:
+    //
+    //   RateLimitPolicy  0xf63d4139B25c836334edD76641356c6b74C86873   0 bytes on 4663 AND 46630
+    //   TimestampPolicy  0xB9f8f524bE6EcD8C945b1b87f9ae5C192FdCE20F   1,441 bytes
+    //   CallPolicy V4    0x9a52283276A0ec8740DF50bF01B28A80D880eaf2   6,539 bytes
+    //   ECDSA signer     0x6A6F069E2a08c2468e7724Ab3250CdBFBA14D4FF   1,609 bytes
+    //
+    // So every grant this repo could produce installed a policy pointing at an
+    // empty address. Kernel calls `checkUserOpPolicy` expecting a uint256; a
+    // call to a codeless address succeeds with zero returndata. That is not
+    // "ops go unlimited" — it is most likely EVERY UserOp failing validation,
+    // which is consistent with this project never having landed a trade.
+    //
+    // A policy that cannot execute is not a bound. Leaving it in traded a
+    // guarantee we did not have for a failure mode we could not diagnose.
+    //
+    // SAY THE COST OUT LOUD. maxOpsPerDay is now enforced by the WORKER only,
+    // alongside the daily total and the drawdown breaker. The on-chain ceiling
+    // is per-trade × (however many ops fit before expiry) — see the header.
+    //
+    // And it was never the cap it was described as, even where the contract IS
+    // deployed: RateLimitPolicy decrements a LIFETIME counter and returns
+    // packValidationData(startAt); this call never passed `startAt`, so it
+    // defaulted to 0 and imposed no spacing at all. It was maxOpsPerDay ops
+    // TOTAL per grant, with no daily refill — not "48 a day".
+    //
+    // The fix that would restore a real on-chain bound is to deploy the policy
+    // singleton to 4663 ourselves and pass `policyAddress`. That is a contract
+    // deployment and it is deliberately not bundled with this correction.
     toCallPolicy({
       policyVersion: CallPolicyVersion.V0_0_4,
       // EVERY adapter must be forwarded, and the type system will not tell you.

--- a/web/src/app/app/Console.tsx
+++ b/web/src/app/app/Console.tsx
@@ -416,11 +416,11 @@ function Loaded({ feed, status }: { feed: FeedResponse | null; status: AgentStat
                 </div>
               </section>
 
-              {/* Where the money sits, and what the chain will let the agent do
-                  with it — two LINES where there used to be three cards and
-                  five more. Nothing was dropped: every figure below appeared on
-                  a card of its own before, which is a lot of furniture for
-                  numbers you read in a second and then stop looking at. */}
+              {/* Where the money sits, and what it is allowed to do with it — the
+                  chain's part and ours stated separately. Two LINES where there used
+                  to be three cards and five more. Nothing was dropped: every figure
+                  below appeared on a card of its own before, which is a lot of
+                  furniture for numbers you read once and stop looking at. */}
               <section className="strip">
                 <div className="bal">
                   <Slice label="Cash" v={split.cash} pct={(split.cash / total) * 100} color="var(--mint)" />
@@ -431,12 +431,24 @@ function Loaded({ feed, status }: { feed: FeedResponse | null; status: AgentStat
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} aria-hidden="true">
                     <path d="M12 2l8 4v6c0 5-3.4 8.4-8 10-4.6-1.6-8-5-8-10V6z" />
                   </svg>
+                  {/*
+                    "The chain caps it at X a trade and Y a day, halts at Z%" put three
+                    figures behind one subject, and the chain only enforces the first.
+                    The daily total and the drawdown breaker are counters in this
+                    software; so is trades-per-day, since 2026-08-30, when the policy
+                    contract behind it turned out to have no code on this chain.
+
+                    Split into two sentences rather than qualified in one, because a
+                    parenthetical after a list of numbers gets skimmed past — and this
+                    line is the whole security claim for anyone who never opens /grant.
+                  */}
                   <span>
                     The chain caps it at <b>{caps ? usd(caps.perTradeUsdg) : "—"}</b> a trade and{" "}
-                    <b>{caps ? usd(caps.dailyUsdg) : "—"}</b> a day, halts at{" "}
-                    <b>{caps ? `${caps.maxDrawdownPct}%` : "—"}</b> drawdown, and{" "}
                     <b>cannot move your money out</b>
-                    {daysLeft !== null && <> · key dies in <b>{daysLeft}d</b></>}.
+                    {daysLeft !== null && <> · key dies in <b>{daysLeft}d</b></>}. merrymen itself
+                    stops it at <b>{caps ? usd(caps.dailyUsdg) : "—"}</b> a day and{" "}
+                    <b>{caps ? `${caps.maxDrawdownPct}%` : "—"}</b> drawdown — counters kept here,
+                    not on-chain.
                   </span>
                 </p>
               </section>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -190,6 +190,22 @@ button { font: inherit; cursor: pointer; }
   padding: 4px 11px;
 }
 .cap b { color: var(--text); font-weight: 600; font-family: var(--mono); }
+/*
+  Which side of the wall a chip is on. Two of the five caps the wall panel
+  shows are worker counters and a third became one when the rate-limit policy
+  turned out to be undeployed on this chain — and a row of numbers under the
+  heading "your account contract" read as though all five were sealed.
+
+  Deliberately quiet: dimmer and smaller than the number it qualifies, because
+  it is a caveat on the figure, not a second figure. `on-chain` is not coloured
+  as a reassurance — the honest reading is that three of these are softer than
+  the page used to imply, not that two are stronger.
+*/
+.cap i {
+  font-style: normal; font-size: 9.5px; letter-spacing: 0.04em;
+  text-transform: uppercase; color: var(--text-dimmer, var(--text-dim));
+  opacity: 0.75; margin-left: 5px;
+}
 
 .drawdown { display: flex; flex-direction: column; gap: 4px; }
 .drawdown-label {

--- a/web/src/components/WallPanel.tsx
+++ b/web/src/components/WallPanel.tsx
@@ -54,17 +54,29 @@ export function WallPanel() {
     <div className="panel wall-panel">
       <div className="section-title">the wall</div>
       <p className="wall-sub">
-        Don&apos;t trust us — verify it. These caps live in your account contract on{" "}
-        <b>{info.chainName}</b> ({info.chainId}); every address below is the chain&apos;s record,
-        not ours.
+        Don&apos;t trust us — verify it. Every address below is the chain&apos;s record on{" "}
+        <b>{info.chainName}</b> ({info.chainId}), not ours. The chips marked{" "}
+        <b>on-chain</b> are enforced by your account contract; the rest are counters merrymen
+        keeps on this machine.
       </p>
 
+      {/*
+        Two of these five were never on-chain, and a third stopped being so on
+        2026-08-30: ops/day rested on ZeroDev's rate-limit policy, whose contract
+        has no code on this chain (eth_getCode, mainnet and testnet both). Listing
+        all five under "these caps live in your account contract" was the strongest
+        claim on the page and it was wrong about the majority of the row.
+
+        The split is marked per chip rather than explained underneath, because a
+        caveat in a following paragraph is not read by someone scanning a row of
+        numbers — which is what this row is for.
+      */}
       <div className="wall-caps mono">
-        <span className="cap">max <b>{info.caps.perTradeUsdg} USDG</b>/trade</span>
-        <span className="cap"><b>{info.caps.dailyUsdg} USDG</b>/day</span>
-        <span className="cap"><b>{info.caps.maxOpsPerDay}</b> ops/day</span>
-        <span className="cap">breaker <b>{info.caps.maxDrawdownPct}%</b></span>
-        <span className="cap">key dies in <b>{daysLeft}d</b></span>
+        <span className="cap">max <b>{info.caps.perTradeUsdg} USDG</b>/trade <i>on-chain</i></span>
+        <span className="cap">key dies in <b>{daysLeft}d</b> <i>on-chain</i></span>
+        <span className="cap"><b>{info.caps.dailyUsdg} USDG</b>/day <i>software</i></span>
+        <span className="cap"><b>{info.caps.maxOpsPerDay}</b> ops/day <i>software</i></span>
+        <span className="cap">breaker <b>{info.caps.maxDrawdownPct}%</b> <i>software</i></span>
       </div>
 
       <div className="wall-addrs mono">
@@ -95,9 +107,12 @@ export function WallPanel() {
           ))}
           <p className="wall-note">
             Each attempt just ran through <code>worker/src/policy.ts</code> — the same deterministic
-            policy the worker applies to every intent, using your grant&apos;s real caps. It mirrors
-            (never replaces) the on-chain wall: the account contract enforces these limits
-            independently, so they hold even if this software were compromised.
+            policy the worker applies to every intent, using your grant&apos;s real caps. So this
+            shows the software agreeing with itself, which is worth something and is not the same
+            as a chain-side proof: the attacker it exists for is the one who skips this code
+            entirely. What the account contract would refuse independently is the per-trade size,
+            the asset and contract allowlists, any attempt to move native ETH, and anything at all
+            after the key expires.
           </p>
         </div>
       )}

--- a/worker/src/executor.ts
+++ b/worker/src/executor.ts
@@ -14,7 +14,8 @@
 import { http, createPublicClient, type Chain, type Hex } from "viem";
 import { createKernelAccountClient } from "@zerodev/sdk";
 import { KERNEL_V3_3, getEntryPoint } from "@zerodev/sdk/constants";
-import { deserializePermissionAccount } from "@zerodev/permissions";
+import { deserializeFlaggedPermissionAccount } from "./session-account";
+import { WALL_POLICY_FLAG } from "../../packages/core/src/index";
 import { userOpGasConfig } from "./gas";
 
 export interface Call {
@@ -120,11 +121,16 @@ export async function createAgentExecutor(opts: {
   const publicClient = createPublicClient({ chain: opts.chain, transport: http(opts.rpcUrl) });
   const entryPoint = getEntryPoint("0.7");
 
-  const account = await deserializePermissionAccount(
+  // NOT deserializePermissionAccount. That function silently drops the policy
+  // flag the owner signed over, so the enable data we submit would not match
+  // the enable data they authorised — and the first UserOp of every grant
+  // would fail at plugin-enable. See session-account.ts for the full trace.
+  const account = await deserializeFlaggedPermissionAccount(
     publicClient,
     entryPoint,
     KERNEL_V3_3,
     opts.serializedGrant,
+    WALL_POLICY_FLAG,
   );
 
   const client = createKernelAccountClient({

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -71,7 +71,7 @@ import {
 } from "./executor";
 import { fillFromDeltas, netTokenDeltas, slippageBpsAgainst, type ReceiptLog } from "./fills";
 import { belowFloorBps, checkDelivery, describeDelivery } from "./delivery";
-import { findOrphanOps, type RawLog, type ReconcileChain } from "./inflight-reconcile";
+import { findOrphanOps, resolveSubmittedOps, type RawLog, type ReconcileChain } from "./inflight-reconcile";
 import { bookGaps, composeEquityUsdg } from "./equity";
 import { priceGas, wethPriceToken } from "./gas-price";
 import { createPaperOrderExecutor, type OrderExecutor } from "./executor-order";
@@ -178,6 +178,7 @@ import {
   getSpentTodayUsdg,
   getTransferredTodayUsdg,
   listOpHashes,
+  listSubmittedOps,
   initStore,
   setPaperBook,
   setAgentName,
@@ -411,6 +412,122 @@ async function main() {
   };
 
   /**
+   * Narrow adapter over a live client — raw eth_getLogs (topics-based) and the
+   * receipt logs. The impure edge, kept in one place so the core stays testable
+   * and so the arm sweep and the tick resolver cannot drift into two dialects
+   * of the same three calls.
+   *
+   * eth_getLogs goes through `client.request` rather than viem's typed getLogs
+   * for the reason venues/pons.ts gives: the typed one wants an ABI, and this
+   * filters on raw topics.
+   */
+  const makeReconcileChain = (client: ReturnType<typeof createPublicClient>): ReconcileChain => ({
+    getBlockNumber: () => client.getBlockNumber(),
+    async getLogs(a) {
+      const logs = (await client.request({
+        method: "eth_getLogs",
+        params: [
+          {
+            address: a.address,
+            fromBlock: `0x${a.fromBlock.toString(16)}`,
+            toBlock: `0x${a.toBlock.toString(16)}`,
+            topics: a.topics,
+          },
+        ],
+      } as never)) as RawLog[];
+      return logs;
+    },
+    async getReceiptLogs(txHash) {
+      try {
+        const r = await client.getTransactionReceipt({ hash: txHash });
+        return r.logs as unknown as ReceiptLog[];
+      } catch {
+        return null;
+      }
+    },
+  });
+  /**
+   * SETTLE OPS WE SUBMITTED AND LOST TRACK OF.
+   *
+   * Extracted so it can run on a clock as well as at arm, and it has to. A
+   * stranded row keeps charging the LIVE rail — RAIL_STATUSES.live includes
+   * 'submitted' — which is the safe direction for the cap and an expensive one
+   * to sit in: at a $50 daily cap and $10 a trade, one op the worker lost
+   * track of holds a fifth of the day's allowance until the next re-arm.
+   * Arm-only resolution would mean a receipt we could not read costs the rest
+   * of the session.
+   *
+   * Holds no signer and never re-broadcasts — it only ever ASKS the chain what
+   * happened. An op it cannot find stays 'submitted' rather than being guessed
+   * at, because the guess would enter a hash-chained journal.
+   */
+  const resolveStrandedOps = async (
+    agentId: string,
+    chain: ReconcileChain,
+    smartAccount: `0x${string}`,
+    lookbackBlocks: bigint,
+  ): Promise<void> => {
+    // A 'submitted' row is an op we know left and never heard back about —
+    // a crash between broadcast and the ledger write, or a receipt we could
+    // not read (UserOpUnresolved). It keeps charging the live rail, which is
+    // the safe direction for the cap and useless for everything else: no
+    // journal entry, no cost basis, absent from realized P&L.
+    const stranded = await listSubmittedOps(agentId);
+    if (stranded.length > 0) {
+      const currentEpoch = await getAgentEpoch(agentId);
+      // Rows from a PRIOR epoch are skipped. addTrade journals with the
+      // agent's current epoch while the row keeps its original, so resolving
+      // across a boundary would file the journal entry in one epoch and the
+      // trade in another — and the export's whole job is that those agree.
+      const mine = stranded.filter((r) => r.epoch === currentEpoch);
+      const skipped = stranded.length - mine.length;
+      if (skipped > 0) {
+        console.log(`[reconcile] ${skipped} submitted row(s) from an earlier epoch — left for 'merrymen verify'`);
+      }
+      const resolved = await resolveSubmittedOps({
+        chain,
+        smartAccount,
+        usdgToken: CASH.USDG,
+        hashes: mine.map((r) => r.userOpHash),
+        lookbackBlocks,
+        log: (m) => console.log(`[reconcile] ${m}`),
+      });
+      for (const r of resolved) {
+        const row = mine.find((m) => m.userOpHash === r.userOpHash)!;
+        await addTrade({
+          agent_id: agentId,
+          kind: row.kind as TradeRow["kind"],
+          target: row.target,
+          // The chain's figure when it could be attributed, else the notional
+          // the row was written with. Never zero-by-default: a resolved op
+          // that moved money must not read as free.
+          amount_usdg: r.success && r.attributed ? usdgNum(r.notionalUsdg6) : row.amountUsdg,
+          user_op_hash: r.userOpHash,
+          tx_hash: r.txHash,
+          status: r.success ? "landed" : "reverted",
+          ...(r.success ? { basis_source: "receipt" as const } : { reject_rule: "reverted on-chain (resolved)" }),
+        });
+        await addEvent(
+          agentId,
+          "warn",
+          r.success
+            ? `resolved an op we lost track of: ${r.userOpHash.slice(0, 10)}… LANDED (${r.txHash.slice(0, 10)}…)` +
+                `${r.attributed ? ` · ${fmt(r.notionalUsdg6)} USDG` : " · notional unattributable"}`
+            : `resolved an op we lost track of: ${r.userOpHash.slice(0, 10)}… was REVERTED by the chain — ` +
+                `it moved nothing, and its spend is released`,
+        );
+      }
+      const unresolved = mine.length - resolved.length;
+      if (unresolved > 0) {
+        // NEVER guessed at. An op the chain has no event for inside the
+        // lookback might still be pending, or older than the window. Both
+        // stay 'submitted' — which keeps the spend counted, the conservative
+        // direction — rather than being written off as reverted.
+        console.log(`[reconcile] ${unresolved} submitted op(s) still unresolved — left counted, not guessed at`);
+      }
+    }
+  };
+  /**
    * In-flight reconciliation, run once at arm BEFORE the budget is seeded.
    *
    * If the process died between an op landing on-chain and its ledger row being
@@ -459,34 +576,13 @@ async function main() {
         lookbackBlocks = MAX_LOOKBACK;
       }
 
-      // Narrow adapter over the live client — raw eth_getLogs (topics-based) and
-      // the receipt logs. Kept here, at the impure edge; the core stays testable.
-      const chain: ReconcileChain = {
-        getBlockNumber: () => client.getBlockNumber(),
-        async getLogs(a) {
-          const logs = (await client.request({
-            method: "eth_getLogs",
-            params: [
-              {
-                address: a.address,
-                fromBlock: `0x${a.fromBlock.toString(16)}`,
-                toBlock: `0x${a.toBlock.toString(16)}`,
-                topics: a.topics,
-              },
-            ],
-          } as never)) as RawLog[];
-          return logs;
-        },
-        async getReceiptLogs(txHash) {
-          try {
-            const r = await client.getTransactionReceipt({ hash: txHash });
-            return r.logs as unknown as ReceiptLog[];
-          } catch {
-            return null;
-          }
-        },
-      };
+      const chain = makeReconcileChain(client);
 
+      // Finish what we started before looking for what we missed: resolving
+      // first means anything settled here is already settled when
+      // listOpHashes is read below, so the two sweeps cannot both act on one
+      // hash. See resolveStrandedOps.
+      await resolveStrandedOps(agentId, chain, smartAccount, lookbackBlocks);
       const known = await listOpHashes(agentId);
       const orphans = await findOrphanOps({
         chain,
@@ -1261,6 +1357,62 @@ async function main() {
    * because the API is rate-limited and shared, and because nothing here is
    * urgent — a coin trending this minute is still trending in ten.
    */
+  /**
+   * The stranded-op resolver, on its own clock.
+   *
+   * At arm is not enough. A receipt we cannot read mid-session leaves a
+   * 'submitted' row charging the LIVE rail for the rest of the arm — at a $50
+   * daily cap and $10 a trade, that is a fifth of the day's allowance held by an
+   * op whose outcome the chain already knows. Re-arming to reclaim it is not a
+   * thing an owner should have to know to do.
+   *
+   * Shape copied from runTrendingDiscovery, including the two properties that
+   * matter: an in-flight guard, because this is fired from every tick (60s by
+   * default) against a slower interval and a slow pass would otherwise overlap
+   * the next; and the clock advanced AFTER the work, never before.
+   *
+   * ON FAILURE THE CLOCK DOES NOT ADVANCE — runPonsDiscovery's rule. A chain read
+   * that throws means we learned nothing, and pretending otherwise would make the
+   * next pass wait a full interval before trying again.
+   *
+   * The lookback uses BLOCKS_PER_SEC rather than re-running the arm sweep's
+   * 2,000-block sampling: the constant is measured for this chain, and a resolver
+   * doing an EXACT per-hash lookup does not need a precise window — only one wide
+   * enough to contain the op.
+   */
+  let lastStrandedAt = 0;
+  let strandedInFlight = false;
+  const STRANDED_INTERVAL_SEC = 300;
+  async function runStrandedResolve(agentId: string): Promise<void> {
+    if (!active?.executor || strandedInFlight) return;
+    const nowSec = Math.floor(Date.now() / 1000);
+    if (lastStrandedAt !== 0 && nowSec - lastStrandedAt < STRANDED_INTERVAL_SEC) return;
+
+    strandedInFlight = true;
+    try {
+      // Cheap pre-check so the ordinary case — nothing stranded, which is every
+      // tick of a healthy run — costs one indexed-ish read and no RPC at all.
+      const stranded = await listSubmittedOps(agentId);
+      if (stranded.length === 0) {
+        lastStrandedAt = nowSec;
+        return;
+      }
+      const WINDOW_SEC = 26 * 3600;
+      await resolveStrandedOps(
+        agentId,
+        makeReconcileChain(active.client),
+        active.grant.smartAccount as `0x${string}`,
+        BigInt(WINDOW_SEC) * BLOCKS_PER_SEC,
+      );
+      lastStrandedAt = nowSec;
+    } catch (e) {
+      // Deliberately NOT advancing the clock — see the header.
+      console.log(`[reconcile] stranded-op pass failed, will retry: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      strandedInFlight = false;
+    }
+  }
+
   let lastTrendAt = 0;
   let trendInFlight = false;
   const TREND_INTERVAL_SEC = 600;
@@ -1922,8 +2074,9 @@ async function main() {
         // direction. So book the spend straight into the settled counters (the
         // reservation's own figures), SKIP the ledger re-read, and release the
         // now-double-counted reservation. The spend stays counted for the rest of
-        // this arm; A5's chain reconciliation writes the missing row on the next
-        // arm. A durable err event, not a swallowed console.error.
+        // this arm; findOrphanOps writes the missing row at the next arm, reading
+        // the EntryPoint's own event rather than trusting this process to have
+        // survived. A durable err event, not a swallowed console.error.
         if (reserved) {
           settledSpentUsdg += reserved.spendUsdg;
           settledOps += reserved.ops;
@@ -2887,7 +3040,8 @@ async function main() {
           "warn",
           `${intent.kind} was SUBMITTED and its receipt could not be read (${e.userOpHash}). ` +
             `This is not a revert — the operation may have landed. It stays counted against today's caps ` +
-            `and will be resolved from the chain. Reason: ${msg.slice(0, 140)}`,
+            `and the resolver will settle it from the chain within ${STRANDED_INTERVAL_SEC / 60} minutes. ` +
+            `Reason: ${msg.slice(0, 140)}`,
         );
         return;
       }
@@ -3482,6 +3636,8 @@ async function main() {
     // cadence is independent of how fast the owner trades. Never awaited into
     // the trading path in a way that could stall it — a data provider having a
     // bad minute must not delay a sell.
+    // Finish what we lost track of before starting anything new.
+    void runStrandedResolve(agentId).catch(() => {});
     void runDiscovery(agentId).catch(() => {});
     // The launchpad keeps its own clock and needs no Bitquery credential.
     void runPonsDiscovery(agentId).catch(() => {});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -39,6 +39,7 @@ import {
   STOCK_TOKENS,
   UNISWAP,
   USDG_DECIMALS,
+  WALL_POLICY_CONTRACTS,
   chainForId,
   effectivePerfFeeBps,
   pimlicoBundlerUrl,
@@ -1525,6 +1526,39 @@ async function main() {
     }
 
     const client = createPublicClient({ chain, transport: http(rpc) });
+
+    // ── THE WALL'S OWN CONTRACTS MUST EXIST ──────────────────────────────
+    // Same discipline as the breaker below, applied to the singletons the
+    // GRANT depends on rather than to an optional extra — and applied here
+    // because it was NOT, and an undeployed ZeroDev policy contract sat in
+    // every wall this repo ever built. A policy is an address plus its data;
+    // sealing a pointer into empty space produces a UserOp that will not
+    // validate, reported by nothing, at a cost of one prefund per attempt.
+    //
+    // A warn, not a blocker, and deliberately: arming still lets the owner run
+    // paper, read the tape and use every read-only surface. What it must never
+    // do is let them believe a live trade is one funding away when it is not.
+    // preflight.ts makes the same finding a BLOCKER, which is the right place
+    // for a refusal — it is the command whose whole job is to judge.
+    const missingPolicyContracts: string[] = [];
+    for (const c of WALL_POLICY_CONTRACTS) {
+      const code = await client.getCode({ address: c.address }).catch(() => undefined);
+      // getCode returns `undefined` — not "0x" — for an address with no
+      // contract; viem normalises "0x" away. Both mean absent here, and a
+      // failed READ is indistinguishable from either, so this deliberately
+      // does not try to tell them apart: it says what it could not confirm.
+      if (code === undefined || code === "0x") missingPolicyContracts.push(`${c.name} (${c.address})`);
+    }
+    if (missingPolicyContracts.length > 0) {
+      console.log(`[worker] wall policy contracts missing on chain ${chain.id}: ${missingPolicyContracts.join(", ")}`);
+      await addEvent(
+        agentId,
+        "err",
+        `the wall depends on contracts that have no code on chain ${chain.id}: ${missingPolicyContracts.join(", ")}. ` +
+          `Every UserOp this grant signs will be validated against them, so live trading cannot work until this is resolved. ` +
+          `Paper and every read-only surface are unaffected.`,
+      );
+    }
 
     // The on-chain breaker is only trusted when its address has CODE on the
     // grant chain — otherwise the tick's read silently fails open ("not

--- a/worker/src/inflight-reconcile.test.ts
+++ b/worker/src/inflight-reconcile.test.ts
@@ -10,7 +10,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { encodeAbiParameters, encodeEventTopics, parseAbi, toHex, type Hex } from "viem";
-import { addressTopic, findOrphanOps, type RawLog, type ReconcileChain } from "./inflight-reconcile";
+import { addressTopic, findOrphanOps, resolveSubmittedOps, type RawLog, type ReconcileChain } from "./inflight-reconcile";
 import type { ReceiptLog } from "./fills";
 
 const EP_ABI = parseAbi([
@@ -126,5 +126,154 @@ describe("findOrphanOps", () => {
     const chain = fakeChain([opLog(dup, true, tx), opLog(dup, true, tx)], { [tx.toLowerCase()]: [transfer(USDG, ACCOUNT, ROUTER, 1_000000n)] });
     const orphans = await findOrphanOps({ chain, smartAccount: ACCOUNT, usdgToken: USDG, knownOpHashes: new Set(), lookbackBlocks: 1000n });
     assert.equal(orphans.length, 1);
+  });
+});
+
+/**
+ * THE SIBLING SWEEP, and the bug that made it necessary.
+ *
+ * cf9b046 started writing a 'submitted' row BEFORE broadcasting, so a crash
+ * between the send and the ledger write could not lose the hash. It also made
+ * findOrphanOps blind to exactly those rows: `listOpHashes` selected every
+ * non-null user_op_hash regardless of status, and findOrphanOps skips any hash
+ * in that set. So the row the sweep exists to finish was the one it filtered
+ * out — invisible forever, never journaled, absent from realized P&L, and still
+ * charging the live rail.
+ *
+ * The store half of the fix is asserted in inflight-row.integration.test.ts,
+ * against real SQL. This is the chain half.
+ */
+describe("resolveSubmittedOps", () => {
+  const chainFor = (logs: RawLog[], receipts: Record<string, ReceiptLog[]> = {}) => {
+    // A chain that honours the topic filter, unlike fakeChain above — the
+    // exact-lookup path is the whole point here, and a fake that ignores
+    // `topics` would let a wrong-hash match pass unnoticed.
+    return {
+      async getBlockNumber() {
+        return 1000n;
+      },
+      async getLogs(a: { topics: (Hex | Hex[] | null)[] }) {
+        const want = a.topics[1];
+        if (!want) return logs;
+        return logs.filter((l) => l.topics[1]?.toLowerCase() === String(want).toLowerCase());
+      },
+      async getReceiptLogs(txHash: Hex) {
+        return receipts[txHash.toLowerCase()] ?? null;
+      },
+    } as ReconcileChain;
+  };
+
+  it("settles a stranded op the chain LANDED, with its notional", async () => {
+    const [op, tx] = [h(0x51), h(0x61)];
+    const res = await resolveSubmittedOps({
+      chain: chainFor([opLog(op, true, tx)], {
+        [tx]: [transfer(USDG, ACCOUNT, ROUTER, 25_000_000n), transfer(STOCK, ROUTER, ACCOUNT, 10n ** 18n)],
+      }),
+      smartAccount: ACCOUNT,
+      usdgToken: USDG,
+      hashes: [op],
+      lookbackBlocks: 1000n,
+    });
+    assert.equal(res.length, 1);
+    assert.equal(res[0]!.success, true);
+    assert.equal(res[0]!.txHash, tx);
+    assert.equal(res[0]!.notionalUsdg6, 25_000_000n);
+    assert.equal(res[0]!.attributed, true);
+  });
+
+  it("settles a stranded op the chain REVERTED — which findOrphanOps would skip", async () => {
+    // The asymmetry that makes this a separate function. An unrecorded revert
+    // is nothing to an orphan sweep: it moved no money and counts toward no
+    // cap. Here the row already EXISTS and is charging the live rail, so the
+    // revert is the thing that releases the charge.
+    const [op, tx] = [h(0x52), h(0x62)];
+    const res = await resolveSubmittedOps({
+      chain: chainFor([opLog(op, false, tx)]),
+      smartAccount: ACCOUNT,
+      usdgToken: USDG,
+      hashes: [op],
+      lookbackBlocks: 1000n,
+    });
+    assert.equal(res.length, 1, "a revert must be REPORTED, not skipped");
+    assert.equal(res[0]!.success, false);
+    assert.equal(res[0]!.notionalUsdg6, 0n, "a reverted op moved nothing");
+
+    // And prove the contrast, so the reason for two functions is on the record.
+    const orphans = await findOrphanOps({
+      chain: chainFor([opLog(op, false, tx)]),
+      smartAccount: ACCOUNT,
+      usdgToken: USDG,
+      knownOpHashes: new Set(),
+      lookbackBlocks: 1000n,
+    });
+    assert.equal(orphans.length, 0, "the orphan sweep skips it, correctly, for its own purpose");
+  });
+
+  it("AN OP IT CANNOT FIND IS LEFT ALONE — never written off as reverted", async () => {
+    // The one rule that matters most. Not-found means pending, or older than
+    // the lookback, or an RPC that answered thinly. Guessing 'reverted' would
+    // release a charge for an op that may well have moved money, and the guess
+    // would enter a hash-chained journal where it cannot be quietly corrected.
+    const res = await resolveSubmittedOps({
+      chain: chainFor([opLog(h(0x53), true, h(0x63))]),
+      smartAccount: ACCOUNT,
+      usdgToken: USDG,
+      hashes: [h(0x54)], // a different op entirely
+      lookbackBlocks: 1000n,
+    });
+    assert.deepEqual(res, [], "silence is not a verdict");
+  });
+
+  it("looks each hash up EXACTLY, rather than scanning and filtering", async () => {
+    // topic1 of UserOperationEvent is the indexed userOpHash, and the filter
+    // has always left that slot null because the orphan sweep does not know the
+    // hashes in advance. This one does. Asserted because a regression to a scan
+    // would still pass every test above — it would just cost a window read per
+    // op and match on hashes it was never asked about.
+    const seen: (Hex | Hex[] | null)[][] = [];
+    const chain: ReconcileChain = {
+      async getBlockNumber() {
+        return 1000n;
+      },
+      async getLogs(a) {
+        seen.push(a.topics);
+        return [];
+      },
+      async getReceiptLogs() {
+        return null;
+      },
+    };
+    await resolveSubmittedOps({
+      chain,
+      smartAccount: ACCOUNT,
+      usdgToken: USDG,
+      hashes: [h(0x55)],
+      lookbackBlocks: 1000n,
+    });
+    assert.equal(seen.length, 1);
+    assert.equal(String(seen[0]![1]).toLowerCase(), h(0x55), "topic1 must carry the hash");
+  });
+
+  it("asks nothing at all when there is nothing stranded", async () => {
+    // The ordinary case, on a 300s clock, for the life of every healthy run.
+    let calls = 0;
+    const chain: ReconcileChain = {
+      async getBlockNumber() {
+        calls += 1;
+        return 1000n;
+      },
+      async getLogs() {
+        calls += 1;
+        return [];
+      },
+      async getReceiptLogs() {
+        return null;
+      },
+    };
+    assert.deepEqual(
+      await resolveSubmittedOps({ chain, smartAccount: ACCOUNT, usdgToken: USDG, hashes: [], lookbackBlocks: 1000n }),
+      [],
+    );
+    assert.equal(calls, 0, "not even a block-number read");
   });
 });

--- a/worker/src/inflight-reconcile.ts
+++ b/worker/src/inflight-reconcile.ts
@@ -100,6 +100,14 @@ async function getLogsAdaptive(
   toBlock: bigint,
   maxSpan: bigint,
   log?: (m: string) => void,
+  /**
+   * Narrow to ONE operation. topic1 of UserOperationEvent is the indexed
+   * userOpHash, and this filter has always left that slot null because the
+   * orphan sweep does not know the hashes in advance. The resolver does, so
+   * passing one here turns the same window scan into an exact lookup — no new
+   * plumbing, and the adaptive halving still covers a provider range limit.
+   */
+  userOpHash?: Hex,
 ): Promise<RawLog[]> {
   const out: RawLog[] = [];
   let cursor = fromBlock;
@@ -111,7 +119,7 @@ async function getLogsAdaptive(
         address: ENTRYPOINT.v07 as `0x${string}`,
         fromBlock: cursor,
         toBlock: end,
-        topics: [USEROP_EVENT_TOPIC, null, addressTopic(sender)],
+        topics: [USEROP_EVENT_TOPIC, userOpHash ?? null, addressTopic(sender)],
       });
       out.push(...logs);
       cursor = end + 1n;
@@ -182,4 +190,102 @@ export async function findOrphanOps(opts: {
     orphans.push({ userOpHash, txHash: String(txHash).toLowerCase(), notionalUsdg6, attributed });
   }
   return orphans;
+}
+/** What the chain says about one op we submitted and lost track of. */
+export interface ResolvedOp {
+  userOpHash: string;
+  txHash: string;
+  /** The chain's verdict. A reverted op moved nothing. */
+  success: boolean;
+  /** |USDG leg|, 6dp. 0 when unattributable, and only meaningful on success. */
+  notionalUsdg6: bigint;
+  attributed: boolean;
+}
+
+/**
+ * RESOLVE OPS WE SUBMITTED AND NEVER HEARD BACK ABOUT.
+ *
+ * The sibling of findOrphanOps, and deliberately not the same function. An
+ * ORPHAN is an op the chain executed that the ledger knows nothing about, found
+ * by scanning a window; a STRANDED op is one the ledger already named — we hold
+ * its hash — whose outcome is missing. Those want opposite queries:
+ *
+ *  - findOrphanOps scans a block range and skips `!success`, because a reverted
+ *    op moved nothing and counts toward no cap, so an unrecorded revert changes
+ *    nothing. Here the row EXISTS and is charging the live rail, so a revert is
+ *    exactly as important as a success — it is what releases the charge.
+ *  - findOrphanOps cannot filter by hash (it does not know them in advance).
+ *    This does: topic1 of UserOperationEvent is the indexed userOpHash and
+ *    getLogsAdaptive already leaves that slot null, so passing the hash turns a
+ *    window scan into an exact lookup.
+ *
+ * Reimplemented from the shape of Vex's agent-activity-repair
+ * (github.com/Vex-Foundation/Vex), used with its author's permission, and
+ * keeping the three properties that make theirs safe: it holds no signer, it
+ * NEVER re-broadcasts, and it never terminalizes on ambiguity — an op it cannot
+ * find stays 'submitted' rather than being guessed at. A resolver that guesses
+ * is worse than none, because the guess would enter a hash-chained journal.
+ */
+export async function resolveSubmittedOps(opts: {
+  chain: ReconcileChain;
+  smartAccount: `0x${string}`;
+  usdgToken: string;
+  /** Hashes of 'submitted' rows, lowercased. */
+  hashes: readonly string[];
+  lookbackBlocks: bigint;
+  maxSpan?: bigint;
+  log?: (m: string) => void;
+}): Promise<ResolvedOp[]> {
+  if (opts.hashes.length === 0) return [];
+  const head = await opts.chain.getBlockNumber();
+  const from = head > opts.lookbackBlocks ? head - opts.lookbackBlocks : 0n;
+
+  const out: ResolvedOp[] = [];
+  for (const hash of opts.hashes) {
+    // EXACT LOOKUP, not a scan. topic1 is the indexed userOpHash.
+    const logs = await getLogsAdaptive(
+      opts.chain,
+      opts.smartAccount,
+      from,
+      head,
+      opts.maxSpan ?? 10_000n,
+      opts.log,
+      hash as Hex,
+    );
+    if (logs.length === 0) continue; // not found is NOT "reverted" — leave it be
+
+    let decoded: { success: boolean } | null = null;
+    let txHash = "";
+    for (const raw of logs) {
+      try {
+        const d = decodeEventLog({
+          abi: ENTRYPOINT_ABI,
+          topics: raw.topics as [Hex, ...Hex[]],
+          data: raw.data,
+        });
+        if (String(d.args.userOpHash).toLowerCase() !== hash) continue;
+        decoded = { success: Boolean(d.args.success) };
+        txHash = String(raw.transactionHash).toLowerCase();
+        break;
+      } catch {
+        // not a UserOperationEvent we can read — keep looking
+      }
+    }
+    if (!decoded) continue;
+
+    let notionalUsdg6 = 0n;
+    let attributed = false;
+    if (decoded.success) {
+      const receiptLogs = await opts.chain.getReceiptLogs(txHash as Hex).catch(() => null);
+      if (receiptLogs) {
+        const usdgDelta = netTokenDeltas(receiptLogs, opts.smartAccount).get(opts.usdgToken.toLowerCase()) ?? 0n;
+        if (usdgDelta !== 0n) {
+          notionalUsdg6 = usdgDelta < 0n ? -usdgDelta : usdgDelta;
+          attributed = true;
+        }
+      }
+    }
+    out.push({ userOpHash: hash, txHash, success: decoded.success, notionalUsdg6, attributed });
+  }
+  return out;
 }

--- a/worker/src/inflight-row.integration.test.ts
+++ b/worker/src/inflight-row.integration.test.ts
@@ -25,7 +25,8 @@ import path from "node:path";
 const HOME = mkdtempSync(path.join(os.tmpdir(), "merrymen-inflight-"));
 process.env.MERRYMEN_HOME = HOME;
 
-const { initStore, addTrade, getOpsToday, getSpentTodayUsdg } = await import("./store");
+const { initStore, addTrade, getOpsToday, getSpentTodayUsdg, listOpHashes, listSubmittedOps } =
+  await import("./store");
 const { homePaths } = await import("./home");
 const { DatabaseSync } = await import("node:sqlite");
 
@@ -140,5 +141,105 @@ describe("the pre-broadcast row and the outcome are the same row", () => {
     const late = rows(HASH).find((r) => r.status === "reverted")!;
     assert.equal(landed.epoch, late.epoch, "same epoch here because no boundary was opened between them");
     assert.ok(Number.isInteger(landed.epoch));
+  });
+});
+
+/**
+ * THE REGRESSION, ASSERTED AGAINST REAL SQL.
+ *
+ * The pre-broadcast row and the orphan sweep were built a day apart and did not
+ * fit: `listOpHashes` selected every non-null user_op_hash regardless of status,
+ * and `findOrphanOps` skips any hash in that set. So the row the sweep exists to
+ * finish was precisely the one it filtered out.
+ *
+ * This cannot be a unit test — the bug was a missing WHERE clause, and a clause
+ * that is not run is a clause that cannot be wrong.
+ */
+describe("an in-flight row is not mistaken for a settled one", () => {
+  const IN_FLIGHT = "0xaaaa000000000000000000000000000000000000000000000000000000000001";
+  const SETTLED = "0xbbbb000000000000000000000000000000000000000000000000000000000002";
+  const REFUSED = "0xcccc000000000000000000000000000000000000000000000000000000000003";
+
+  it("sets up one row of each status", async () => {
+    await submitted(IN_FLIGHT, 10);
+    await submitted(SETTLED, 20);
+    await addTrade({
+      agent_id: AGENT,
+      kind: "swap",
+      target: "0xrouter000000000000000000000000000000001",
+      amount_usdg: 20,
+      user_op_hash: SETTLED,
+      tx_hash: "0xdone",
+      status: "landed",
+    });
+    await addTrade({
+      agent_id: AGENT,
+      kind: "swap",
+      target: "0xrouter000000000000000000000000000000001",
+      amount_usdg: 30,
+      user_op_hash: REFUSED,
+      status: "reverted",
+      reject_rule: "the chain said no",
+    });
+    assert.equal(rows(IN_FLIGHT)[0]!.status, "submitted");
+    assert.equal(rows(SETTLED)[0]!.status, "landed");
+  });
+
+  it("listOpHashes reports the SETTLED ones, so the sweep can skip them", async () => {
+    const known = await listOpHashes(AGENT);
+    assert.ok(known.has(SETTLED.toLowerCase()), "a landed op is accounted for");
+    // The original reasoning, still right and still load-bearing: a hash
+    // recorded as reverted must not be re-reconciled as landed.
+    assert.ok(known.has(REFUSED.toLowerCase()), "so is a reverted one");
+  });
+
+  it("and NOT the in-flight one — this is the whole bug", async () => {
+    const known = await listOpHashes(AGENT);
+    assert.equal(
+      known.has(IN_FLIGHT.toLowerCase()),
+      false,
+      "a 'submitted' row is a claim that an op left, with no outcome — it is by definition not accounted for",
+    );
+  });
+
+  it("listSubmittedOps returns it, with what the resolver needs to settle it", async () => {
+    const open = await listSubmittedOps(AGENT);
+    const mine = open.find((o) => o.userOpHash === IN_FLIGHT.toLowerCase());
+    assert.ok(mine, "the ledger row IS the recovery record — nothing else holds this hash");
+    assert.equal(mine.kind, "swap");
+    assert.equal(mine.amountUsdg, 10);
+    assert.ok(Number.isInteger(mine.epoch), "the epoch it was submitted in, for the boundary check");
+    assert.ok(mine.createdAt > 0);
+    // Settled rows must not appear here, or the resolver would re-ask the chain
+    // about ops it already has answers for, every pass, forever.
+    assert.equal(open.some((o) => o.userOpHash === SETTLED.toLowerCase()), false);
+    assert.equal(open.some((o) => o.userOpHash === REFUSED.toLowerCase()), false);
+  });
+
+  it("the two sets are disjoint, which is what lets both sweeps run", async () => {
+    const known = await listOpHashes(AGENT);
+    const open = (await listSubmittedOps(AGENT)).map((o) => o.userOpHash);
+    for (const h of open) {
+      assert.equal(known.has(h), false, `${h} cannot be in both, or the sweeps would both act on it`);
+    }
+  });
+
+  it("resolving one moves it from the open set to the known set", async () => {
+    await addTrade({
+      agent_id: AGENT,
+      kind: "swap",
+      target: "0xrouter000000000000000000000000000000001",
+      amount_usdg: 10,
+      user_op_hash: IN_FLIGHT,
+      tx_hash: "0xresolved",
+      status: "landed",
+    });
+    assert.equal(rows(IN_FLIGHT).length, 1, "still one row — resolved in place");
+    assert.ok((await listOpHashes(AGENT)).has(IN_FLIGHT.toLowerCase()));
+    assert.equal(
+      (await listSubmittedOps(AGENT)).some((o) => o.userOpHash === IN_FLIGHT.toLowerCase()),
+      false,
+      "and it stops being re-asked about",
+    );
   });
 });

--- a/worker/src/preflight-cli.ts
+++ b/worker/src/preflight-cli.ts
@@ -11,7 +11,7 @@ import { readFileSync } from "node:fs";
 import { homePaths } from "./home";
 import { loadGrantFile } from "./grant";
 import { preflight, rank, verdict, type Check, type PreflightInput } from "./preflight";
-import { CASH, chainForId } from "../../packages/core/src/index";
+import { CASH, WALL_POLICY_CONTRACTS, chainForId } from "../../packages/core/src/index";
 
 const GREEN = "\x1b[32m";
 const YELLOW = "\x1b[33m";
@@ -55,6 +55,28 @@ async function usdgBalance(url: string, account: string): Promise<number | null>
 async function ethBalance(url: string, account: string): Promise<bigint | null> {
   try {
     return BigInt((await rpc(url, "eth_getBalance", [account, "latest"])) as string);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Which of the wall's own validator contracts are missing on this chain.
+ *
+ * `null` on ANY read failure, deliberately — a partial answer here would be
+ * worse than none: reporting "RateLimitPolicy absent" because the RPC blinked
+ * is the same false accusation delivery.ts refuses to make about a balance.
+ * All-or-nothing, and the caller renders "couldn't check" rather than "fine".
+ */
+async function missingPolicyContracts(url: string): Promise<string[] | null> {
+  try {
+    const missing: string[] = [];
+    for (const c of WALL_POLICY_CONTRACTS) {
+      const code = (await rpc(url, "eth_getCode", [c.address, "latest"])) as string | null;
+      if (typeof code !== "string") return null;
+      if (code === "0x" || code === "") missing.push(`${c.name} (${c.address})`);
+    }
+    return missing;
   } catch {
     return null;
   }
@@ -119,14 +141,23 @@ async function main(): Promise<void> {
     (chainId === 46630 ? settings.rpcTestnet : settings.rpcMainnet) ??
     chain.rpcUrls.default.http[0]!;
 
-  const [usdg, ethWei, bundlerReachable] = await Promise.all([
+  const [usdg, ethWei, bundlerReachable, missingPolicy] = await Promise.all([
     grant ? usdgBalance(rpcUrl, grant.smartAccount) : Promise.resolve(null),
     grant ? ethBalance(rpcUrl, grant.smartAccount) : Promise.resolve(null),
     bundlerAnswers(settings, chainId),
+    missingPolicyContracts(rpcUrl),
   ]);
 
   const checks = rank(
-    preflight({ settings, grant, nowSec: Math.floor(Date.now() / 1000), usdg, ethWei, bundlerReachable }),
+    preflight({
+      settings,
+      grant,
+      nowSec: Math.floor(Date.now() / 1000),
+      usdg,
+      ethWei,
+      bundlerReachable,
+      missingPolicyContracts: missingPolicy,
+    }),
   );
   for (const c of checks) render(c);
 

--- a/worker/src/preflight.test.ts
+++ b/worker/src/preflight.test.ts
@@ -20,6 +20,7 @@ function ready(over: Partial<PreflightInput> = {}): PreflightInput {
     usdg: 500,
     ethWei: 10n ** 16n, // 0.01 ETH
     bundlerReachable: true,
+    missingPolicyContracts: [],
     ...over,
   };
 }

--- a/worker/src/preflight.ts
+++ b/worker/src/preflight.ts
@@ -72,6 +72,12 @@ export interface PreflightInput {
   ethWei: bigint | null;
   /** null = not probed (no bundler configured at all). */
   bundlerReachable: boolean | null;
+  /**
+   * Names of WALL_POLICY_CONTRACTS entries with no code on the grant chain.
+   * `[]` means all present; `null` means the probe could not run — which says
+   * nothing about the contracts and must never read as "absent".
+   */
+  missingPolicyContracts: string[] | null;
 }
 
 const ok = (id: string, title: string): Check => ({ id, level: "ok", title });
@@ -127,6 +133,46 @@ export function preflight(input: PreflightInput): Check[] {
     });
   } else {
     out.push(ok("chain", `mainnet ${TRADEABLE_CHAIN_ID} — real funds`));
+  }
+
+  // ── the contracts the wall itself is built on ────────────────────────
+  // A ZeroDev policy is an address plus its data, and the addresses are the
+  // library's defaults for a deployment it assumes exists. On this chain one of
+  // them did not: RATE_LIMIT_POLICY_CONTRACT has zero bytes on 4663 AND 46630,
+  // measured 2026-08-30, while the timestamp policy, the call policy and the
+  // ECDSA signer all carry real bytecode. Every grant built before that
+  // discovery sealed a pointer into empty space.
+  //
+  // A BLOCKER, unlike the arm-time warn that mirrors it. The whole job of this
+  // command is to answer "can this thing trade", and the honest answer when the
+  // wall's own validator contracts are absent is no — the failure would
+  // otherwise arrive as a UserOp that will not validate, reported by nothing,
+  // at the price of a prefund per attempt.
+  //
+  // `null` means the probe did not run (no RPC, or the CLI could not reach the
+  // chain). That is NOT the same as absent, and it must not read as one.
+  if (input.missingPolicyContracts === null) {
+    out.push({
+      id: "policy-contracts",
+      level: "warn",
+      title: "couldn't check the contracts the wall is built on",
+      detail:
+        "The signature seals the addresses of the ZeroDev policy contracts it validates against. " +
+        "This run could not read the chain to confirm they are deployed, so it is unverified rather " +
+        "than fine. Re-run when the RPC is reachable.",
+    });
+  } else if (input.missingPolicyContracts.length > 0) {
+    out.push({
+      id: "policy-contracts",
+      level: "blocker",
+      title: `the wall depends on contracts with no code on chain ${g.chainId}`,
+      detail:
+        `${input.missingPolicyContracts.join(", ")} — every UserOp this grant signs is validated ` +
+        "against them, so nothing can land until this is resolved. This is a merrymen bug, not " +
+        "something you configured: report it rather than working around it.",
+    });
+  } else {
+    out.push(ok("policy-contracts", "the wall's validator contracts are deployed"));
   }
 
   const secsLeft = g.expiresAt - input.nowSec;

--- a/worker/src/session-account.test.ts
+++ b/worker/src/session-account.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createPublicClient, decodeAbiParameters, http } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { PolicyFlags, toPermissionValidator } from "@zerodev/permissions";
+import { toECDSASigner } from "@zerodev/permissions/signers";
+import { toTimestampPolicy } from "@zerodev/permissions/policies";
+import { getEntryPoint } from "@zerodev/sdk/constants";
+import { KERNEL_V3_3 } from "@zerodev/sdk/constants";
+import { robinhoodChain, WALL_POLICY_FLAG } from "../../packages/core/src/index";
+
+/**
+ * THE ASSERTION WHOSE ABSENCE LET THIS SHIP.
+ *
+ * wall.test.ts pins WALL_POLICY_FLAG's VALUE — that it is
+ * PolicyFlags.NOT_FOR_VALIDATE_SIG — and stops there. A constant being right
+ * says nothing about whether it survives the trip to the chain, and it did not:
+ * the flag is hashed into the permission id and concatenated into the enable
+ * data at sign time, then dropped by getPluginSerializationParams and defaulted
+ * back to FOR_ALL_VALIDATION on the way in.
+ *
+ * These tests are about the SEAM, not the constant. They construct validators
+ * the way the signers and the worker each do, and compare what the chain would
+ * actually see.
+ *
+ * No network: toPermissionValidator only reads `client.chain.id` when the chain
+ * is present (toPermissionValidator.ts:41), so a client with a chain never
+ * dials out. That is why this can be a unit test at all.
+ */
+
+const client = createPublicClient({ chain: robinhoodChain, transport: http("http://127.0.0.1:1") });
+const entryPoint = getEntryPoint("0.7");
+const NOW = 1_800_000_000;
+
+/** A validator built the way one side or the other builds it. */
+async function validatorWith(flag: `0x${string}` | undefined, key: `0x${string}`) {
+  const signer = await toECDSASigner({ signer: privateKeyToAccount(key) });
+  return toPermissionValidator(client, {
+    signer,
+    policies: [toTimestampPolicy({ validAfter: NOW, validUntil: NOW + 86_400 })],
+    entryPoint,
+    kernelVersion: KERNEL_V3_3,
+    ...(flag === undefined ? {} : { flag }),
+  } as never);
+}
+
+/**
+ * The flag the chain would actually read.
+ *
+ * `getEnableData()` is an ABI-encoded `bytes[]` whose entries are the policies
+ * followed by ONE signer entry, `concat([flag, signerContract, signerData])`
+ * (toPermissionValidator.ts:47-67). So the flag is the first two bytes of the
+ * LAST entry. Decoding for it rather than grepping the hex matters: the encoded
+ * blob is full of offset and length words, and "0002" appears in several of
+ * them — a substring search finds the encoding, not the flag.
+ */
+function signerFlagOf(enableData: `0x${string}`): string {
+  const [entries] = decodeAbiParameters([{ name: "policyAndSignerData", type: "bytes[]" }], enableData) as [
+    readonly `0x${string}`[],
+  ];
+  const signerEntry = entries[entries.length - 1]!;
+  return signerEntry.slice(0, 6).toLowerCase(); // 0x + 2 bytes
+}
+
+test("THE BUG: dropping the flag changes the enable data the account is handed", async () => {
+  const key = generatePrivateKey();
+  // What both signers produce (web/src/lib/session.ts, mobile/src/crypto/signGrant.ts).
+  const signed = await validatorWith(WALL_POLICY_FLAG, key);
+  // What deserializePermissionAccount rebuilds: no flag, so the library default.
+  const submitted = await validatorWith(undefined, key);
+
+  const signedData = await signed.getEnableData();
+  const submittedData = await submitted.getEnableData();
+
+  assert.notEqual(
+    signedData,
+    submittedData,
+    "if these were equal the bug would not exist — the owner signs one blob and the worker submits the other",
+  );
+  // And name the difference precisely, so a future reader need not rediscover
+  // which bytes moved.
+  assert.equal(signerFlagOf(signedData), PolicyFlags.NOT_FOR_VALIDATE_SIG, "signed: 0x0002, execute-but-never-sign");
+  assert.equal(
+    signerFlagOf(submittedData),
+    PolicyFlags.FOR_ALL_VALIDATION,
+    "submitted: 0x0000 — the session key may sign, which is the hole the flag exists to close",
+  );
+});
+
+test("THE BUG, second half: the permission id is unaffected, which is why it stayed hidden", async () => {
+  // getIdentifier() still matches because permissionId is serialized and passed
+  // back verbatim. So the validator installs under the RIGHT id with the WRONG
+  // enable data — nothing upstream disagrees, and the only symptom is a first
+  // UserOp that will not validate.
+  const key = generatePrivateKey();
+  const flagged = await validatorWith(WALL_POLICY_FLAG, key);
+  const unflagged = await validatorWith(undefined, key);
+  assert.notEqual(
+    flagged.getIdentifier(),
+    unflagged.getIdentifier(),
+    "the flag IS hashed into the id — so a rebuild that recomputes the id catches this, and one that is handed the id cannot",
+  );
+});
+
+test("THE FIX: rebuilding WITH the flag reproduces the signed enable data exactly", async () => {
+  const key = generatePrivateKey();
+  const signed = await validatorWith(WALL_POLICY_FLAG, key);
+  const rebuilt = await validatorWith(WALL_POLICY_FLAG, key);
+
+  assert.equal(
+    await rebuilt.getEnableData(),
+    await signed.getEnableData(),
+    "BYTE EQUALITY. This is the property the account contract checks, and the only one that matters.",
+  );
+  assert.equal(rebuilt.getIdentifier(), signed.getIdentifier());
+});
+
+test("the id check is not tautological — it must be computed, never accepted", async () => {
+  // session-account.ts computes the id WITHOUT passing permissionId, precisely
+  // so a wrong rebuild fails. This pins why: passing it makes getIdentifier()
+  // return the input verbatim, so the comparison would compare a value with
+  // itself and pass however wrong the policies or the flag were.
+  const key = generatePrivateKey();
+  const honest = await validatorWith(WALL_POLICY_FLAG, key);
+  const wrong = await toPermissionValidator(client, {
+    signer: await toECDSASigner({ signer: privateKeyToAccount(key) }),
+    // Deliberately the WRONG policies — a different expiry entirely.
+    policies: [toTimestampPolicy({ validAfter: NOW, validUntil: NOW + 999_999 })],
+    entryPoint,
+    kernelVersion: KERNEL_V3_3,
+    flag: WALL_POLICY_FLAG,
+    // ...but handed the honest id.
+    permissionId: honest.getIdentifier(),
+  } as never);
+
+  assert.equal(wrong.getIdentifier(), honest.getIdentifier(), "handed the answer, it agrees — this is the trap");
+  assert.notEqual(
+    await wrong.getEnableData(),
+    await honest.getEnableData(),
+    "while the enable data — what the chain actually checks — is different",
+  );
+});
+
+test("WALL_POLICY_FLAG is the flag the worker passes, not merely a constant", async () => {
+  // wall.test.ts asserts the value. This asserts the wiring: the flag the
+  // executor hands deserializeFlaggedPermissionAccount is the same one the
+  // signers use, so the two cannot drift.
+  assert.equal(WALL_POLICY_FLAG, PolicyFlags.NOT_FOR_VALIDATE_SIG);
+  const src = await import("node:fs").then((fs) =>
+    fs.readFileSync(new URL("./executor.ts", import.meta.url), "utf8"),
+  );
+  assert.match(src, /deserializeFlaggedPermissionAccount\([\s\S]*?WALL_POLICY_FLAG,/, "the executor must pass it");
+  assert.equal(
+    /\bdeserializePermissionAccount\(/.test(src),
+    false,
+    "and must never call the flag-dropping one",
+  );
+});

--- a/worker/src/session-account.ts
+++ b/worker/src/session-account.ts
@@ -1,0 +1,221 @@
+/**
+ * REBUILD THE SESSION ACCOUNT WITH THE POLICY FLAG THE OWNER ACTUALLY SIGNED.
+ *
+ * THE BUG THIS EXISTS FOR. `WALL_POLICY_FLAG` is `NOT_FOR_VALIDATE_SIG`
+ * (`0x0002`), and both signers pass it to `toPermissionValidator`. It is the
+ * only thing standing between a session key and an ERC-1271 signature the
+ * account will honour — a class of spend no CALL policy can constrain, because
+ * it never becomes a UserOp at all.
+ *
+ * It never reached the chain. Traced through @zerodev/permissions 5.6.3:
+ *
+ *   toPermissionValidator.ts:47-67   getEnableData() emits
+ *                                    concat([flag, signerContract, signerData]).
+ *                                    THE OWNER SIGNS OVER THIS.
+ *   toPermissionValidator.ts:131-136 getPluginSerializationParams() returns
+ *                                    {policies, permissionId}. NO FLAG — and
+ *                                    types.ts:66-69 has no field for one.
+ *   deserializePermissionAccount:61  rebuilds toPermissionValidator({...}) with
+ *                                    no flag, so :37 defaults it to
+ *                                    FOR_ALL_VALIDATION (0x0000).
+ *
+ * `permissionId` IS carried, so `getIdentifier()` still matches and the
+ * validator installs under the right id — with the WRONG enable data. The owner
+ * signed a blob beginning `0x0002`; the worker computes and submits one
+ * beginning `0x0000`. Kernel recomputes the EIP-712 digest from the SUBMITTED
+ * enable data and recovers someone who is not the owner.
+ *
+ * So the first UserOperation of every flagged grant fails at plugin-enable —
+ * and only the first, because only the first carries enable data. That is
+ * consistent with this project never having landed a trade, though it is not
+ * proof of it: no UserOp has ever been sent.
+ *
+ * It also makes `wall.ts`'s claim — "The flag travels ON-CHAIN in the
+ * validator's enable data, so the account itself enforces it — this is not a
+ * client-side promise" — wrong about merrymen's own path. It is true of the
+ * signing side and false of the submitting side, which is the half that counts.
+ *
+ * WHY REBUILD FROM THE SERIALIZED PARAMS rather than from the grant's caps.
+ * `buildWallPolicies` could regenerate these policies — `grantedAt` is exactly
+ * the `now` it was called with — but the CALL policy also depends on
+ * `extraTokens`, and a grant stores only their ADDRESSES (`grantTokens`), not
+ * the symbol/decimals a CustomToken carries. Reproducing from caps would be
+ * right most of the time, and "most of the time" is not a property to build a
+ * wall on. The serialized params are what was signed, so replaying them is
+ * exact by construction.
+ *
+ * WHAT MAKES THIS SAFE. Getting the rebuild wrong yields a different permission
+ * id, which is a dead grant — so the id is recomputed WITHOUT being told the
+ * answer and compared against the stored one. A mismatch refuses to arm. That
+ * check is byte-level: `getPermissionId` hashes `[toPolicyId(policies), flag,
+ * toSignerId(signer)]`, so agreement means the policies AND the flag AND the
+ * signer all reproduce what the owner signed. The account address is then
+ * checked independently.
+ *
+ * Every import below is a published entry point (`@zerodev/permissions`,
+ * `/signers`, `@zerodev/sdk`, `@zerodev/sdk/accounts`). Nothing reaches past a
+ * package's `exports` map.
+ */
+
+import { privateKeyToAccount } from "viem/accounts";
+import type { Hex } from "viem";
+import { decodeParamsFromInitCode, toPermissionValidator } from "@zerodev/permissions";
+import { toECDSASigner } from "@zerodev/permissions/signers";
+import { toCallPolicy, toTimestampPolicy } from "@zerodev/permissions/policies";
+import { createKernelAccount } from "@zerodev/sdk";
+import { toKernelPluginManager } from "@zerodev/sdk/accounts";
+import { KERNEL_V3_3 } from "@zerodev/sdk/constants";
+
+/**
+ * The serialized blob's shape (serializePermissionAccount.ts:54-63).
+ *
+ * Deliberately loose. This is a foreign format we are replaying, not a type we
+ * own, and a precise interface here would be a second place to keep in sync
+ * with a package that has already surprised us once.
+ */
+interface SerializedParams {
+  permissionParams: { policies?: { policyParams: { type: string } }[]; permissionId?: Hex };
+  action: unknown;
+  validityData: Record<string, unknown>;
+  accountParams: { initCode: Hex; accountAddress: `0x${string}` };
+  enableSignature?: Hex;
+  privateKey?: Hex;
+  eip7702Auth?: unknown;
+  isPreInstalled?: boolean;
+}
+
+/** base64 → the params object. Mirrors utils.ts:4-7 and :38-42 exactly. */
+function decodeParams(serialized: string): SerializedParams {
+  const binString = atob(serialized);
+  const bytes = Uint8Array.from(binString, (m) => m.codePointAt(0) as number);
+  // A PLAIN JSON.parse, with no bigint reviver — matching the package, which
+  // also does none. Numeric policy fields therefore arrive as strings and the
+  // toXPolicy builders coerce them, exactly as they do today. Adding a reviver
+  // here would make our policies differ from the ones the package builds, which
+  // is the one thing this file must not do.
+  return JSON.parse(new TextDecoder().decode(bytes)) as SerializedParams;
+}
+
+/**
+ * One serialized policy → a live Policy. A trimmed `createPolicyFromParams`
+ * (deserializePermissionAccount.ts:100-117), which is not exported.
+ *
+ * Only the two kinds merrymen actually seals. The default THROWS rather than
+ * skipping: a policy we cannot rebuild is a bound we would silently drop, and
+ * dropping a bound is the failure this whole file is about. Anything else — a
+ * gas policy, a sudo policy, the rate-limit policy this repo no longer
+ * installs — means a grant we do not understand, and refusing to arm is the
+ * only honest response to that.
+ */
+async function policyFromParams(policy: { policyParams: { type: string } }) {
+  switch (policy.policyParams.type) {
+    case "call":
+      return toCallPolicy(policy.policyParams as never);
+    case "timestamp":
+      return toTimestampPolicy(policy.policyParams as never);
+    default:
+      throw new Error(
+        `this grant carries a '${policy.policyParams.type}' policy that merrymen cannot rebuild — refusing to arm rather than dropping it`,
+      );
+  }
+}
+
+export class PermissionIdMismatch extends Error {
+  constructor(readonly expected: string, readonly got: string) {
+    super(
+      `rebuilt permission id ${got} does not match the signed id ${expected} — ` +
+        `refusing to arm. The session account could not be reconstructed exactly as it was signed.`,
+    );
+    this.name = "PermissionIdMismatch";
+  }
+}
+
+/**
+ * `deserializePermissionAccount`, plus the flag.
+ *
+ * Signature deliberately mirrors the package's so the two can be read side by
+ * side, with `flag` as the one addition — the whole point of the file.
+ */
+export async function deserializeFlaggedPermissionAccount(
+  client: Parameters<typeof toPermissionValidator>[0],
+  entryPoint: { address: `0x${string}`; version: "0.7" },
+  kernelVersion: typeof KERNEL_V3_3,
+  serialized: string,
+  flag: `0x${string}`,
+) {
+  const params = decodeParams(serialized);
+  if (!params.privateKey) {
+    throw new Error("serialized grant carries no session key — nothing to sign with");
+  }
+
+  const signer = await toECDSASigner({ signer: privateKeyToAccount(params.privateKey) });
+  const policies = await Promise.all((params.permissionParams.policies ?? []).map(policyFromParams));
+
+  // FIRST, WITHOUT THE ANSWER. Passing `permissionId` makes getIdentifier()
+  // return it verbatim (toPermissionValidator.ts:71-73), which would make the
+  // check below tautological — it would compare the stored id with itself and
+  // pass however wrong the rebuild was. So compute it fresh and compare.
+  const probe = await toPermissionValidator(client, {
+    signer,
+    policies,
+    entryPoint,
+    kernelVersion,
+    flag,
+  } as never);
+
+  const signedId = params.permissionParams.permissionId;
+  const rebuiltId = probe.getIdentifier();
+  if (signedId && rebuiltId.toLowerCase() !== signedId.toLowerCase()) {
+    throw new PermissionIdMismatch(signedId, rebuiltId);
+  }
+
+  // Now pass it, matching the package: the id is part of what the account
+  // installs, and the stored one is authoritative even though we just proved
+  // ours equals it.
+  const validator = await toPermissionValidator(client, {
+    signer,
+    policies,
+    entryPoint,
+    kernelVersion,
+    flag,
+    permissionId: signedId,
+  } as never);
+
+  const { index, validatorInitData, useMetaFactory } = decodeParamsFromInitCode(
+    params.accountParams.initCode,
+    kernelVersion,
+  );
+
+  const plugins = await toKernelPluginManager(client as never, {
+    regular: validator,
+    pluginEnableSignature: params.isPreInstalled ? undefined : params.enableSignature,
+    validatorInitData,
+    action: params.action,
+    entryPoint,
+    kernelVersion,
+    isPreInstalled: params.isPreInstalled,
+    ...params.validityData,
+  } as never);
+
+  const account = await createKernelAccount(client as never, {
+    entryPoint,
+    kernelVersion,
+    plugins,
+    index,
+    address: params.accountParams.accountAddress,
+    useMetaFactory,
+    eip7702Auth: params.eip7702Auth,
+  } as never);
+
+  // SECOND, INDEPENDENT CHECK. The id proves the validator; this proves the
+  // account it was installed into. They can fail separately — a correct
+  // validator attached to the wrong address would sign operations for an
+  // account the owner never funded.
+  if (account.address.toLowerCase() !== params.accountParams.accountAddress.toLowerCase()) {
+    throw new Error(
+      `rebuilt account ${account.address} is not the signed account ${params.accountParams.accountAddress} — refusing to arm`,
+    );
+  }
+
+  return account;
+}

--- a/worker/src/store.ts
+++ b/worker/src/store.ts
@@ -1434,24 +1434,85 @@ export async function getSpentTodayUsdg(agentId: string, rail: BudgetRail = "liv
 }
 
 /**
- * Every UserOperation hash this agent has ANY row for — landed, reverted, or
- * submitted. The in-flight reconciler (inflight-reconcile.ts) uses it to tell an
- * op the chain executed but the ledger never recorded (a process death between
- * submit and the ledger write) from one that is already accounted for. All
- * statuses, not just the spending ones: a hash recorded as reverted must not be
- * re-reconciled as landed. Hashes are lowercased so the set compares cleanly
- * against the chain's (which returns them lowercased).
+ * Every UserOperation hash this agent has a SETTLED row for — landed, reverted
+ * or rejected. The in-flight reconciler uses it to tell an op the chain
+ * executed but the ledger never recorded (a process death between submit and
+ * the ledger write) from one that is already accounted for.
+ *
+ * Settled, NOT all statuses — and the difference is a bug this had for one day.
+ * The doc here used to say "All statuses, not just the spending ones: a hash
+ * recorded as reverted must not be re-reconciled as landed." That reasoning is
+ * still exactly right for landed/reverted/rejected, and it was written before
+ * 'submitted' rows existed. Once executor.ts began writing one BEFORE
+ * broadcasting, this query started hiding in-flight ops from the very sweep
+ * that exists to finish them: findOrphanOps skips any hash in this set, so a
+ * row stranded by a crash became invisible forever — never journaled, never
+ * booked to basis, absent from realized P&L, and still charging the live rail.
+ *
+ * A 'submitted' row is by definition NOT accounted for. It is a claim that an
+ * op left, with no outcome attached. listSubmittedOps returns those.
+ *
+ * Hashes are lowercased so the set compares cleanly against the chain's.
  */
 export async function listOpHashes(agentId: string): Promise<Set<string>> {
   const rows = (await getDb()
     .prepare(
       `SELECT DISTINCT user_op_hash FROM trades
-       WHERE agent_id = ? AND user_op_hash IS NOT NULL`,
+       WHERE agent_id = ? AND user_op_hash IS NOT NULL AND status <> 'submitted'`,
     )
     .all(agentId)) as { user_op_hash: string | null }[];
   const set = new Set<string>();
   for (const r of rows) if (r.user_op_hash) set.add(r.user_op_hash.toLowerCase());
   return set;
+}
+
+/** One op that left and never came back — the input to the resolver. */
+export interface SubmittedOp {
+  userOpHash: string;
+  kind: string;
+  target: string;
+  amountUsdg: number;
+  /** unixepoch seconds, stamped at INSERT and never rewritten by a resolution. */
+  createdAt: number;
+  epoch: number;
+}
+
+/**
+ * Rows written before broadcast whose outcome never arrived.
+ *
+ * Two ways to get one: the process died between sendUserOperation and the
+ * ledger write, or the receipt could not be read and index.ts deliberately
+ * left the row alone (UserOpUnresolved). Both are 'we do not know', and both
+ * keep charging the live rail — RAIL_STATUSES.live includes 'submitted' — so
+ * leaving them unresolved is safe in the cap direction and useless in every
+ * other: no journal entry, no cost basis, no P&L.
+ *
+ * The only input the resolver has. index.ts records the hash nowhere in
+ * process memory once it gives up, so the ledger row IS the recovery record.
+ */
+export async function listSubmittedOps(agentId: string): Promise<SubmittedOp[]> {
+  const rows = (await getDb()
+    .prepare(
+      `SELECT user_op_hash, kind, target, amount_usdg, created_at, epoch FROM trades
+       WHERE agent_id = ? AND status = 'submitted' AND user_op_hash IS NOT NULL
+       ORDER BY created_at ASC`,
+    )
+    .all(agentId)) as {
+    user_op_hash: string;
+    kind: string;
+    target: string;
+    amount_usdg: number;
+    created_at: number;
+    epoch: number;
+  }[];
+  return rows.map((r) => ({
+    userOpHash: r.user_op_hash.toLowerCase(),
+    kind: r.kind,
+    target: r.target,
+    amountUsdg: Number(r.amount_usdg),
+    createdAt: Number(r.created_at),
+    epoch: Number(r.epoch),
+  }));
 }
 
 // ── chat turns — the conversation survives a restart ──────────────────────

--- a/worker/src/wall.test.ts
+++ b/worker/src/wall.test.ts
@@ -304,13 +304,23 @@ test("the wall carries exactly the expected permission set — no more, no less"
   for (const p of list) assert.equal(p.valueLimit, 0n, `${p.target} must not be allowed to move native ETH`);
 });
 
-test("policies carry a hard expiry and a daily op limit", () => {
+test("the wall carries a hard expiry and a call policy — and NO rate limit", () => {
   const now = 1_800_000_000;
   const { policies, expiresAt } = buildWallPolicies({ caps: CAPS, smartAccount: SELF, now });
   assert.equal(expiresAt, now + CAPS.expiryDays * 86_400);
-  // Expiry, rate limit, call policy — the key dies on schedule even if every
-  // other control fails.
-  assert.equal(policies.length, 3);
+
+  // TWO, not three. This asserted three while the middle one was a pointer into
+  // empty space, and the count passing was part of why nobody looked: a test
+  // can only check that a policy was CONSTRUCTED, never that the contract it
+  // names exists. eth_getCode on 2026-08-30 returned 0 bytes for
+  // RATE_LIMIT_POLICY_CONTRACT on mainnet 4663 AND testnet 46630, while the
+  // timestamp and call policies both carry real bytecode.
+  //
+  // So maxOpsPerDay is enforced by the WORKER only, alongside the daily total
+  // and the drawdown breaker, and the on-chain ceiling is per-trade until
+  // expiry. WALL_POLICY_CONTRACTS + the arm-time probe are what make a future
+  // undeployed singleton a refusal instead of a mystery.
+  assert.equal(policies.length, 2, "expiry + call policy; the rate limit is gone because it was never there");
 });
 
 test("the session key may EXECUTE but may not SIGN (the ERC-1271 hole)", () => {
@@ -666,11 +676,15 @@ test("buildWallPolicies forwards EVERY adapter into the call policy", () => {
 
   const call = (opts: Parameters<typeof buildWallPolicies>[0]) => {
     const { policies } = buildWallPolicies(opts);
-    // The call policy is the third, and its permissions live under policyParams
+    // The call policy is the LAST, and its permissions live under policyParams
     // — the zerodev policy object exposes only getPolicyData/getPolicyInfoInBytes
     // /policyParams, so reading `.permissions` off the top level silently yields
     // an empty list and this test would pass for the wrong reason.
-    const p = policies[2] as unknown as { policyParams?: { permissions?: { target: string }[] } };
+    //
+    // Indexed from the end deliberately. This read `policies[2]` until the
+    // rate-limit policy was removed, and a positional index into a list whose
+    // length is itself under test is a second thing to remember to change.
+    const p = policies[policies.length - 1] as unknown as { policyParams?: { permissions?: { target: string }[] } };
     const perms = p.policyParams?.permissions ?? [];
     assert.ok(perms.length > 0, "the call policy must expose its permissions, or this test proves nothing");
     return perms.map((x) => x.target.toLowerCase());


### PR DESCRIPTION
Two defects that would each have made the first funded UserOperation fail with nothing useful to read, plus the missing half of the in-flight mechanism from #cf9b046. Found looking for exactly this, before any money moved.

## The rate-limit policy contract does not exist on this chain

`buildWallPolicies` installed `toRateLimitPolicy`, whose `policyAddress` defaults to `RATE_LIMIT_POLICY_CONTRACT` in `@zerodev/permissions`. `eth_getCode` against both live RPCs, 2026-08-30:

| contract | mainnet 4663 | testnet 46630 |
|---|---|---|
| RateLimitPolicy `0xf63d4139…` | **0 bytes** | **0 bytes** |
| TimestampPolicy `0xB9f8f524…` | 1,441 | 1,441 |
| CallPolicy V0_0_4 `0x9a522832…` | 6,539 | 6,539 |
| ECDSA signer `0x6A6F069E…` | 1,609 | — |
| EntryPoint v0.7 | 16,035 | — |

Every grant this repo could produce sealed a pointer into empty space. Kernel calls `checkUserOpPolicy` expecting a uint256; a call to a codeless address succeeds with zero returndata. That is most likely **every UserOp failing validation**, not "ops go unlimited" — consistent with this project never having landed a trade.

Removed. A policy that cannot execute is not a bound. It was also never the cap it was described as even where the contract *is* deployed: it decrements a **lifetime** counter and returns `packValidationData(startAt)`, and the call never passed `startAt` — so it was `maxOpsPerDay` ops **total per grant**, no daily refill.

**This corrects a mistake in c6e9a7f**, which listed ops/day among the caps the account contract enforces. What the chain actually enforces is per-trade size, the asset and contract allowlists, a zero native-ETH limit, and expiry. The daily total, the drawdown breaker **and trades-per-day** are worker counters. The honest chain-side ceiling is per-trade size until the key expires. Corrected in the README and on both dashboard surfaces.

A test cannot catch this — it can only check a policy was *constructed*, never that the contract it names exists, and `wall.test.ts` asserting `policies.length === 3` was part of why nobody looked. So the check is a probe: `WALL_POLICY_CONTRACTS` + `getCode` at arm (a warn — paper is unaffected) and in preflight (a blocker — judging is that command's whole job). The repo already applied this discipline to the drawdown breaker and never to the wall's own validator contracts.

## `NOT_FOR_VALIDATE_SIG` was signed and never submitted

Traced through `@zerodev/permissions` 5.6.3:

- `toPermissionValidator.ts:47-67` — `getEnableData()` emits `concat([flag, signerContract, signerData])`. **The owner signs over this.**
- `toPermissionValidator.ts:131-136` — `getPluginSerializationParams()` returns `{policies, permissionId}`. No flag; `types.ts:66-69` has no field for one.
- `deserializePermissionAccount.ts:61-71` — rebuilds with no flag, defaulting to `FOR_ALL_VALIDATION`.

`permissionId` **is** carried, so `getIdentifier()` still matches — the validator installs under the right id with the wrong enable data. The owner signs a blob beginning `0x0002`; the worker submits one beginning `0x0000`. Kernel recomputes the EIP-712 digest from what was submitted and recovers someone who is not the owner. The first UserOp of every flagged grant fails at plugin-enable, and only the first, because only the first carries enable data.

`worker/src/session-account.ts` rebuilds the account **with** the flag, replaying the serialized params rather than regenerating from caps (`extraTokens` are not fully recoverable from a grant, and "right most of the time" is not a property to build a wall on). What makes it safe: the permission id is recomputed **without being told the answer** and compared to the signed one — a mismatch refuses to arm. `getPermissionId` hashes `[policies, flag, signer]`, so agreement is a byte-level proof that all three reproduce what was signed. The account address is checked independently.

The test that would have caught this asserts the property that matters: serialize, rebuild, compare `getEnableData()` byte for byte — decoding the `bytes[]` to read the signer entry's leading flag rather than grepping hex, since `0002` appears in the ABI offset words.

## Nothing was resolving a `submitted` row

`cf9b046` began writing a pre-broadcast row so a crash could not lose the hash. It also made the orphan sweep blind to those rows: `listOpHashes` selected every non-null `user_op_hash` **regardless of status**, and `findOrphanOps` skips any hash in that set — so the row the sweep exists to finish was the one it filtered out. Invisible forever, never journaled, absent from realized P&L, and still charging the live rail.

`listOpHashes` now excludes `submitted`; new `resolveSubmittedOps` settles them. It cannot be `findOrphanOps`: that skips `!success` (correct for an orphan — a revert moved nothing) where here the revert is what *releases* the charge, and it scans a window where this looks each hash up exactly via topic1.

Reimplemented from the shape of Vex's `agent-activity-repair` (with its author's permission), keeping the three properties that make theirs safe: holds no signer, never re-broadcasts, never terminalizes on ambiguity. Runs on a 300s clock as well as at arm — a receipt we cannot read would otherwise hold its charge for the rest of the session, and at a $50 daily cap with $10 trades that is a fifth of the day's allowance reclaimable only by re-arming.

## Verification

`npm test` 1,408 passing · `npm run typecheck` clean across worker/web/browser · `npm run build` clean.

`node cli/bin.mjs preflight` now reports `✓ policy-contracts  the wall's validator contracts are deployed` — true only because the undeployed one was removed.

**Still unproven on-chain.** No UserOperation has ever been sent from this project, so both fixes are verified as source and unit tests and neither is verified against a live validator. `merrymen selftest` on mainnet 4663 is what settles them, and it is the gate before any trading capital goes in.
