### PR TITLE
Execution safety (re-targeted at main): bound the gas, classify the reverts, serialize the intents

### DIFF
--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -385,6 +385,28 @@ export const PC_CAPABILITIES = [
 ] as const;
 export type PcCapability = (typeof PC_CAPABILITIES)[number];
 
+/**
+ * The highest slippage a grant may ever be configured with, in bps.
+ *
+ * This was 5,000 — a minOut of HALF the quote — and it lived in a web
+ * route's validation table rather than anywhere a policy belongs, duplicated
+ * in the worker where an out-of-range value silently fell back to the default
+ * instead of being refused. The worker-side sanity check in
+ * `minOutWithSlippage` is looser still (`>= 10_000`), because its job is only
+ * to stop a negative minOut, not to express a bound.
+ *
+ * 1,000 bps, and it is a PRODUCT POLICY rather than a preference: there is no
+ * env var and no settings field that raises it, because a ceiling a running
+ * agent can lift for itself is not a ceiling. Vex pins the same number for
+ * the same reason, and names 5,000 as the range where a provider will accept
+ * a fill that is a total loss.
+ *
+ * Above ~1,000 bps on this chain the number stops describing slippage. The v4
+ * fee survey found a median LP fee of 86.33%, so a fill 10% below quote is
+ * not a market moving — it is a pool set up to keep the difference.
+ */
+export const SLIPPAGE_BPS_MAX = 1_000;
+
 export const SETTINGS_DEFAULTS = {
   paperTradingEnabled: true,
   paperStartUsdg: 1000,

--- a/web/src/app/api/settings/route.ts
+++ b/web/src/app/api/settings/route.ts
@@ -17,6 +17,7 @@ import {
   LLM_PROVIDERS,
   SECRET_SETTING_KEYS,
   SETTINGS_DEFAULTS,
+  SLIPPAGE_BPS_MAX,
   STOCK_TOKENS,
   isHostedMode,
   isValidCustomToken,
@@ -149,7 +150,10 @@ export async function GET(req: Request) {
 const KNOWN_SYMBOLS = new Set(STOCK_TOKENS.map((t) => t.symbol));
 const URL_FIELDS = ["bundlerUrl", "rpcMainnet", "rpcTestnet"] as const;
 const NUM_FIELDS: Record<string, [number, number]> = {
-  slippageBps: [1, 5_000],
+  // Imported, never a literal. This entry and the worker's own clamp are two
+  // enforcement points for one rule, and they read 5_000 and 5_000 while the
+  // rule they were meant to express was never written down anywhere.
+  slippageBps: [1, SLIPPAGE_BPS_MAX],
   // 0 is a MEANINGFUL low bound here, not a typo: it is the impact guard's
   // off switch, and the guard's own rejection message tells owners to raise
   // this setting — which was impossible while it was missing from this list.

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { LogoMark } from "@/components/Logo";
-import { MERRYMEN_GATEWAY_ORIGIN, isValidCustomToken, uncoveredBasketSymbols, type CustomToken, type StoredGrant } from "@merrymen/core";
+import { MERRYMEN_GATEWAY_ORIGIN, SLIPPAGE_BPS_MAX, isValidCustomToken, uncoveredBasketSymbols, type CustomToken, type StoredGrant } from "@merrymen/core";
 import type { SettingsView } from "@/app/api/settings/route";
 import type { TelegramStatus } from "@/app/api/telegram/route";
 import SetupChecklist from "./SetupChecklist";
@@ -1218,7 +1218,7 @@ export default function SettingsPage() {
               </select>
             </Field>
             <Field label="max slippage" hint="vs the pre-trade quote.">
-              <input type="number" min={1} max={5000} placeholder={String(d.slippageBps)} value={v("slippageBps")} onChange={set("slippageBps")} />
+              <input type="number" min={1} max={SLIPPAGE_BPS_MAX} placeholder={String(d.slippageBps)} value={v("slippageBps")} onChange={set("slippageBps")} />
               <span className="field-unit">bps</span>
             </Field>
             <Field label="performance fee" hint="On profit above the high-water mark only. Accrual ledger — nothing is collected yet.">

--- a/worker/src/executor.ts
+++ b/worker/src/executor.ts
@@ -17,6 +17,7 @@ import { KERNEL_V3_3, getEntryPoint } from "@zerodev/sdk/constants";
 import { deserializeFlaggedPermissionAccount } from "./session-account";
 import { WALL_POLICY_FLAG } from "../../packages/core/src/index";
 import { userOpGasConfig } from "./gas";
+import { boundGas, type UserOpGas } from "./gas-limits";
 
 export interface Call {
   to: `0x${string}`;
@@ -87,6 +88,18 @@ export class UserOpUnresolved extends Error {
   }
 }
 
+/**
+ * Refused BEFORE broadcast, on gas grounds. Nothing was signed and nothing
+ * spent, so this is a sibling of a policy rejection rather than of a revert —
+ * index.ts must not book it as an on-chain failure.
+ */
+export class GasRefused extends Error {
+  constructor(readonly rule: string, detail: string) {
+    super(`gas refused (${rule}): ${detail}`);
+    this.name = "GasRefused";
+  }
+}
+
 /** How many times the RECEIPT is re-read. Never the send — see execute(). */
 const RECEIPT_ATTEMPTS = 3;
 
@@ -145,9 +158,74 @@ export async function createAgentExecutor(opts: {
   return {
     address: account.address,
     async execute(calls: Call[], hooks?: ExecuteHooks) {
+      const callData = await account.encodeCalls(calls);
+
+      // ── BOUND THE GAS BEFORE SIGNING ANYTHING ───────────────────────
+      // Estimating ourselves is not optional here: viem's prepareUserOperation
+      // fills each field only when it is undefined, and skips the bundler
+      // estimate entirely once all three are set — so the only way to bound a
+      // limit is to have a number of our own first. See gas-limits.ts for why a
+      // floor matters at all (an under-estimated callGasLimit does not bounce;
+      // it OOGs inside the EntryPoint and the account pays anyway).
+      //
+      // TWO estimates of the same calldata. The second is the disagreement
+      // probe, and it is the only signal available for "this number is not
+      // trustworthy" without knowing what the calldata should cost. It costs one
+      // round trip against an operation that is about to spend real money.
+      // Kept outside the closure so a refusal can carry what the bundler said.
+      let estimateError = "";
+      const estimate = async (): Promise<UserOpGas | null> => {
+        try {
+          const g = (await client.estimateUserOperationGas({ callData })) as Partial<UserOpGas>;
+          if (
+            typeof g.callGasLimit !== "bigint" ||
+            typeof g.verificationGasLimit !== "bigint" ||
+            typeof g.preVerificationGas !== "bigint"
+          ) {
+            return null;
+          }
+          return {
+            callGasLimit: g.callGasLimit,
+            verificationGasLimit: g.verificationGasLimit,
+            preVerificationGas: g.preVerificationGas,
+          };
+        } catch (e) {
+          // A refusal to quote, NOT a quote of zero — boundGas is told null and
+          // says so in its own words.
+          //
+          // BUT KEEP THE REASON. Before this file existed, a failing estimate
+          // happened INSIDE prepareUserOperation and its error propagated with
+          // the AA code and revert reason attached — reaching the owner as
+          // `couldn't submit: <the actual cause>`. Moving the estimate one
+          // layer earlier and swallowing it here would collapse AA21 (account
+          // underfunded), AA23 (the wall refused the call), a simulation
+          // revert, a 429 and a bundler outage into one sentence that names
+          // none of them — on the single most likely outcome of a first op.
+          estimateError = e instanceof Error ? e.message : String(e);
+          return null;
+        }
+      };
+      const first = await estimate();
+      // Only probe a second time when the first succeeded: a null first is
+      // already a refusal, and asking again would just be slower.
+      const second = first ? await estimate() : null;
+      const bounded = boundGas(first, second);
+      if (!bounded.ok) {
+        // BEFORE the send, so nothing is spent and no 'submitted' row exists.
+        // This is a pre-broadcast rejection in the same shape as a policy one.
+        throw new GasRefused(
+          bounded.rule,
+          // The bundler's own words first when we have them — they are the
+          // diagnosis; ours is the policy.
+          estimateError ? `${estimateError} — ${bounded.detail}` : bounded.detail,
+        );
+      }
+
       const userOpHash = await client.sendUserOperation({
-        callData: await account.encodeCalls(calls),
-      });
+        callData,
+        // Explicit, so prepareUserOperation uses these instead of estimating.
+        ...bounded.gas,
+      } as never);
       // DURABILITY BEFORE THE WAIT. Between here and the ledger write in
       // index.ts sits a receipt wait, a network price call and a DB round
       // trip; nothing was written durably across any of it, so a SIGTERM from

--- a/worker/src/gas-limits.test.ts
+++ b/worker/src/gas-limits.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { GAS_BOUNDS, boundGas, totalGas, type UserOpGas } from "./gas-limits";
+
+/**
+ * The gap this closes was total: no floor, no ceiling, whatever the bundler
+ * returned was what got signed. These tests are about the two asymmetries that
+ * make the policy the shape it is.
+ */
+
+const est = (call: bigint, ver: bigint, pre: bigint): UserOpGas => ({
+  callGasLimit: call,
+  verificationGasLimit: ver,
+  preVerificationGas: pre,
+});
+const NORMAL = est(180_000n, 90_000n, 55_000n);
+
+test("headroom is applied to every field, not just the call", () => {
+  // verificationGasLimit covers the session-key signature check and the FIRST
+  // op also carries enable data and account deployment — the most expensive
+  // verification this account will ever do, and the one we care most about
+  // not clipping.
+  const v = boundGas(NORMAL, null);
+  assert.ok(v.ok);
+  assert.deepEqual(v.gas, est(360_000n, 180_000n, 110_000n));
+  assert.equal(v.total, 650_000n);
+  assert.equal(totalGas(NORMAL) * 2n, v.total);
+});
+
+test("being generous is FREE and being tight is total — so the bound is one-sided", () => {
+  // A UserOp is charged for gas USED, not gas requested; the EntryPoint refunds
+  // the rest. So a limit that is too high costs a slightly larger prefund, while
+  // one that is too low costs the whole operation AND still charges for it.
+  // Nothing here should ever reduce an estimate.
+  const v = boundGas(NORMAL, null);
+  assert.ok(v.ok);
+  for (const k of ["callGasLimit", "verificationGasLimit", "preVerificationGas"] as const) {
+    assert.ok(v.gas[k] > NORMAL[k], `${k} must never be clamped downward`);
+  }
+});
+
+test("REFUSES rather than clamps when the estimate is absurd", () => {
+  // Clamping would submit an operation we have positively decided is
+  // under-provisioned — the OOG case, on purpose. An approve plus an
+  // exactInputSingle does not approach 3M, so crossing it means this is not the
+  // operation we think it is.
+  const v = boundGas(est(2_000_000n, 500_000n, 100_000n), null);
+  assert.equal(v.ok, false);
+  assert.equal(v.rule, "gas-absurd");
+  assert.match(v.detail, /nothing was spent/i);
+});
+
+test("two estimates far apart is a refusal — the estimator disagreeing with itself", () => {
+  // Vex re-estimated one unchanged calldata across twelve consecutive blocks and
+  // got 804,028-1,660,619, a 2.07x spread. Their four mined-reverted swaps had
+  // burned ~97.3% of their limit with zero logs. 4x is the line past which
+  // neither figure is one to sign against.
+  const v = boundGas(est(100_000n, 50_000n, 25_000n), est(500_000n, 250_000n, 125_000n));
+  assert.equal(v.ok, false);
+  assert.equal(v.rule, "gas-unstable");
+});
+
+test("a normal spread between two estimates is fine, and bounds against the HIGHER", () => {
+  // The cheap one may be the wrong one, and headroom is the direction where
+  // being wrong is free.
+  const lo = est(100_000n, 50_000n, 25_000n);
+  const hi = est(150_000n, 75_000n, 30_000n);
+  const a = boundGas(lo, hi);
+  const b = boundGas(hi, lo);
+  assert.ok(a.ok && b.ok);
+  assert.deepEqual(a.gas, b.gas, "order must not matter");
+  assert.equal(a.total, totalGas(hi) * 2n);
+});
+
+test("instability is judged on the TOTAL, because the fields trade off", () => {
+  // Verification moving into preVerification between estimator versions is a
+  // re-attribution, not instability — and the total is what the account posts a
+  // prefund against. Per-field comparison would refuse this, wrongly.
+  const a = est(200_000n, 150_000n, 20_000n);
+  const b = est(200_000n, 20_000n, 150_000n);
+  assert.equal(totalGas(a), totalGas(b));
+  assert.equal(boundGas(a, b).ok, true);
+});
+
+test("A REFUSAL TO QUOTE IS NOT A QUOTE OF ZERO", () => {
+  // The same conflation delivery.ts refuses to make about a balance. Signing
+  // limits we invented is precisely the OOG this file exists to prevent.
+  const v = boundGas(null, null);
+  assert.equal(v.ok, false);
+  assert.equal(v.rule, "gas-unreadable");
+  assert.match(v.detail, /not a quote of zero/i);
+});
+
+test("a zero or negative field is not an estimate either", () => {
+  // The shape a malformed RPC reply takes, and signing it guarantees the OOG.
+  for (const bad of [est(0n, 90_000n, 55_000n), est(180_000n, -1n, 55_000n), est(180_000n, 90_000n, 0n)]) {
+    const v = boundGas(bad, null);
+    assert.equal(v.ok, false, "must not be treated as a very cheap operation");
+    assert.equal(v.rule, "gas-unreadable");
+  }
+});
+
+test("the disagreement check is SKIPPED, never assumed, when there is one estimate", () => {
+  // A check that did not run must not read as one that passed. With a single
+  // estimate the verdict is ok on the headroom alone — and gas-unstable is
+  // simply unreachable, rather than silently satisfied.
+  const v = boundGas(est(100_000n, 50_000n, 25_000n), null);
+  assert.ok(v.ok);
+  assert.equal(v.total, 350_000n);
+});
+
+test("the bounds are the numbers the comments claim", () => {
+  assert.equal(GAS_BOUNDS.headroomBps, 20_000, "2x");
+  assert.equal(GAS_BOUNDS.disagreementBps, 40_000, "4x");
+  assert.equal(GAS_BOUNDS.absoluteMax, 3_000_000n);
+  assert.ok(GAS_BOUNDS.disagreementBps > GAS_BOUNDS.headroomBps, "a refusal must be looser than the headroom it guards");
+});
+
+test("REGRESSION: a zero field in the SECOND estimate is caught too", () => {
+  // The guard checked `first` only, and boundGas then reassigns
+  // `first = second` whenever the second total is higher. So a zero
+  // callGasLimit riding in on an otherwise-inflated second estimate was signed
+  // unchecked — an op that passes validation and prefund, runs out of gas in
+  // the inner call, and is charged in full. Exactly the indistinguishable OOG
+  // this module exists to prevent, produced by the guard against it.
+  //
+  // These numbers are the reviewer's: 175,000 vs 600,000 is 3.43x, UNDER the 4x
+  // disagreement line, so nothing else would have caught it.
+  const good = est(100_000n, 50_000n, 25_000n);
+  const zeroBearing = est(0n, 400_000n, 200_000n);
+  assert.equal(totalGas(zeroBearing) <= totalGas(good) * 4n, true, "under the disagreement line, as the scenario requires");
+
+  const v = boundGas(good, zeroBearing);
+  assert.equal(v.ok, false, "must not be signed");
+  assert.equal(v.rule, "gas-unreadable");
+  // And in the other order, since which call returns the zero is chance.
+  assert.equal(boundGas(zeroBearing, good).ok, false);
+});
+
+test("REGRESSION: the zero check runs BEFORE the disagreement math", () => {
+  // A zero field also skews the total that the 4x test compares, so validating
+  // first is what makes that comparison trustworthy rather than incidentally
+  // correct. A zero-bearing pair far apart must read as unreadable, not unstable
+  // — the honest answer is "that is not an estimate", not "they disagree".
+  const v = boundGas(est(0n, 10n, 10n), est(900_000n, 900_000n, 900_000n));
+  assert.equal(v.ok, false);
+  assert.equal(v.rule, "gas-unreadable", "not 'gas-unstable'");
+});

--- a/worker/src/gas-limits.ts
+++ b/worker/src/gas-limits.ts
@@ -1,0 +1,190 @@
+/**
+ * GAS LIMITS — the ones this repo never set.
+ *
+ * `grep -r 'callGasLimit|verificationGasLimit|preVerificationGas'` across
+ * worker/, packages/ and web/ returned nothing before this file. `gas.ts`
+ * supplies `estimateFeesPerGas` — a PRICE — and every limit was whatever the
+ * bundler returned, unexamined, with no floor and no ceiling.
+ *
+ * WHY A FLOOR. In ERC-4337 an under-estimated `callGasLimit` does not bounce the
+ * operation. The EntryPoint runs it, the inner call runs out of gas,
+ * `success=false`, and the account is charged the full `actualGasCost` anyway.
+ * merrymen then books that as `reverted` with the reason "reverted on-chain" —
+ * indistinguishable from a slippage revert, so nothing ever learns and the same
+ * trade is retried at tick cadence. You pay, repeatedly, for an estimate that
+ * was slightly wrong about a route that was fine.
+ *
+ * WHY A CEILING, AND WHY IT REFUSES RATHER THAN CLAMPS. An estimate far above
+ * what the calldata should cost means the estimator and reality disagree, and
+ * the safe response to disagreement is not to pick a number — it is to decline.
+ * Clamping would submit an operation we have positively decided is
+ * under-provisioned, which is the OOG case above, on purpose.
+ *
+ * The evidence is Vex's (github.com/Vex-Foundation/Vex, used with its author's
+ * permission): four KyberSwap swaps mined-reverted on Base having burned ~97.3%
+ * of their limit with zero logs, and re-estimating that exact calldata across
+ * twelve consecutive blocks returned 804,028–1,660,619 — a 2.07x spread on an
+ * unchanged input. merrymen's swaps are `exactInputSingle`, the same calldata
+ * shape they measured.
+ *
+ * WHERE IT PLUGS IN. viem's `prepareUserOperation` fills each gas field only
+ * when it is undefined (`request.callGasLimit ?? gas.callGasLimit`), and skips
+ * the bundler estimate entirely once all of them are set. So bounding requires
+ * estimating FIRST and then passing explicit limits — one extra bundler round
+ * trip per operation, which is what Vex pays too.
+ *
+ * Pure and injectable, like delivery.ts: the arithmetic is decided here and
+ * tested without a chain, because a gas policy that can only be exercised by
+ * spending gas is a gas policy nobody exercises.
+ */
+
+/** The three fields an EntryPoint 0.7 operation is bounded by. */
+export interface UserOpGas {
+  callGasLimit: bigint;
+  verificationGasLimit: bigint;
+  preVerificationGas: bigint;
+}
+
+export interface GasBounds {
+  /**
+   * Multiplier applied to the bundler's estimate, in basis points.
+   *
+   * 2x, matching Vex. Not tuning: it is the smallest headroom that survives the
+   * spread they measured on an unchanged input, and the cost of being generous
+   * is nothing. A UserOp is charged for gas USED, not gas requested — the limit
+   * only has to be large enough, and the EntryPoint refunds the difference.
+   * The asymmetry is total: too high costs a slightly larger prefund, too low
+   * costs the entire operation.
+   */
+  headroomBps: number;
+  /**
+   * Refuse when the estimate exceeds this multiple of the FIRST estimate, bps.
+   *
+   * Vex's 4x. This catches the estimator disagreeing with itself, which is the
+   * only signal available without knowing what the calldata "should" cost.
+   */
+  disagreementBps: number;
+  /**
+   * Refuse outright above this total, whatever any estimate says.
+   *
+   * Vex's 3M. An approve plus an `exactInputSingle` does not approach it, so
+   * crossing it means the operation is not the operation we think it is.
+   */
+  absoluteMax: bigint;
+}
+
+export const GAS_BOUNDS: GasBounds = {
+  headroomBps: 20_000, // 2x
+  disagreementBps: 40_000, // 4x
+  absoluteMax: 3_000_000n,
+};
+
+export type GasVerdict =
+  | { ok: true; gas: UserOpGas; total: bigint }
+  /**
+   * Mirrors ImpactVerdict (impact.ts) rather than inventing a shape: a literal
+   * `rule` a caller can branch on, and a `detail` written for the owner.
+   */
+  | { ok: false; rule: "gas-absurd" | "gas-unstable" | "gas-unreadable"; detail: string };
+
+const bps = (v: bigint, n: number) => (v * BigInt(n)) / 10_000n;
+
+/** callGasLimit + verificationGasLimit + preVerificationGas. */
+export function totalGas(g: UserOpGas): bigint {
+  return g.callGasLimit + g.verificationGasLimit + g.preVerificationGas;
+}
+
+/**
+ * Turn one or two estimates into the limits to sign, or a refusal.
+ *
+ * `second` is optional and is the disagreement probe: the SAME calldata,
+ * estimated again. Passing it is what makes `gas-unstable` reachable; without
+ * it the check is skipped rather than assumed to pass, because a check that
+ * did not run must never read as one that did.
+ */
+export function boundGas(
+  first: UserOpGas | null,
+  second: UserOpGas | null,
+  bounds: GasBounds = GAS_BOUNDS,
+): GasVerdict {
+  if (!first) {
+    return {
+      ok: false,
+      rule: "gas-unreadable",
+      detail:
+        "the bundler would not estimate gas for this operation. That is a refusal to quote, not a quote of zero — " +
+        "submitting with limits we invented would risk paying for an operation that runs out of gas inside the EntryPoint.",
+    };
+  }
+  // A zero or negative field is not an estimate. Signing one guarantees the OOG
+  // this file exists to prevent, and it is the shape a malformed RPC reply takes:
+  // viem's formatter turns a bundler's "0x0" into 0n, so the field is PRESENT
+  // and zero rather than absent, and the executor's typeof-bigint guard passes it.
+  //
+  // BOTH estimates, not just the first. This checked `first` only, and then the
+  // comparison below reassigns `first = second` whenever the second total is
+  // higher — so a zero callGasLimit riding in on an otherwise-inflated second
+  // estimate was signed unchecked. That op passes validation and prefund, runs
+  // out of gas in the inner call, and the account is charged in full: precisely
+  // the indistinguishable OOG this file was written to prevent, produced by the
+  // guard against it.
+  //
+  // Checked BEFORE the disagreement test on purpose — a zero field also skews
+  // the total that test compares, so validating first makes that math
+  // trustworthy as well.
+  const badField = (g: UserOpGas): [string, bigint] | null => {
+    for (const [name, v] of Object.entries(g) as [keyof UserOpGas, bigint][]) {
+      if (v <= 0n) return [name, v];
+    }
+    return null;
+  };
+  for (const candidate of second ? [first, second] : [first]) {
+    const bad = badField(candidate);
+    if (bad) {
+      return {
+        ok: false,
+        rule: "gas-unreadable",
+        detail: `the bundler returned ${String(bad[1])} for ${bad[0]}, which is not an estimate. Refusing rather than guessing.`,
+      };
+    }
+  }
+
+  if (second) {
+    // Compared on the TOTAL, not per field. The fields trade off against each
+    // other between estimator versions — verification moving into
+    // preVerification is a re-attribution, not instability — and it is the
+    // total the account pays a prefund against.
+    const a = totalGas(first);
+    const b = totalGas(second);
+    const [lo, hi] = a <= b ? [a, b] : [b, a];
+    if (hi > bps(lo, bounds.disagreementBps)) {
+      return {
+        ok: false,
+        rule: "gas-unstable",
+        detail:
+          `two estimates for the same calldata came back ${lo} and ${hi} — more than ` +
+          `${bounds.disagreementBps / 10_000}x apart. The estimator disagrees with itself, so neither figure is one to sign against.`,
+      };
+    }
+    // Bound against the HIGHER of the two. The cheap one may be the wrong one,
+    // and headroom is the direction where being wrong is free.
+    first = a >= b ? first : second;
+  }
+
+  const gas: UserOpGas = {
+    callGasLimit: bps(first.callGasLimit, bounds.headroomBps),
+    verificationGasLimit: bps(first.verificationGasLimit, bounds.headroomBps),
+    preVerificationGas: bps(first.preVerificationGas, bounds.headroomBps),
+  };
+  const total = totalGas(gas);
+  if (total > bounds.absoluteMax) {
+    return {
+      ok: false,
+      rule: "gas-absurd",
+      detail:
+        `this operation wants ${total} gas, past the ${bounds.absoluteMax} ceiling. An approve plus a swap does not ` +
+        "approach that, so the operation is not the one it is meant to be. Refused before signing — nothing was spent.",
+    };
+  }
+  return { ok: true, gas, total };
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -62,6 +62,7 @@ import { impactBps, judgeImpact, probeAmountIn } from "./impact";
 import { bestRoute, buildTradeCalls, minOutWithSlippage, requoteRoute } from "./venues/uniswap";
 import {
   createAgentExecutor,
+  GasRefused,
   UserOpReverted,
   UserOpUnresolved,
   type AgentExecutor,
@@ -71,6 +72,7 @@ import {
 } from "./executor";
 import { fillFromDeltas, netTokenDeltas, slippageBpsAgainst, type ReceiptLog } from "./fills";
 import { belowFloorBps, checkDelivery, describeDelivery } from "./delivery";
+import { classifyRevert, suppressionKey } from "./revert";
 import { findOrphanOps, resolveSubmittedOps, type RawLog, type ReconcileChain } from "./inflight-reconcile";
 import { bookGaps, composeEquityUsdg } from "./equity";
 import { priceGas, wethPriceToken } from "./gas-price";
@@ -394,6 +396,14 @@ async function main() {
   // did not.
   let settledSpentUsdg = 0n;
   let settledOps = 0;
+  /**
+   * Intents the chain refused for a reason retrying cannot fix, this arm.
+   *
+   * suppressionKey (kind + token pair) -> the RevertClass that closed it, so a
+   * refusal names itself in the tape instead of looking like a strategy that
+   * quietly stopped proposing. Cleared at every arm.
+   */
+  const suppressedIntents = new Map<string, string>();
   let inFlightSpentUsdg = 0n;
   let inFlightOps = 0;
   const spentToday = () => settledSpentUsdg + inFlightSpentUsdg;
@@ -1803,6 +1813,7 @@ async function main() {
     // Nothing is in flight at arm time, so clear any stale reservation with it.
     inFlightSpentUsdg = 0n;
     inFlightOps = 0;
+    suppressedIntents.clear();
     // Recover any op that landed on-chain last run but never reached the ledger,
     // BEFORE seeding — else the seed under-counts the day's spend and loosens the
     // cap. Live only (paper never touches the chain); best-effort (guarded).
@@ -2008,7 +2019,45 @@ async function main() {
     };
   }
 
-  async function processIntent(
+  /**
+   * SERIALIZED. Every caller goes through processIntent, which holds this.
+   *
+   * The hazard is named in this file already, at the budget reservation: "a
+   * chat trade interleaved with a tick could both pass checkPolicy against the
+   * same stale spend figure and overshoot the daily cap by one action". The
+   * reservation narrows that window and does not close it — `state` is
+   * snapshotted, then `await scoutContextFor(intent)` yields the event loop
+   * BEFORE checkPolicy judges it, and reserveBudget is not taken until several
+   * awaits later still.
+   *
+   * And there is a second race the reservation cannot touch at all: two
+   * concurrent sendUserOperation calls read the same account NONCE, so the
+   * bundler drops one. The tick is serialized against itself by runLoop, but
+   * submitChatTrade and submitChatTransfer fire on the Telegram poll's event
+   * loop and can enter mid-tick.
+   *
+   * One lock closes both, because processIntent IS the critical section — from
+   * reading the counters to writing the row. Cheap where it matters: the tick
+   * already awaits its intents in sequence, so it never contends with itself.
+   *
+   * A promise chain rather than a semaphore, and deliberately unbounded: there
+   * is no timeout because a caller that gave up waiting would proceed into
+   * exactly the concurrency this exists to prevent. The chain is kept alive
+   * across a rejection (the .catch below), or one throwing intent would
+   * poison every later one — which is how a lock like this usually fails.
+   */
+  let intentChain: Promise<unknown> = Promise.resolve();
+  function processIntent(intent: TradeIntent, equityUsdg: bigint, equityKnown = true): Promise<void> {
+    const run = intentChain.then(
+      () => processIntentLocked(intent, equityUsdg, equityKnown),
+      () => processIntentLocked(intent, equityUsdg, equityKnown),
+    );
+    // The chain must never hold a rejection, or the next waiter inherits it.
+    intentChain = run.catch(() => {});
+    return run;
+  }
+
+  async function processIntentLocked(
     intent: TradeIntent,
     equityUsdg: bigint,
     equityKnown = true,
@@ -2110,6 +2159,33 @@ async function main() {
     // on the broker rail. Step 5's schema work gives broker rows their own
     // columns — until then the ticker in `target` keeps the tape readable.
     const tradeTarget = intent.kind === "equity-order" ? intent.ticker : intent.target;
+
+    // ── ALREADY REFUSED, FOR A REASON RETRYING CANNOT FIX ────────────────
+    // Read AFTER checkPolicy so the tape's ordering does not change: a trade
+    // that breaks a cap should still say so, because that is the more useful
+    // fact about it. This only catches what the policy would have allowed.
+    //
+    // The row is a rejection carrying the ORIGINAL revert class, not a new
+    // word — so 'why did it stop trading NVDA' has the same answer on the
+    // hundredth tick as on the first, instead of a gap in the tape.
+    const suppressed = suppressedIntents.get(
+      suppressionKey(
+        intent.kind,
+        intent.kind === "swap" ? intent.sellToken : undefined,
+        intent.kind === "swap" ? intent.buyToken : undefined,
+      ),
+    );
+    if (suppressed && verdict.ok) {
+      await recordTrade({
+        agent_id: agentId,
+        kind: intent.kind,
+        target: tradeTarget,
+        amount_usdg: usdgNum(notional),
+        status: "rejected",
+        reject_rule: suppressed,
+      });
+      return;
+    }
 
     if (!verdict.ok) {
       console.log(`[policy] REJECTED ${intent.kind}: ${verdict.rule} — ${verdict.detail}`);
@@ -3011,6 +3087,33 @@ async function main() {
       // pre-broadcast 'submitted' row exactly as it is, and say so. The row
       // already carries the hash, which is what makes it recoverable — by the
       // arm-time reconciler, or by anyone with a block explorer.
+      // ── REFUSED BEFORE BROADCAST, ON GAS ────────────────────────────
+      // Nothing was signed and nothing spent, so this is a sibling of a policy
+      // rejection and not of a revert. Booking it 'reverted' would put a row in
+      // the tape claiming the chain refused a trade the chain never saw, and
+      // the reason it exists — a bundler estimate we would not stake an
+      // operation on — would be flattened into "couldn't submit".
+      //
+      // The rule string is a literal from gas-limits.ts, so it joins the
+      // vocabulary the notifier and the dashboard already read rather than
+      // becoming another free-form sentence in reject_rule.
+      if (e instanceof GasRefused) {
+        releaseBudget();
+        await addEvent(agentId, "warn", `${intent.kind} refused before signing: ${msg.slice(0, 300)}`);
+        await recordTrade({
+          agent_id: agentId,
+          kind: intent.kind,
+          target: tradeTarget,
+          sell_token: intent.kind === "swap" ? intent.sellToken : undefined,
+          buy_token: intent.kind === "swap" ? intent.buyToken : undefined,
+          amount_usdg: usdgNum(notional),
+          status: "rejected",
+          reject_rule: e.rule,
+          ...sim,
+        });
+        return;
+      }
+
       if (e instanceof UserOpUnresolved) {
         lastTradeOutcome = { status: "submitted", rejectRule: "receipt-unresolved" };
         // KEEP THE SPEND COUNTED. `finally` below releases the reservation
@@ -3057,10 +3160,49 @@ async function main() {
       // string test was how the timeout above ended up in the wrong branch, and
       // every future error phrasing would have found the same hole.
       const onChain = e instanceof UserOpReverted;
-      const reason = onChain
-        ? msg.replace(/\s*\(0x[0-9a-fA-F]+\)\s*$/, "").slice(0, 90)
+      // CLASSIFIED, not stored raw. reject_rule used to take ninety characters
+      // of the error text — free-form, unbounded cardinality, in a column every
+      // other producer fills from a small vocabulary. Nothing could read it, so
+      // nothing did, and the same trade was re-proposed on the next tick.
+      //
+      // classifyRevert sees the RAW message: truncation is for storage, and
+      // matching an already-sliced string would make the verdict depend on where
+      // the 90th character happened to fall.
+      const revertVerdict = onChain ? classifyRevert(msg) : null;
+      const reason = revertVerdict
+        ? revertVerdict.rule
         : `couldn't submit: ${msg.replace(/\s+/g, " ").slice(0, 80)}`;
-      await addEvent(agentId, "err", `${intent.kind} ${onChain ? "reverted on-chain" : "failed before submit"}: ${msg.slice(0, 200)}`);
+      // The raw text still reaches the owner — the classification is for the
+      // LOOP, and losing the original would trade one blindness for another.
+      await addEvent(
+        agentId,
+        "err",
+        `${intent.kind} ${onChain ? "reverted on-chain" : "failed before submit"}: ${msg.slice(0, 200)}` +
+          (revertVerdict ? ` — ${revertVerdict.detail}` : ""),
+      );
+      // WHAT MAKES THE TAXONOMY WORTH HAVING. Vex's tells a person which
+      // parameter to change; there is no person here, so a class whose cause
+      // cannot change without something else changing first must stop the intent
+      // being re-proposed every 60 seconds for the rest of the arm.
+      //
+      // Keyed on the token pair, not the intent object: the same buy re-proposed
+      // next tick is a different object with the same meaning. Cleared at arm and
+      // never persisted — a fresh arm has fresh information (a re-signed grant, a
+      // funded account), and a suppression outliving its reason is
+      // indistinguishable from a strategy that simply stopped working.
+      if (revertVerdict && !revertVerdict.retryable) {
+        const key = suppressionKey(
+          intent.kind,
+          intent.kind === "swap" ? intent.sellToken : undefined,
+          intent.kind === "swap" ? intent.buyToken : undefined,
+        );
+        suppressedIntents.set(key, revertVerdict.rule);
+        await addEvent(
+          agentId,
+          "warn",
+          `${intent.kind} ${revertVerdict.rule} — not retried again until the next arm, because retrying cannot fix it`,
+        );
+      }
       await recordTrade({
         agent_id: agentId,
         kind: intent.kind,

--- a/worker/src/intent-serialization.test.ts
+++ b/worker/src/intent-serialization.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+/**
+ * TWO INTENTS MUST NOT BE IN FLIGHT AT ONCE.
+ *
+ * index.ts already named half of this hazard, at the budget reservation: "a
+ * chat trade interleaved with a tick could both pass checkPolicy against the
+ * same stale spend figure and overshoot the daily cap by one action". The
+ * reservation narrows that window and cannot close it — `state` is snapshotted,
+ * `await scoutContextFor(intent)` yields BEFORE checkPolicy judges it, and
+ * reserveBudget comes several awaits later still.
+ *
+ * The second half the reservation cannot touch at all: two concurrent
+ * sendUserOperation calls read the same account nonce and the bundler drops one.
+ *
+ * The lock itself is exercised as a model below, because processIntent needs a
+ * live grant, a chain and a database. The wiring — that the exported name is
+ * the wrapper and not the body — is asserted against the source, which is the
+ * part a refactor would silently undo.
+ */
+
+/** The wrapper as index.ts implements it. */
+function makeSerializer() {
+  let chain: Promise<unknown> = Promise.resolve();
+  return function run<T>(fn: () => Promise<T>): Promise<T> {
+    const p = chain.then(fn, fn);
+    chain = p.catch(() => {});
+    return p;
+  };
+}
+
+test("overlapping calls run one at a time, in order", async () => {
+  const run = makeSerializer();
+  const log: string[] = [];
+  const work = (id: string) => async () => {
+    log.push(`${id}:start`);
+    await new Promise((r) => setTimeout(r, 5));
+    log.push(`${id}:end`);
+  };
+  // Fired together, the way a tick and a Telegram callback would.
+  await Promise.all([run(work("a")), run(work("b")), run(work("c"))]);
+  assert.deepEqual(log, ["a:start", "a:end", "b:start", "b:end", "c:start", "c:end"]);
+});
+
+test("no two bodies overlap even when each yields several times", async () => {
+  // processIntent yields at scoutContextFor, at the quote, at the gas read, at
+  // the receipt wait and at every ledger write. A lock that only covered the
+  // synchronous head would be worthless.
+  const run = makeSerializer();
+  let inside = 0;
+  let maxInside = 0;
+  const work = async () => {
+    inside += 1;
+    maxInside = Math.max(maxInside, inside);
+    for (let i = 0; i < 4; i++) await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 1));
+    inside -= 1;
+  };
+  await Promise.all(Array.from({ length: 8 }, () => run(work)));
+  assert.equal(maxInside, 1, "the whole body is the critical section, not its first await");
+});
+
+test("A THROWN INTENT MUST NOT POISON THE QUEUE", async () => {
+  // The classic way a lock like this fails: the chain keeps the rejection and
+  // every later caller inherits it. processIntent absorbs almost everything,
+  // but "almost" is the word that matters for a lock.
+  const run = makeSerializer();
+  const results: string[] = [];
+  const bad = run(async () => {
+    throw new Error("boom");
+  }).catch(() => results.push("bad rejected"));
+  const good = run(async () => {
+    results.push("good ran");
+  });
+  await Promise.all([bad, good]);
+  assert.deepEqual(results, ["bad rejected", "good ran"]);
+});
+
+test("the rejection still reaches ITS OWN caller, not just the queue", async () => {
+  const run = makeSerializer();
+  await assert.rejects(
+    run(async () => {
+      throw new Error("boom");
+    }),
+    /boom/,
+    "swallowing it here would hide a failure from the code that asked for the work",
+  );
+});
+
+test("index.ts routes every caller through the wrapper", () => {
+  const src = readFileSync("worker/src/index.ts", "utf8");
+  // The body is renamed, so a call to the old name cannot bypass the lock by
+  // accident — it would not compile. This asserts the shape survives a refactor.
+  assert.match(src, /function processIntent\(intent: TradeIntent[\s\S]{0,400}?intentChain\.then\(/, "the exported name must be the wrapper");
+  assert.match(src, /async function processIntentLocked\(/, "and the body must be separately named");
+
+  // Every call site uses the wrapper. processIntentLocked is referenced exactly
+  // twice — the two arms of the .then — and nowhere else.
+  const locked = src.match(/processIntentLocked/g) ?? [];
+  assert.equal(locked.length, 3, "declaration plus the two .then arms; a fourth would be a bypass");
+});
+
+test("no timeout, deliberately", () => {
+  // A caller that gave up waiting would proceed into exactly the concurrency
+  // this prevents. Unbounded waiting is the correct behaviour here, and this
+  // pins it so nobody "fixes" it later.
+  const src = readFileSync("worker/src/index.ts", "utf8");
+  const region = src.slice(src.indexOf("let intentChain"), src.indexOf("async function processIntentLocked"));
+  assert.equal(/setTimeout|race|timeout/i.test(region), false, "a timed-out lock is not a lock");
+});

--- a/worker/src/reject-reason.test.ts
+++ b/worker/src/reject-reason.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+/**
+ * THE PRE-SUBMIT REASON STRING, tested by RUNNING it rather than by a fixture.
+ *
+ * index.ts builds the reason for a failure that never reached the chain as
+ * `couldn't submit: ${msg.replace(/\s+/g, " ").slice(0, 80)}`. A refactor on
+ * this branch dropped one backslash — `/s+/g` — which does not collapse
+ * whitespace, it deletes every letter "s". "insufficient funds for gas" became
+ * "in ufficient fund  for ga ", in the one row that explains why a first real
+ * operation failed, and unsearchable afterwards.
+ *
+ * Nothing caught it: the only nearby test used a hand-written
+ * "couldn't submit: AA21" fixture, which cannot exercise the expression that
+ * produced it. So this extracts the expression FROM THE SOURCE and runs it.
+ * That is uglier than importing a function, and it is the point — the bug was
+ * in a line with no seam, and adding the test without adding the seam is what
+ * keeps the assertion honest about what it covers.
+ */
+
+/** Pull the live expression out of index.ts and evaluate it on a message. */
+function reasonFor(msg: string): string {
+  const src = readFileSync("worker/src/index.ts", "utf8");
+  const line = src.split(/\r?\n/).find((l) => l.includes("couldn't submit: ${msg"));
+  assert.ok(line, "the pre-submit reason line must exist");
+  const expr = line.slice(line.indexOf("`"), line.lastIndexOf("`") + 1);
+  return new Function("msg", `return ${expr};`)(msg) as string;
+}
+
+test("REGRESSION: whitespace is collapsed, and letters are not deleted", () => {
+  // Real bundler text. Under /s+/g every one of these loses its s's.
+  const cases = [
+    "insufficient funds for gas * price + value",
+    "UserOperation reverted during simulation with reason: AA21 didn't pay prefund",
+    "HTTP request failed.\n\nStatus: 429\nURL: https://api.pimlico.io",
+  ];
+  for (const raw of cases) {
+    const out = reasonFor(raw);
+    assert.ok(out.startsWith("couldn't submit: "), out);
+    const body = out.slice("couldn't submit: ".length);
+    // The words a human or a grep would look for must survive intact.
+    for (const word of raw.split(/\s+/).slice(0, 3)) {
+      if (word.length > 3 && body.length >= raw.length) {
+        assert.ok(body.includes(word), `"${word}" must survive — got: ${body}`);
+      }
+    }
+    assert.equal(/\n/.test(body), false, "newlines must be collapsed, not stored raw");
+    assert.equal(/ {2}/.test(body), false, "runs of whitespace must collapse to one space");
+  }
+});
+
+test("REGRESSION: the letter s specifically survives", () => {
+  // The narrowest statement of the bug, so a future reader does not have to
+  // infer it from the cases above.
+  const out = reasonFor("sssss");
+  assert.match(out, /sssss/);
+});
+
+test("the reason is bounded, because reject_rule is not a log", () => {
+  const out = reasonFor("x".repeat(500));
+  assert.ok(out.length <= "couldn't submit: ".length + 80);
+});

--- a/worker/src/revert.test.ts
+++ b/worker/src/revert.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { PATTERN_SOURCES, classifyRevert, suppressionKey } from "./revert";
+
+/**
+ * The value of this table is entirely in what it REFUSES to claim, so most of
+ * these tests are about the default rather than the entries.
+ */
+
+test("the default is unclassified AND retryable — the safe direction", () => {
+  // The dangerous failure here is not a missing entry; it is a wrong one that
+  // suppresses a token because nobody recognised the message. So anything
+  // unfamiliar stays retryable and says out loud that it is unrecognised.
+  const v = classifyRevert("Panic: arithmetic underflow or overflow (0x11)");
+  assert.equal(v.rule, "unclassified");
+  assert.equal(v.retryable, true);
+  assert.match(v.detail, /does not recognise/i);
+});
+
+test("an empty or garbage message does not match anything by accident", () => {
+  for (const m of ["", "0x", "   ", "reverted"]) {
+    assert.equal(classifyRevert(m).rule, "unclassified", `"${m}" must not be classified`);
+  }
+});
+
+test("a slippage revert is transient and stays retryable", () => {
+  // SwapRouter02's own string when amountOut < amountOutMinimum. This repo
+  // builds that floor itself, so seeing it means the floor worked.
+  const v = classifyRevert("reverted on-chain: Too little received (0xabc)");
+  assert.equal(v.rule, "slippage");
+  assert.equal(v.retryable, true);
+});
+
+test("insufficient balance and allowance are NOT retryable — and are different faults", () => {
+  const bal = classifyRevert("ERC20: transfer amount exceeds balance");
+  assert.equal(bal.rule, "insufficient-balance");
+  assert.equal(bal.retryable, false);
+
+  const allow = classifyRevert("ERC20: transfer amount exceeds allowance");
+  assert.equal(allow.rule, "allowance");
+  assert.equal(allow.retryable, false);
+  // The distinction earns its keep in the detail: merrymen batches approve and
+  // swap into ONE operation, so an allowance failure means the batch was built
+  // wrong — a wiring fault, not a market one.
+  assert.match(allow.detail, /wiring fault/i);
+});
+
+test("balance is matched before allowance, since the strings overlap", () => {
+  // "transfer amount exceeds balance" and "...exceeds allowance" share a prefix.
+  // Order in the table is the tiebreak, and getting it wrong would report every
+  // empty account as an approval bug.
+  assert.equal(classifyRevert("ERC20: transfer amount exceeds balance").rule, "insufficient-balance");
+});
+
+test("AA21 is a prefund problem, which no retry fixes", () => {
+  const v = classifyRevert("UserOperation reverted: AA21 didn't pay prefund");
+  assert.equal(v.rule, "prefund");
+  assert.equal(v.retryable, false);
+  assert.match(v.detail, /no paymaster/i);
+});
+
+test("a validation failure is the WALL, and is reported as the wall working", () => {
+  // On this account the validator IS the sealed policy, so AA23/AA24 mean the
+  // grant does not cover what was attempted. Retrying cannot make it succeed.
+  const v = classifyRevert("AA24 signature error");
+  assert.equal(v.rule, "wall-refused");
+  assert.equal(v.retryable, false);
+  assert.match(v.detail, /re-signed/i);
+});
+
+test("classification reads the RAW message, not a truncated one", () => {
+  // index.ts stores 90 characters; matching against that would make the verdict
+  // depend on where the cut landed. A long prefix must not hide the reason.
+  const long = `${"context ".repeat(20)}Too little received`;
+  assert.ok(long.length > 90);
+  assert.equal(classifyRevert(long).rule, "slippage");
+  assert.equal(classifyRevert(long.slice(0, 90)).rule, "unclassified", "which is exactly what truncating would cost");
+});
+
+test("every non-retryable class explains why retrying cannot help", () => {
+  // The rule this table is judged by: a refusal the owner cannot act on is a
+  // refusal they will assume is a bug.
+  for (const m of [
+    "ERC20: transfer amount exceeds balance",
+    "ERC20: transfer amount exceeds allowance",
+    "AA21 didn't pay prefund",
+    "AA24 signature error",
+    "SPL",
+  ]) {
+    const v = classifyRevert(m);
+    assert.equal(v.retryable, false, m);
+    assert.ok(v.detail.length > 60, `${v.rule} needs a real explanation, not a label`);
+  }
+});
+
+test("the suppression key is about MEANING, not object identity", () => {
+  // The same buy re-proposed next tick is a different object. Keying on the
+  // pair is what makes suppression survive that.
+  const a = suppressionKey("swap", "0xAAA", "0xBBB");
+  assert.equal(a, suppressionKey("swap", "0xaaa", "0xbbb"), "case must not create a second key");
+  assert.notEqual(a, suppressionKey("swap", "0xBBB", "0xAAA"), "direction matters — a sell is not the buy");
+  assert.notEqual(a, suppressionKey("transfer", "0xAAA", "0xBBB"), "so does the kind");
+});
+
+/**
+ * FOUR DEFECTS AN ADVERSARIAL REVIEW FOUND IN THIS BRANCH, pinned so they
+ * cannot come back. Every one of them passed the original test suite.
+ */
+
+test("REGRESSION: STF is a balance/allowance failure, NOT slippage", () => {
+  // STF is TransferHelper.safeTransferFrom's revert in v3-periphery — the INPUT
+  // token's transferFrom failing. It was in the slippage entry, ABOVE the
+  // balance and allowance entries, in a first-match-wins table. So on the
+  // Uniswap v3 path (the only live venue) the two classes the whole suppression
+  // mechanism exists for were unreachable, and an account that did not hold the
+  // token was told "the floor doing its job; it is worth retrying" every tick.
+  const v = classifyRevert("execution reverted: STF");
+  assert.equal(v.rule, "insufficient-balance", "not 'slippage'");
+  assert.equal(v.retryable, false, "and retrying it burns gas on a trade that cannot fill");
+  assert.match(v.detail, /safeTransferFrom/);
+});
+
+test("REGRESSION: the real slippage revert still classifies as slippage", () => {
+  // The other half — fixing STF must not lose the case it was standing in for.
+  const v = classifyRevert("execution reverted: Too little received");
+  assert.equal(v.rule, "slippage");
+  assert.equal(v.retryable, true);
+});
+
+test("REGRESSION: three-letter codes are word-bounded and case-sensitive", () => {
+  // /SPL/i matched inside any word containing those letters. A taxonomy that
+  // fires on a substring is worse than one that abstains — it suppresses a
+  // token on a coincidence.
+  for (const innocent of [
+    "reverted: SPLIT_FAILED",
+    "reverted: token STFU has no pool",
+    "the pool at 0xSTFa19b0Cd8 is empty",
+    "reverted: BLOCKED",
+    "stf",
+    "spl",
+  ]) {
+    assert.equal(
+      classifyRevert(innocent).rule,
+      "unclassified",
+      `"${innocent}" must not be classified — it only LOOKS like a code`,
+    );
+  }
+  // And the real ones still match.
+  assert.equal(classifyRevert("execution reverted: SPL").rule, "no-liquidity");
+  assert.equal(classifyRevert("execution reverted: LOK").rule, "no-liquidity");
+  assert.equal(classifyRevert("reverted: EXPIRED").rule, "deadline");
+});
+
+test("REGRESSION: no stray control characters in the pattern sources", () => {
+  // \b written through one escaping layer too few becomes U+0008 BACKSPACE,
+  // which silently matches nothing a revert string contains. It reads as a word
+  // boundary in a diff and behaves as a character class of one control byte.
+  for (const p of PATTERN_SOURCES) {
+    // eslint-disable-next-line no-control-regex
+    assert.equal(/[\u0000-\u001F]/.test(p), false, `pattern ${JSON.stringify(p)} carries a control character`);
+  }
+});

--- a/worker/src/revert.ts
+++ b/worker/src/revert.ts
@@ -1,0 +1,217 @@
+/**
+ * WHAT A REVERT MEANT, so the loop can do something other than repeat itself.
+ *
+ * `index.ts` put ninety characters of the raw error into `reject_rule` and
+ * derived nothing. That is free-form text of unbounded cardinality in a column
+ * every other producer fills from a small vocabulary — and it sat in a headless
+ * loop with a 60-second tick and no human reading it. **A revert you cannot
+ * classify is a revert you repeat.** The 1,242 identical `ops-cap` rejections of
+ * 2026-07-15 are what that looks like from the outside.
+ *
+ * That is also why this is worth more here than in the tool it is borrowed from.
+ * Vex (github.com/Vex-Foundation/Vex, used with its author's permission) maps
+ * revert strings to a taxonomy so a PERSON is told which parameter to change.
+ * merrymen has no person in the loop, so the classification has to feed back
+ * into the next decision itself — see `retryable`.
+ *
+ * THE RULE FOR THIS TABLE, taken from theirs verbatim: **add nothing from
+ * memory.** Every pattern below is either a string this codebase itself emits
+ * (grep the reference beside it) or a documented EntryPoint/Kernel code. A
+ * plausible-looking string that no contract on this chain actually returns is
+ * worse than no entry: it produces confident misclassification of the one
+ * failure someone is trying to understand.
+ *
+ * So the table starts SMALL. `unclassified` is the honest default and is
+ * treated as retryable — it must never become the bucket that quietly suppresses
+ * a token because nobody recognised the message.
+ */
+
+/**
+ * What kind of failure this was, and therefore what the loop should do next.
+ *
+ * Deliberately about the REMEDY rather than the cause: two different reverts
+ * that call for the same response are one class here, because the only consumer
+ * is a decision about whether to try again.
+ */
+export type RevertClass =
+  /** The price moved between the quote and the fill. Genuinely transient. */
+  | "slippage"
+  /** We do not hold what we tried to spend. Retrying cannot fix it. */
+  | "insufficient-balance"
+  /** The router was not approved for the amount. A wiring fault, not a market one. */
+  | "allowance"
+  /** The account could not pay the EntryPoint's prefund. Needs ETH, not a retry. */
+  | "prefund"
+  /** The session key's own policy refused it — the wall, working. */
+  | "wall-refused"
+  /** The route has no liquidity to fill this. Retrying at the same size will not. */
+  | "no-liquidity"
+  /** A deadline passed before inclusion. Transient by construction. */
+  | "deadline"
+  /** We do not recognise it. Retryable, deliberately — see the header. */
+  | "unclassified";
+
+export interface RevertVerdict {
+  rule: RevertClass;
+  /** What the owner reads. One sentence, no jargon the message did not already use. */
+  detail: string;
+  /**
+   * May the same intent be tried again on a later tick?
+   *
+   * FALSE IS THE DANGEROUS ANSWER, so it is only ever returned for a class whose
+   * cause cannot change without something else changing first. Everything else,
+   * including `unclassified`, stays true: suppressing a token because a message
+   * was unfamiliar is how a taxonomy turns into an outage.
+   */
+  retryable: boolean;
+}
+
+/**
+ * The table. Ordered — the first match wins, so the specific sits above the
+ * general.
+ *
+ * Each entry names where its pattern comes from. An entry without a source is
+ * an entry to delete.
+ */
+const PATTERNS: readonly { re: RegExp; rule: RevertClass; retryable: boolean; detail: string }[] = [
+  {
+    // STF is TransferHelper.safeTransferFrom's revert string in v3-periphery,
+    // and it fires when the INPUT token's transferFrom fails — insufficient
+    // balance or insufficient allowance. It is NOT slippage.
+    //
+    // It was in the slippage entry, above the balance and allowance entries,
+    // in a first-match-wins table. So on the Uniswap v3 path — the only live
+    // venue — the two classes this whole suppression mechanism exists for were
+    // unreachable, and an account that simply did not hold the token was told
+    // "this is the floor doing its job; it is worth retrying" every 60 seconds.
+    // That is the 1,242-identical-rejections failure the header warns about,
+    // produced by the thing meant to prevent it.
+    //
+    // It is also exactly what the header's own rule forbids: STF is not a
+    // string the slippage path emits, and it was added from memory. Ordered
+    // ABOVE the generic ERC-20 entries because it is more specific, and the
+    // detail names both causes because the revert genuinely does not say which.
+    re: /\bSTF\b/,
+    rule: "insufficient-balance",
+    retryable: false,
+    detail:
+      "the router could not pull the token this trade meant to sell — TransferHelper.safeTransferFrom reverted, which " +
+      "means either the account does not hold the amount or the approve did not cover it. Retrying cannot change " +
+      "either, so this intent is suppressed for the rest of the arm.",
+  },
+  {
+    // SwapRouter02's ACTUAL slippage revert. Case-sensitive on the router's own
+    // phrasing rather than a loose /slippage/i, which would match any message
+    // that merely mentions the word — including our own.
+    re: /Too little received|Too much requested|amountOutMinimum/,
+    rule: "slippage",
+    retryable: true,
+    detail:
+      "the fill would have come in under the slippage floor this operation was signed with, so the router refused it. " +
+      "The trade did not happen and nothing moved. This is the floor doing its job; it is worth retrying.",
+  },
+  {
+    // ERC-20 conventions (OpenZeppelin's message and the bare form).
+    re: /transfer amount exceeds balance|insufficient balance|ERC20InsufficientBalance/i,
+    rule: "insufficient-balance",
+    retryable: false,
+    detail:
+      "the account does not hold what this operation tried to spend. Retrying cannot change that — the position or the " +
+      "cash has to arrive first, so this intent is suppressed for the rest of the arm rather than repeated every tick.",
+  },
+  {
+    re: /transfer amount exceeds allowance|insufficient allowance|ERC20InsufficientAllowance/i,
+    rule: "allowance",
+    retryable: false,
+    detail:
+      "the router was not approved for this amount. merrymen batches the approve and the swap into one operation, so " +
+      "seeing this means the batch did not carry the approve it should have — a wiring fault, not a market one.",
+  },
+  {
+    // ERC-4337 EntryPoint 0.7 codes: AA21 (no prefund), AA31 (paymaster deposit).
+    // merrymen uses no paymaster, so AA21 is the one that fires.
+    re: /AA21|didn'?t pay prefund|insufficient funds for gas/i,
+    rule: "prefund",
+    retryable: false,
+    detail:
+      "the account could not pay the EntryPoint's gas prefund. It pays its own gas and there is no paymaster, so this " +
+      "needs ETH at the smart account — not a retry.",
+  },
+  {
+    // AA23/AA24 are validation failures. On this account the validator IS the
+    // wall, so a refusal here is a permission the grant does not carry.
+    re: /AA23|AA24|signature error|InvalidSignature|PolicyFailed/i,
+    rule: "wall-refused",
+    retryable: false,
+    detail:
+      "the account contract refused to validate this operation — the session key's sealed policy does not permit it. " +
+      "That is the wall working. It cannot be retried into success; the grant has to be re-signed to cover it.",
+  },
+  {
+    // Uniswap v3 pool, when the swap would move the pool past its tick range.
+    // Word-bounded and case-SENSITIVE. These are three-letter Solidity revert
+    // strings, and /SPL/i would match inside "...SPLIT...", a token symbol, or
+    // a hex address that happens to spell it. A taxonomy that fires on a
+    // substring is worse than one that abstains.
+    re: /\bSPL\b|\bLOK\b|not enough liquidity|insufficient liquidity/,
+    rule: "no-liquidity",
+    retryable: false,
+    detail:
+      "the pool could not fill an order this size. Retrying at the same size will fail the same way; a smaller ticket " +
+      "or a different venue is the only thing that changes it.",
+  },
+  {
+    // SwapRouter02's deadline check, and the deadline this repo passes
+    // (venues/uniswap.ts builds one per trade).
+    // Same discipline: EXPIRED word-bounded and case-sensitive, and the bare
+    // /deadline/i dropped — it matched any message merely mentioning one.
+    re: /Transaction too old|\bEXPIRED\b/,
+    rule: "deadline",
+    retryable: true,
+    detail:
+      "the operation's deadline passed before it was included. Nothing moved, and the next tick builds a fresh one.",
+  },
+];
+
+/**
+ * Classify a revert message.
+ *
+ * Takes the RAW error text, because the caller's truncation is for storage and
+ * this is for meaning — matching against an already-sliced string would make
+ * classification depend on where the 90th character happened to fall.
+ */
+/**
+ * The raw regex sources, for the test that asserts none of them carries a
+ * control character. `` written through one escaping layer too few becomes
+ * U+0008 BACKSPACE — which reads as a word boundary in a diff and matches
+ * nothing a revert string contains. That happened here.
+ */
+export const PATTERN_SOURCES: readonly string[] = PATTERNS.map((p) => p.re.source);
+
+export function classifyRevert(message: string): RevertVerdict {
+  for (const p of PATTERNS) {
+    if (p.re.test(message)) return { rule: p.rule, detail: p.detail, retryable: p.retryable };
+  }
+  return {
+    rule: "unclassified",
+    // Says what it does not know. A sentence claiming more than that is how a
+    // table like this stops being trustworthy.
+    detail:
+      "the chain refused this operation and merrymen does not recognise the reason. It is left retryable, because " +
+      "suppressing a trade on an unfamiliar message would hide the failure rather than explain it. The raw text is in " +
+      "the event log.",
+    retryable: true,
+  };
+}
+
+/**
+ * A key for suppressing one intent after a non-retryable revert.
+ *
+ * Scoped to the token pair rather than the intent: the same buy re-proposed a
+ * tick later is a different object with the same meaning, and it is the meaning
+ * that must not be repeated. Kept out of the class above because WHAT to
+ * suppress is the caller's business — this only says whether to.
+ */
+export function suppressionKey(kind: string, sellToken?: string, buyToken?: string): string {
+  return `${kind}:${(sellToken ?? "").toLowerCase()}->${(buyToken ?? "").toLowerCase()}`;
+}

--- a/worker/src/settings.ts
+++ b/worker/src/settings.ts
@@ -10,6 +10,7 @@ import { chmodSync, readFileSync, writeFileSync } from "node:fs";
 import {
   HOUSE_KEY_FIELDS,
   SETTINGS_DEFAULTS,
+  SLIPPAGE_BPS_MAX,
   STOCK_TOKENS,
   isHostedMode,
   isValidCustomToken,
@@ -272,7 +273,7 @@ export function mergeSettings(
       return v && /^[A-Za-z0-9_-]{1,64}$/.test(v) ? v : d.strategy;
     })(),
     swapVenue: oneOf(file.swapVenue, env.MERRYMEN_SWAP_VENUE, ["uniswap", "rialto"], d.swapVenue),
-    slippageBps: num(file.slippageBps, env.MERRYMEN_SLIPPAGE_BPS, d.slippageBps, 1, 5_000),
+    slippageBps: num(file.slippageBps, env.MERRYMEN_SLIPPAGE_BPS, d.slippageBps, 1, SLIPPAGE_BPS_MAX),
     // Floor of 0 is meaningful here: it turns the guard off. Ceiling of 10_000
     // is 100% impact, past which the number stops meaning anything.
     maxImpactBps: num(file.maxImpactBps, env.MERRYMEN_MAX_IMPACT_BPS, d.maxImpactBps, 0, 10_000),

--- a/worker/src/slippage-ceiling.test.ts
+++ b/worker/src/slippage-ceiling.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { SETTINGS_DEFAULTS, SLIPPAGE_BPS_MAX } from "../../packages/core/src/index";
+import { minOutWithSlippage } from "./venues/uniswap";
+
+/**
+ * THE CEILING IS A PRODUCT POLICY, AND IT HAS TO LIVE IN ONE PLACE.
+ *
+ * It was 5,000 bps — a minOut of half the trade — written as a literal in a web
+ * route's validation table and again in the worker's resolver, where an
+ * out-of-range value SILENTLY fell back to the default rather than being
+ * refused. Two enforcement points for a rule that was never written down, and a
+ * third check (`minOutWithSlippage`) twice as permissive again because its job
+ * is only to stop a negative minOut.
+ *
+ * These tests are about the seams rather than the number: a ceiling that lives
+ * in three literals is one careless edit from being three different ceilings.
+ */
+
+test("the ceiling is low enough that a fill still resembles the quote", () => {
+  assert.equal(SLIPPAGE_BPS_MAX, 1_000);
+  // The number that motivates it: at the old ceiling, minOut was half the quote.
+  assert.equal(minOutWithSlippage(1_000_000n, 5_000), 500_000n);
+  // At this one, a fill can come in 10% light and no further.
+  assert.equal(minOutWithSlippage(1_000_000n, SLIPPAGE_BPS_MAX), 900_000n);
+});
+
+test("the default sits well inside it, so the ceiling is a bound and not a setting", () => {
+  assert.ok(
+    SETTINGS_DEFAULTS.slippageBps < SLIPPAGE_BPS_MAX,
+    "a default at the ceiling would mean the ordinary case is the worst allowed case",
+  );
+  assert.equal(SETTINGS_DEFAULTS.slippageBps, 100);
+});
+
+test("NO OVERRIDE CHANNEL — not an env var, not a setting, not a flag", () => {
+  // The whole point. A ceiling a running agent can raise for itself is not a
+  // ceiling, and every mechanism this repo has for widening a bound is one the
+  // agent's own configuration can reach. So the constant must be referenced,
+  // never read from anywhere.
+  const src = [
+    "packages/core/src/settings.ts",
+    "worker/src/settings.ts",
+    "web/src/app/api/settings/route.ts",
+  ].map((f) => readFileSync(f, "utf8"));
+
+  for (const [i, text] of src.entries()) {
+    const line = text.split(/\r?\n/).find((l) => /SLIPPAGE_BPS_MAX\s*=/.test(l));
+    if (i === 0) {
+      assert.ok(line, "core declares it");
+      assert.match(line, /=\s*1_000;/, "as a literal, with no env fallback");
+    } else {
+      assert.equal(line, undefined, "and nothing else redeclares it");
+    }
+  }
+  // No MERRYMEN_* escape hatch anywhere near it.
+  assert.equal(
+    /MERRYMEN_[A-Z_]*SLIPPAGE[A-Z_]*MAX/.test(src.join("\n")),
+    false,
+    "an env var here would let the deployment out-vote the policy",
+  );
+});
+
+test("both enforcement points import the constant rather than restating it", () => {
+  // The failure this prevents is silent: the web route REJECTS out of range
+  // while the worker FALLS BACK to the default, so two different numbers would
+  // not disagree loudly — a hand-edited settings.json would simply behave
+  // differently from the same value typed into the dashboard.
+  const worker = readFileSync("worker/src/settings.ts", "utf8");
+  const route = readFileSync("web/src/app/api/settings/route.ts", "utf8");
+
+  assert.match(worker, /slippageBps: num\([^)]*SLIPPAGE_BPS_MAX\)/);
+  assert.match(route, /slippageBps: \[1, SLIPPAGE_BPS_MAX\]/);
+  for (const [name, text] of [["worker", worker], ["route", route]] as const) {
+    assert.equal(/slippageBps[^\n]*5_000/.test(text), false, `${name} must not carry the old literal`);
+  }
+});
+
+test("minOutWithSlippage is a sanity check, not the bound — and stays that way", () => {
+  // Its guard is >= 10_000, i.e. it only prevents a zero or negative floor. That
+  // is correct for what it is and must not be mistaken for a policy: a value
+  // between the ceiling and 10,000 is unreachable through configuration, so if
+  // one ever arrives here it came from code, and throwing is right.
+  assert.doesNotThrow(() => minOutWithSlippage(1_000n, 9_999));
+  assert.throws(() => minOutWithSlippage(1_000n, 10_000));
+  assert.throws(() => minOutWithSlippage(1_000n, -1));
+});


### PR DESCRIPTION
Re-targets #15 at `main`. Same commit (`542981f`), nothing new — #15 was based on `fix/first-op-blockers`, that branch merged to `main` first, and #15 then merged into an already-merged branch. So none of Phase 2 ever reached `main`: `gas-limits.ts`, `revert.ts`, the single-flight lock and the slippage ceiling are all absent from production.

This is a branching mistake, not a code change. Verified by dry-run merge into `main`: clean, 1,448 tests passing, typecheck clean.

---

Four gaps where Vex was ahead. Three cost money on routes that were fine; the fourth was a ceiling that was not one.

## Gas-limit headroom

`grep -r 'callGasLimit|verificationGasLimit|preVerificationGas'` across the repo returned **nothing**. `gas.ts` supplied `estimateFeesPerGas` — a *price* — and every limit was whatever the bundler returned, unexamined.

In 4337 an under-estimated `callGasLimit` does not bounce: the EntryPoint runs it, the inner call OOGs, `success=false`, and the account is charged the full `actualGasCost` — which merrymen books as "reverted on-chain", indistinguishable from a slippage revert. So nothing learns and the trade is retried at tick cadence.

New `gas-limits.ts` estimates twice, applies 2× headroom, and **refuses rather than clamps** above 4× disagreement or 3M absolute. Vex's evidence: four swaps mined-reverted having burned ~97.3% of their limit, and the same calldata re-estimated across twelve blocks spanned 2.07×.

## A revert taxonomy the loop acts on

`reject_rule` took ninety raw characters and derived nothing — free-form text of unbounded cardinality, in a headless loop with a 60-second tick.

**This is where merrymen goes past Vex rather than catching up.** Theirs names a remedy for a person; there is no person here, so a non-retryable class suppresses that token pair for the rest of the arm. `unclassified` is the default and stays **retryable** — suppressing on an unfamiliar message is how a taxonomy becomes an outage.

## Single-flight

`index.ts` already named the hazard at the budget reservation and closed half of it: `state` is snapshotted, then `await scoutContextFor` yields **before** `checkPolicy` judges it. Separately, two concurrent `sendUserOperation` calls share one account nonce. `processIntent` is now a wrapper over a promise-chain lock — one mechanism, both races.

## A real slippage ceiling

5,000 bps — a `minOut` of half the trade — in a web route's validation table, duplicated in the worker where an out-of-range value **silently fell back to the default**. Now `SLIPPAGE_BPS_MAX = 1000` in core, imported by both, with no env var or setting that raises it.

---

## Four defects an adversarial review found in the above

All fixed in this commit. **All four passed the original test suite.**

1. **A dropped backslash.** `msg.replace(/s+/g, " ")` deletes every letter `s` rather than collapsing whitespace. `"insufficient funds for gas"` became `"in ufficient fund  for ga "` — in the one row explaining why a first real operation failed. The new test extracts the expression from source and **runs** it, rather than asserting against a hand-written fixture.

2. **`STF` was in the slippage bucket.** It is `TransferHelper.safeTransferFrom` reverting — a balance or allowance failure — and it sat *above* both of those entries in a first-match-wins table. On the v3 path, the only live venue, the two classes the suppression mechanism exists for were **unreachable**. An account that did not hold the token would be told "the floor doing its job; it is worth retrying" every 60 seconds.

3. **Three-letter codes matched loosely.** `/SPL/i` fired on `SPLIT_FAILED`. Now word-bounded and case-sensitive. Writing `\b` through one escaping layer too few had also left literal `U+0008` BACKSPACE bytes in three patterns — invisible in a diff, matching nothing.

4. **The zero-field gas guard checked only the first estimate,** while `boundGas` reassigns to the second when its total is higher. A zero `callGasLimit` 3.43× apart — *under* the disagreement line — would have been signed, passed validation and prefund, and been charged in full.

## Verification

`npm test` 1,448 passing · `npm run typecheck` clean · `npm run build` clean · dry-run merge into `main` conflict-free.

**Unrelated pre-existing flake:** `worker/src/memory/integration.test.ts` fails roughly 1 run in 8, from `2b69b62`. Untouched here, tracked separately.

**Still unproven on-chain.** The gas path assumes ZeroDev's kernel client forwards explicit gas fields to viem's `prepareUserOperation` — read from the installed source, not observed. `merrymen selftest` is what settles it.
