### PR TITLE
Give the hosted product a front door, and stop claiming a TEE we never built

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,16 @@ Anyone can ship a trading agent, and platforms will ship their own. A
 first-party agent is **custodial by construction**: their servers, their keys,
 their discretion — the safety story is a terms-of-service. merrymen inverts it:
 
-- **Your machine.** The agent, its memory, and its ledger live in `~/.merrymen`.
-  There is no server-side anything.
-- **Your keys.** Minted locally, backed up by you, never transmitted.
+- **Your machine, if you self-host.** The agent, its memory and its ledger live
+  in `~/.merrymen`, and there is no server-side anything. Hosted at
+  app.merrymen.dev the worker and the ledger are ours — what does not change is
+  the next line.
+- **Your keys, either way.** Minted in your browser, backed up by you, never
+  transmitted. The hosted server refuses to accept an owner key at all and
+  refuses to boot if one is found at rest, so a database dump of ours cannot
+  move your funds. The honest limit: that key sits in plain text in your
+  browser's local storage, so the trust is in this origin rather than in our
+  servers — not nowhere.
 - **The chain enforces the caps that bound a loss.** The session key may only
   call contracts it names, may only move assets you sealed into it, may not send
   native ETH at all, and dies on schedule — all in the account contract. A

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -13,6 +13,17 @@ const MARQUEE = [
 const GITHUB = "https://github.com/millw14/merrymen";
 
 /**
+ * The hosted product.
+ *
+ * This page described merrymen for months without ever linking to it. The
+ * primary button went to /docs and the quickstart was `npm install -g`, so the
+ * only people who reached app.merrymen.dev were the ones already told the
+ * subdomain — while the hero copy two lines below says "self-host it or run it
+ * hosted", offering exactly one of those.
+ */
+const HOSTED_APP = "https://app.merrymen.dev";
+
+/**
  * The beta testers' room — an open Telegram invite. Anyone with the link joins,
  * which is the point while the band is still being tuned.
  *
@@ -101,10 +112,20 @@ const CAPS: [IconName, string, string][] = [
   ["power", "Kill switch", "One command destroys the grant; the worker stands down next tick. On-chain expiry is the backstop."],
 ];
 
+/*
+  These described the SELF-HOSTED path exclusively — install a package, paste a
+  bundler key — while the button above them now opens the hosted app, where
+  neither step exists. Rewritten for the path the primary CTA actually takes.
+
+  Step 2 deliberately does NOT promise paper trading. It used to say the agent
+  "trades on paper instantly", and hosted cannot do that today: paperActive()
+  requires no executor, and hosted always injects the house bundler key. Put
+  that sentence back when the worker keys paper on capability instead.
+*/
 const STEPS: [string, string, string][] = [
-  ["1", "Install & open it", "One command installs merrymen and opens your dashboard. No accounts, nothing to connect."],
-  ["2", "Create your agent — it trades on paper instantly", "Pick a spending-limit preset and go. Your agent starts trading at real live prices with pretend money, so you watch it work before risking a cent."],
-  ["3", "Add a key to go live", "When you're ready, paste one free key and the same agent trades for real — inside the exact same limits. Steer it from Telegram if you like."],
+  ["1", "Open it and connect a wallet", "No install, nothing to run, no card. Your wallet signs to prove it is you — it never moves anything, and merrymen never sees a private key of yours."],
+  ["2", "Sign the wall", "Choose what your agent may spend and how long its key lives, then sign once. That signature IS the limit: your account contract checks it on every operation, so the agent cannot exceed it even if our software is compromised."],
+  ["3", "Fund it and it trades", "Send it some money and it starts working the market. Change the limits whenever you like — re-signing is free and instant. Steer it from Telegram if you prefer, or take everything back out with your own key."],
 ];
 
 export default function Home() {
@@ -126,11 +147,19 @@ export default function Home() {
             blockchain itself, not by the bot behaving. Name it, chat with it, and steer it from Telegram.
           </p>
           <div className="hero-cta" data-reveal="up" style={{ ["--d" as string]: "170ms" }}>
+            {/* Hosted is the primary path because it is the one with no
+                prerequisites: no install, no node, no machine left running.
+                Docs stay one button away for the people who want to self-host,
+                which the hero copy promises and which is genuinely the better
+                answer for anyone who would rather not trust our frontend. */}
             <span className="mag" data-magnetic>
-              <Link href="/docs" className="btn btn-primary btn-lg has-box">
-                Get started <span className="box"><Icon name="arrow" size={16} /></span>
-              </Link>
+              <a href={HOSTED_APP} className="btn btn-primary btn-lg has-box">
+                Start trading <span className="box"><Icon name="arrow" size={16} /></span>
+              </a>
             </span>
+            <Link href="/docs" className="btn btn-ghost btn-lg">
+              <Icon name="arrow" size={15} /> Self-host it instead
+            </Link>
             {/* Deep-links the CURRENT installer, not the releases page, so a
                 wrong or stale build is never one click away. See the note on
                 WINDOWS_DOWNLOAD above. */}
@@ -524,10 +553,13 @@ npm install -g merrymen && merrymen start`}
           <p data-reveal="up" style={{ ["--d" as string]: "80ms" }}>Free, open source, and yours. Install it, name your merryman, loose the first arrow.</p>
           <div className="hero-cta" data-reveal="up" style={{ marginTop: 30, ["--d" as string]: "150ms" }}>
             <span className="mag" data-magnetic>
-              <Link href="/docs" className="btn btn-primary btn-lg has-box">
-                Read the docs <span className="box"><Icon name="arrow" size={16} /></span>
-              </Link>
+              <a href={HOSTED_APP} className="btn btn-primary btn-lg has-box">
+                Start trading <span className="box"><Icon name="arrow" size={16} /></span>
+              </a>
             </span>
+            <Link href="/docs" className="btn btn-ghost btn-lg">
+              Read the docs
+            </Link>
             <a href={TELEGRAM_BETA} target="_blank" rel="noreferrer" className="btn btn-ghost btn-lg">
               <Icon name="chat" size={15} /> Join the beta
             </a>

--- a/site/components/Nav.tsx
+++ b/site/components/Nav.tsx
@@ -3,6 +3,7 @@ import { Logo } from "./Logo";
 import { Icon } from "./Icon";
 
 const GITHUB = "https://github.com/millw14/merrymen";
+const HOSTED_APP = "https://app.merrymen.dev";
 const X_URL = "https://x.com/MerrymenAI";
 
 function XMark({ size = 15 }: { size?: number }) {
@@ -38,10 +39,12 @@ export function Nav() {
           <a href={GITHUB} target="_blank" rel="noreferrer" className="nav-ghost">
             GitHub
           </a>
+          {/* Points where the hero's primary button points. Two primaries
+              disagreeing about where to start is worse than either choice. */}
           <span className="mag" data-magnetic>
-            <Link href="/docs" className="btn btn-primary has-box">
-              Get started <span className="box"><Icon name="arrow" size={15} /></span>
-            </Link>
+            <a href={HOSTED_APP} className="btn btn-primary has-box">
+              Start trading <span className="box"><Icon name="arrow" size={15} /></span>
+            </a>
           </span>
         </div>
       </div>

--- a/web/src/lib/session.ts
+++ b/web/src/lib/session.ts
@@ -27,10 +27,19 @@
  *     to tell whose account this is, because `owner` is a key minted here and
  *     can never equal the signed-in wallet.
  *
- * TESTNET DEMO CAVEATS (labeled in the UI): both private keys are kept in
- * localStorage so you can inspect and back them up; production owner keys live
- * in a Turnkey TEE and never touch a browser. Whoever holds the owner key
- * controls the funds — the UI forces a backup before funding. Drawdown breaker
+ * WHERE THE KEYS ACTUALLY LIVE, on every deployment including hosted mainnet.
+ *
+ * Both private keys are kept in this browser's localStorage. That is not a
+ * testnet demo caveat — it is the shipped arrangement, and :308 below makes
+ * this key load-bearing for hosted custody and for client-side recovery.
+ * Whoever holds the owner key controls the funds; the UI forces a backup
+ * before funding for exactly that reason.
+ *
+ * This block used to say production owner keys live in a Turnkey TEE and
+ * never touch a browser. No such thing is shipped — no dependency, no code
+ * path, no vendor. README.md is accurate that TEE custody is on the roadmap.
+ * The comment mattered because a TEE is precisely what someone would cite to
+ * argue that server-side custody is already fine here. It is not. Drawdown breaker
  * is worker-enforced until the breaker contract ships (Phase 2).
  */
 

--- a/worker/src/executor.ts
+++ b/worker/src/executor.ts
@@ -6,9 +6,11 @@
  * Needs a bundler:
  *   MERRYMEN_BUNDLER_URL   e.g. Pimlico/Alchemy bundler RPC for chain 46630/4663
  *
- * The serialized grant embeds the session private key for the TESTNET demo
- * (mirrors web/src/lib/session.ts). Production: Turnkey TEE holds the key and
- * this module signs via its API instead of deserializing a local key.
+ * The serialized grant embeds the session private key, on every deployment —
+ * not just a testnet demo (mirrors web/src/lib/session.ts). A TEE that holds
+ * it instead and signs via an API is the roadmap, not the present tense: this
+ * comment used to claim it already worked that way in production, and nothing
+ * of the sort is shipped.
  */
 
 import { http, createPublicClient, type Chain, type Hex } from "viem";


### PR DESCRIPTION
Stage 1 of the onboarding plan. Two unrelated-looking things that are the same thing: the product was hard to find, and some of what it said about itself wasn't true.

## The front door

`grep -rn "app.merrymen.dev" site/` returned **nothing**. The hero CTA went to `/docs`, the nav CTA went to `/docs`, and the quickstart was `npm install -g merrymen`. The only people who ever reached the hosted app were the ones already told the subdomain — while the hero copy two lines below promised *"self-host it or run it hosted"* and offered exactly one of those.

Both primaries now open the hosted app. Docs stay one button away as **"self-host it instead"**, which is genuinely the better answer for anyone who'd rather not trust our frontend. The nav is aligned with the hero, because two primary buttons disagreeing about where to start is worse than either choice alone.

The three-step explainer described the self-hosted path exclusively — install a package, paste a bundler key — neither of which exists on the path the button now takes.

**Step 2 deliberately does not restore the old "it trades on paper instantly" promise.** Hosted cannot do that today: `paperActive()` requires no executor and hosted always injects the house bundler key. That sentence goes back in Stage 2, when the worker keys paper on capability instead.

## The TEE that does not exist

Two comments asserted in the present tense that production owner keys live in a Turnkey TEE and never touch a browser (`web/src/lib/session.ts:30-33`, `worker/src/executor.ts:9-11`). Repo-wide: those two comments, one design-doc reference explicit that it's unbuilt, **no dependency, no code path.** `README.md:191-194` is accurate — "TEE custody is on the roadmap".

This mattered more than a stale comment usually does. A TEE is precisely what someone reaches for to argue that server-side custody is already fine here, and it isn't. Worse: `session.ts` framed the localStorage owner key as a *"TESTNET DEMO CAVEAT"* while `:308` in the same file makes that key load-bearing for **hosted mainnet** custody and for client-side recovery. The caveat is the shipped arrangement.

## The README described a different product

> "The agent, its memory, and its ledger live in `~/.merrymen`. There is no server-side anything."

True self-hosted, false hosted — where the worker and the ledger are ours. What doesn't change is the key: minted in the browser, never transmitted, refused by the server, which refuses to boot if one is found at rest.

Now says both, including the honest limit: that key sits in plain text in browser storage, so the trust is in **this origin** rather than in our servers — not nowhere. Worth stating plainly, because the argument for staying non-custodial is stronger when it's accurate about what it's defending.

## Verification

`npm test` 1,448 passing · typecheck clean · both `web` and `site` build clean.

In a browser: every primary button resolves to `https://app.merrymen.dev`, the rewritten steps render, and nothing overflows at 375px. (The site's reveal animations don't fire in a headless pane — it reports `document.hidden` so rAF never runs — so the end state was forced before screenshotting.)
