### PR TITLE
Make practice mode real, and make a simulated fill look simulated

### DIFF
--- a/web/src/app/api/grants/route.ts
+++ b/web/src/app/api/grants/route.ts
@@ -13,6 +13,7 @@ import { homePaths, merrymenHome } from "@merrymen/home";
 import { createPublicClient, http, parseAbi } from "viem";
 import { CASH, MORPHO, carriesOwnerKey, chainForId, isHostedMode, type StoredGrant } from "@merrymen/core";
 import { requestOrigin, tenantOf, verifyGrantBinding } from "@/lib/auth";
+import { withReadDb } from "@/lib/ledger";
 import { getGrantStore } from "@merrymen/grant-store";
 import { deriveKernelAccountAddress } from "@/lib/derive-account";
 
@@ -246,7 +247,34 @@ export async function GET(req: Request) {
     workerAliveAt = hb.at;
     mode = hb.mode ?? null;
   } catch {
-    // no heartbeat file — worker never ran
+    // no heartbeat file — worker never ran, or (hosted) it beats somewhere
+    // this process cannot see. Fall through to the ledger.
+  }
+
+  // HOSTED READS THE LEDGER, because the file above is in this service's own
+  // MERRYMEN_HOME and the worker writes into its tenant's — different
+  // directories, different containers. Every hosted tenant reported IDLE
+  // regardless of what their agent was doing, which made the LIVE/PAPER chip
+  // decorative exactly where it matters most.
+  //
+  // The file still wins when present: self-hosted it is the same worker on the
+  // same disk, so it is fresher than a mirror that runs on its own clock.
+  if (workerAliveAt === null) {
+    try {
+      const row = await withReadDb(async (db) =>
+        db
+          ? ((await db
+              .prepare("SELECT mode, beat_at FROM agents WHERE smart_account = ?")
+              .get(grant.smartAccount)) as { mode?: string | null; beat_at?: number | null } | undefined)
+          : undefined,
+      );
+      if (row?.beat_at) {
+        workerAliveAt = Number(row.beat_at);
+        mode = (row.mode as AgentStatus["mode"]) ?? null;
+      }
+    } catch {
+      // an unreadable ledger is an unknown mode, not a claim about one
+    }
   }
 
   // Never echo key material to the browser: the serialized session account, the

--- a/web/src/app/app/Console.tsx
+++ b/web/src/app/app/Console.tsx
@@ -648,8 +648,26 @@ function Loaded({ feed, status }: { feed: FeedResponse | null; status: AgentStat
 function TradeRow({ t }: { t: TradeRecord }) {
   const rejected = t.status === "rejected" || t.status === "reverted";
   const isVault = t.kind.includes("vault");
-  const cls = rejected ? "no" : isVault ? "vault" : "ok";
-  const ic = rejected ? "✕" : isVault ? "⛬" : "↑";
+  /*
+    A SIMULATED FILL MUST NOT LOOK LIKE A REAL ONE.
+
+    This fork was rejected / vault / everything-else, and `paper` fell into
+    everything-else — so a pretend fill got the same green class, the same ↑
+    and the same dollar figure as money that actually moved. On a screen whose
+    job is to say what happened, that is the one mistake with no upside.
+
+    It mattered more than it looks: hosted tenants could not reach paper mode
+    at all, so nobody hit it — and the moment paper starts working (it does
+    now), an unfunded or testnet agent begins filling this tape with numbers
+    that read as profit.
+
+    The other two tape surfaces already got this right — TradesPanel.tsx:80-84
+    and BandSection.tsx:175 both render a 📜 chip. Same marker, same gold, so
+    the product speaks with one voice about the same fact.
+  */
+  const paper = t.status === "paper";
+  const cls = rejected ? "no" : isVault ? "vault" : paper ? "sim" : "ok";
+  const ic = rejected ? "✕" : isVault ? "⛬" : paper ? "📜" : "↑";
   const kindLabel: Record<string, string> = {
     swap: "traded",
     "vault-deposit": "parked in the vault",
@@ -674,7 +692,10 @@ function TradeRow({ t }: { t: TradeRecord }) {
         </span>
       </span>
       <span className="amt">
+        {/* The figure is real arithmetic on a pretend fill. Label it where the
+            eye lands, not only in the icon. */}
         {rejected ? "—" : usd(t.amount_usdg)}
+        {paper && <span className="sim-tag">sim</span>}
         <br />
         <span className="t">{timeAgo(t.created_at)}</span>
       </span>

--- a/web/src/app/app/console.css
+++ b/web/src/app/app/console.css
@@ -168,6 +168,19 @@
 .sc-root .trade.ok .ic { background: color-mix(in srgb, var(--mint) 14%, transparent); color: var(--mint); }
 .sc-root .trade.no .ic { background: color-mix(in srgb, var(--rose) 14%, transparent); color: var(--rose); }
 .sc-root .trade.vault .ic { background: color-mix(in srgb, var(--gold) 13%, transparent); color: var(--gold); }
+/*
+  The fourth state this fork always needed. Gold rather than green, because
+  green on this screen means money moved — see TradeRow's comment. Matches
+  .paper-badge / .paper-chip in globals.css, which the self-hosted panels
+  have used for the same fact since before the console existed.
+*/
+.trade.sim .ic { color: var(--gold); }
+.trade.sim .amt { color: var(--gold); }
+.sim-tag {
+  font-size: 8.5px; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--gold); border: 1px solid color-mix(in srgb, var(--gold) 40%, transparent);
+  border-radius: 4px; padding: 0 4px; margin-left: 6px; vertical-align: middle;
+}
 .sc-root .trade .sym { font-weight: 600; font-size: 14px; }
 .sc-root .trade .desc { font-size: 12.5px; color: var(--dim); }
 .sc-root .trade .desc .rule { font-family: var(--mono); color: var(--rose); }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -185,6 +185,7 @@ import {
   setPaperBook,
   setAgentName,
   setAgentHwm,
+  setAgentMode,
   setAgentStatus,
   clearTrenchEntry,
   getTrenchEntry,
@@ -283,9 +284,52 @@ async function main() {
   let watchTokens = watchTokensFor(cfg.basketSymbols, cfg.customTokens);
 
   // ── paper trading plumbing ────────────────────────────────────────────
-  // Paper mode = a grant but no signer: fills simulate at live oracle prices.
+  /**
+   * PAPER IS A CAPABILITY, not the absence of a bundler key.
+   *
+   * This used to read `!active.executor && cfg.paperTradingEnabled` — paper as
+   * the accidental consequence of having nothing to sign with. That worked
+   * self-hosted, where a missing key is the normal starting state, and it broke
+   * completely hosted: the orchestrator injects the house bundler key into every
+   * child, so `active.executor` is never null and NO HOSTED TENANT COULD EVER BE
+   * IN PAPER MODE.
+   *
+   * The result was worse than a missing feature. A hosted tenant on testnet got
+   * a LIVE executor building real swaps against router and token addresses that
+   * exist only on mainnet — neither trading nor simulating, while the console
+   * chip read LIVE and the chain card promised "a simulated book at real live
+   * prices".
+   *
+   * So ask what the agent can actually DO. Three ways to be unable to trade for
+   * real, each independently sufficient:
+   *
+   *  1. No signer. Nothing can be submitted.
+   *  2. Not a tradeable chain. Every token and router merrymen knows is a
+   *     mainnet-4663 deployment, so on any other chain a swap has no venue to
+   *     route through — preflight.ts calls this a hard blocker for the same
+   *     reason.
+   *  3. No capital. A swap with nothing to sell is a refusal, not a trade.
+   *
+   * `paperTradingEnabled` KEEPS ITS MEANING and its `true` default: it is
+   * permission to simulate rather than sit idle, not a request to simulate
+   * instead of trading. Reading it as a mode selector would have been a
+   * catastrophe — it defaults to true, so every funded mainnet agent in the
+   * fleet would have quietly stopped trading and started reporting pretend
+   * fills. Capability decides WHETHER we can trade; this flag only decides what
+   * to do when we cannot.
+   *
+   * UNKNOWN IS NOT UNFUNDED. `lastCashUsdg` is null until the first balance read
+   * of the process, and a null must never push a funded live agent into
+   * simulation — an agent that thinks it is trading while writing pretend fills
+   * is the single worst outcome available here, far worse than an idle tick. So
+   * only a READ zero counts.
+   */
   let lastPrices: Map<string, PriceQuote> = new Map();
-  const paperActive = () => !!active && !active.executor && cfg.paperTradingEnabled;
+  const chainCanTrade = () => !!active && active.grant.chainId === TRADEABLE_CHAIN_ID;
+  const readAsBroke = () => lastCashUsdg !== null && lastCashUsdg === 0n;
+  /** Could this agent put a real order on-chain right now? */
+  const canTradeForReal = () => !!active && !!active.executor && chainCanTrade() && !readAsBroke();
+  const paperActive = () => !!active && !canTradeForReal() && cfg.paperTradingEnabled;
   function paperPriceOf(
     token: `0x${string}`,
   ): { priceUsd: number; stale: boolean; source: PriceQuote["source"] } | null {
@@ -3239,17 +3283,28 @@ async function main() {
   }
 
   function heartbeat(blockNumber: bigint) {
+    const at = Math.floor(Date.now() / 1000);
+    const mode = paperActive() ? "paper" : active?.executor ? "live" : "idle";
     try {
       ensureHome();
-      const mode = paperActive() ? "paper" : active?.executor ? "live" : "idle";
       writeFileSync(
         homePaths.heartbeat(),
-        JSON.stringify({ at: Math.floor(Date.now() / 1000), block: blockNumber.toString(), mode }),
+        JSON.stringify({ at, block: blockNumber.toString(), mode }),
         "utf8",
       );
     } catch {
       // heartbeat is best-effort telemetry — never let it kill the loop
     }
+    // AND ON A CHANNEL THE DASHBOARD CAN ACTUALLY READ. The file above lives in
+    // this worker's own MERRYMEN_HOME; hosted, that is a different directory in
+    // a different container from the web service, which reads its own — so every
+    // hosted tenant showed IDLE no matter what their agent was doing. `agents` is
+    // already mirrored to the shared database, so the row carries it too.
+    //
+    // Both, not one: the file is what the orchestrator's watchdog reads to decide
+    // a child is wedged, and it must keep beating even when the database is
+    // unreachable — otherwise a database blip gets a healthy worker SIGKILLed.
+    if (active) void setAgentMode(active.agentId, mode, at);
   }
 
   async function tick() {
@@ -3321,7 +3376,20 @@ async function main() {
       // goes to missingPrice, which holds the tick — the same fail-closed rule
       // readPositions uses, and for the same reason: valuing a post-split
       // position at the pre-split multiplier books a drawdown that never happened.
-      const mults = await readMultipliers(client, watchTokens);
+      // ON MAINNET, ALWAYS — even when the grant is on testnet.
+      //
+      // Paper already prices from mainnet (mergePoolPrices reads through
+      // mainnetClient), because the token registry only exists there. The
+      // multiplier was the one input still read on the GRANT chain, so a testnet
+      // grant got live mainnet prices and no multiplier at all — and
+      // paperMultiplierOf returns null for an unread token by design, so the
+      // fill path refused every single simulated trade rather than guess a share
+      // count.
+      //
+      // That is why practice mode looked implemented and produced nothing. Both
+      // halves of a paper fill now come from the same chain, which is the only
+      // arrangement where the arithmetic is about one world.
+      const mults = await readMultipliers(mainnetClient(), watchTokens);
       lastMultipliers = mults.multipliers;
       for (const p of paperPositionsOf(bookRow.shares)) {
         if (p.shares <= 0) continue;

--- a/worker/src/ledger-mirror.test.ts
+++ b/worker/src/ledger-mirror.test.ts
@@ -26,7 +26,7 @@ const SRC = [
   "CREATE TABLE trades (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT, kind TEXT, target TEXT, sell_token TEXT, buy_token TEXT, amount_usdg REAL, user_op_hash TEXT, tx_hash TEXT, status TEXT, reject_rule TEXT, created_at INTEGER);",
   "CREATE TABLE equity (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT, eth_wei TEXT, cash_usdg REAL, vault_usdg REAL, equity_usdg REAL, at INTEGER);",
   "CREATE TABLE decisions (id TEXT PRIMARY KEY, agent_id TEXT, source TEXT, strategy TEXT, provider TEXT, model TEXT, symbol TEXT, action TEXT, size_usdg REAL, reason TEXT, dropped_rule TEXT, signals_json TEXT, at INTEGER);",
-  "CREATE TABLE agents (smart_account TEXT PRIMARY KEY, name TEXT, owner_address TEXT, session_key_address TEXT, chain_id INTEGER, caps TEXT, granted_at INTEGER, expires_at INTEGER, status TEXT, created_at INTEGER);",
+  "CREATE TABLE agents (smart_account TEXT PRIMARY KEY, name TEXT, owner_address TEXT, session_key_address TEXT, chain_id INTEGER, caps TEXT, granted_at INTEGER, expires_at INTEGER, status TEXT, created_at INTEGER, mode TEXT, beat_at INTEGER);",
   "CREATE TABLE positions (agent_id TEXT, symbol TEXT, token TEXT, raw_balance TEXT, ui_multiplier TEXT, price_usd REAL, price_stale INTEGER, value_usdg REAL, updated_at INTEGER, PRIMARY KEY (agent_id, symbol));",
 ].join("\n");
 
@@ -42,7 +42,7 @@ const mem = (ddl: string) => {
 const seedChild = () => {
   const raw = new DatabaseSync(":memory:");
   raw.exec(SRC);
-  raw.exec("INSERT INTO agents VALUES ('0xagent','Robin','0xowner','0xsk',4663,'{}',1,2,'armed',3)");
+  raw.exec("INSERT INTO agents VALUES ('0xagent','Robin','0xowner','0xsk',4663,'{}',1,2,'armed',3,'live',99)");
   for (let i = 1; i <= 5; i++) {
     raw.exec(
       `INSERT INTO events (agent_id, level, message, created_at) VALUES ('0xagent','ok','e${i}',${100 + i})`,

--- a/worker/src/ledger-mirror.ts
+++ b/worker/src/ledger-mirror.ts
@@ -199,23 +199,28 @@ export async function mirrorTenant(args: {
     const agents = (await child
       .prepare(
         `SELECT smart_account, name, owner_address, session_key_address, chain_id, caps,
-                granted_at, expires_at, status, created_at FROM agents`,
+                granted_at, expires_at, status, created_at, mode, beat_at FROM agents`,
       )
       .all()) as Record<string, unknown>[];
     if (agents.length) {
       await shared.tx(async (db) => {
         const ins = db.prepare(
           `INSERT INTO agents (smart_account, name, owner_address, session_key_address, chain_id,
-                               caps, granted_at, expires_at, status, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                               caps, granted_at, expires_at, status, created_at, mode, beat_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT (smart_account) DO UPDATE SET
              name = excluded.name, status = excluded.status, caps = excluded.caps,
-             expires_at = excluded.expires_at`,
+             expires_at = excluded.expires_at, mode = excluded.mode,
+             beat_at = excluded.beat_at`,
         );
         for (const a of agents) {
           await ins.run(
             a.smart_account, a.name, a.owner_address, a.session_key_address, a.chain_id,
             a.caps, a.granted_at, a.expires_at, a.status, a.created_at,
+            // Nullable on purpose: an agent that has never beaten has no mode,
+            // and null is the honest value for that. It renders as IDLE, which
+            // is what it is.
+            a.mode ?? null, a.beat_at ?? null,
           );
         }
       });

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -47,6 +47,7 @@ import { acquireTenantLease, type TenantLease } from "./tenant-lease";
 import { isHostedMode, type MerrymenSettings } from "../../packages/core/src/index";
 import { makePgDb, translateSchema } from "./db";
 import { MIRROR_STATE_DDL, mirrorTenant, openChildLedger } from "./ledger-mirror";
+import { applyLedgerSchema } from "./store";
 
 /** How often to re-read the store for tenants added or killed. */
 const RECONCILE_MS = 15_000;
@@ -366,6 +367,13 @@ async function mirrorLedgers(): Promise<void> {
   let shared;
   try {
     shared = await makePgDb(url);
+    // The full ledger schema, not just the cursor table. Nothing else applies
+    // it to the shared database — children have DATABASE_URL stripped, so their
+    // initStore() opens sqlite — which meant every migration that landed in the
+    // child schema silently broke the mirror's INSERT for that table until
+    // somebody ran the DDL by hand. Idempotent, and it runs on the mirror's own
+    // clock, so a fresh deploy heals itself.
+    await applyLedgerSchema(shared);
     await shared.exec(translateSchema(MIRROR_STATE_DDL));
   } catch (e) {
     log(`ledger mirror: shared db unavailable — ${e instanceof Error ? e.message : String(e)}`);

--- a/worker/src/paper-mode.test.ts
+++ b/worker/src/paper-mode.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { TRADEABLE_CHAIN_ID } from "./preflight";
+
+/**
+ * PAPER IS A CAPABILITY, and the predicate that decides it is one line in a
+ * 4,000-line closure with no seam. So this models the rule and pins the source
+ * against it — the model is worthless without the second half, because a model
+ * that has drifted from the code it describes is just a second opinion.
+ *
+ * The bug being pinned: paper used to be `!executor && paperTradingEnabled`,
+ * i.e. the accidental consequence of having nothing to sign with. Hosted always
+ * injects the house bundler key, so no hosted tenant could ever be in paper —
+ * a testnet tenant got a LIVE executor building swaps against mainnet-only
+ * addresses, which is neither trading nor simulating.
+ */
+
+/** The rule as index.ts implements it. */
+function paperActive(a: {
+  armed: boolean;
+  executor: boolean;
+  chainId: number;
+  cashUsdg: bigint | null;
+  paperTradingEnabled: boolean;
+}) {
+  const chainCanTrade = a.armed && a.chainId === TRADEABLE_CHAIN_ID;
+  const readAsBroke = a.cashUsdg !== null && a.cashUsdg === 0n;
+  const canTradeForReal = a.armed && a.executor && chainCanTrade && !readAsBroke;
+  return a.armed && !canTradeForReal && a.paperTradingEnabled;
+}
+
+const base = {
+  armed: true,
+  executor: true,
+  chainId: TRADEABLE_CHAIN_ID,
+  cashUsdg: 100_000_000n,
+  paperTradingEnabled: true,
+};
+
+test("THE REGRESSION THAT MATTERED: a funded mainnet agent trades for real", () => {
+  // paperTradingEnabled defaults to TRUE. Reading it as a mode selector rather
+  // than as permission would have put every funded agent in the fleet into
+  // simulation while its owner believed it was trading — the single worst
+  // outcome available here, and an easy mistake to make while fixing the other
+  // direction.
+  assert.equal(paperActive(base), false);
+});
+
+test("a testnet grant is paper, whatever the bundler key says", () => {
+  // The case that could not previously happen hosted. Every token and router
+  // merrymen knows is a mainnet deployment, so there is no venue to route
+  // through — preflight calls the same fact a hard blocker.
+  assert.equal(paperActive({ ...base, chainId: 46630 }), true);
+  assert.equal(paperActive({ ...base, chainId: 46630, executor: true }), true, "an executor does not make a dead chain tradeable");
+});
+
+test("no signer is still paper — the original case, unbroken", () => {
+  assert.equal(paperActive({ ...base, executor: false }), true);
+});
+
+test("an account read as empty is paper, because a swap needs something to sell", () => {
+  assert.equal(paperActive({ ...base, cashUsdg: 0n }), true);
+});
+
+test("UNKNOWN IS NOT UNFUNDED", () => {
+  // lastCashUsdg is null until the first balance read of the process. If null
+  // counted as broke, every worker would spend its first tick simulating — and
+  // worse, a funded agent whose balance read failed would quietly start writing
+  // pretend fills. Only a READ zero counts.
+  assert.equal(paperActive({ ...base, cashUsdg: null }), false);
+});
+
+test("paperTradingEnabled is permission to simulate, not a request to", () => {
+  // Turning it off does not force a broken agent to trade; it makes it idle.
+  assert.equal(paperActive({ ...base, chainId: 46630, paperTradingEnabled: false }), false);
+  assert.equal(paperActive({ ...base, executor: false, paperTradingEnabled: false }), false);
+  // And it never overrides a working agent in either direction.
+  assert.equal(paperActive({ ...base, paperTradingEnabled: false }), false);
+});
+
+test("nothing is paper when nothing is armed", () => {
+  assert.equal(paperActive({ ...base, armed: false }), false);
+  assert.equal(paperActive({ ...base, armed: false, executor: false }), false);
+});
+
+test("the model above matches the source it claims to describe", () => {
+  // Without this the tests are a second opinion, not a check.
+  const src = readFileSync("worker/src/index.ts", "utf8");
+  assert.match(src, /const chainCanTrade = \(\) =>[^;]*TRADEABLE_CHAIN_ID/);
+  assert.match(src, /const readAsBroke = \(\) => lastCashUsdg !== null && lastCashUsdg === 0n;/);
+  assert.match(src, /const canTradeForReal = \(\)[^;]*!!active\.executor && chainCanTrade\(\) && !readAsBroke\(\)/);
+  assert.match(src, /const paperActive = \(\) => !!active && !canTradeForReal\(\) && cfg\.paperTradingEnabled;/);
+});
+
+test("paper prices AND multipliers both come from mainnet", () => {
+  // They disagreed: prices read through mainnetClient, multipliers through the
+  // grant-chain client. On a testnet grant that meant live prices and no
+  // multiplier — and paperMultiplierOf returns null for an unread token by
+  // design, so the fill path refused every simulated trade. Practice mode
+  // looked implemented and produced nothing.
+  const src = readFileSync("worker/src/index.ts", "utf8");
+  assert.match(src, /readMultipliers\(mainnetClient\(\), watchTokens\)/);
+  assert.equal(
+    /readMultipliers\(client,/.test(src),
+    false,
+    "reading multipliers on the grant chain is what broke testnet paper",
+  );
+});

--- a/worker/src/store.ts
+++ b/worker/src/store.ts
@@ -308,6 +308,22 @@ const SQLITE_ALTERS: string[] = [
     "ALTER TABLE fee_accruals ADD COLUMN epoch INTEGER NOT NULL DEFAULT 1",
     // The epoch this agent is currently writing into.
     "ALTER TABLE agents ADD COLUMN epoch INTEGER NOT NULL DEFAULT 1",
+    // WHAT THE WORKER IS ACTUALLY DOING, on a channel the dashboard can read.
+    //
+    // The heartbeat is a JSON file in the worker's own MERRYMEN_HOME, and the
+    // web service reads homePaths.heartbeat() — its OWN home. Self-hosted those
+    // are the same directory and it works. Hosted they are different
+    // directories in different containers, so the dashboard never saw a
+    // heartbeat at all and every tenant read as IDLE regardless of what their
+    // agent was doing.
+    //
+    // `agents` is already mirrored to the shared Postgres (ledger-mirror.ts),
+    // so putting the mode here makes it visible without inventing a second
+    // transport. The file stays: it is what the orchestrator's watchdog reads
+    // to decide a child is wedged, and that is a different question asked by a
+    // different process.
+    "ALTER TABLE agents ADD COLUMN mode TEXT",
+    "ALTER TABLE agents ADD COLUMN beat_at INTEGER",
     // Measured execution quality: quoted-out vs received-out, in bps, positive
     // when the fill was worse than quoted. The slippage SETTING is one flat 1%
     // constant applied to a $5 trade and a $5,000 one alike; this is the
@@ -382,6 +398,30 @@ function initSqlite(): Db {
   return wrapSqlite(db);
 }
 
+/**
+ * Apply the ledger schema and every migration to a Db that is not ours.
+ *
+ * The mirror writes tenant rows into a SHARED Postgres that no `initStore()`
+ * ever touches: children have DATABASE_URL stripped (orchestrator.ts's
+ * CHILD_SECRET_STRIP) so they open sqlite, and the orchestrator only ever
+ * created `mirror_state`. So every column the mirror copies had to already
+ * exist there by some other means, and a migration that landed in the child
+ * schema would silently break the mirror's INSERT — caught, logged once,
+ * invisible.
+ *
+ * Idempotent: CREATE TABLE IF NOT EXISTS, and each ALTER swallowed the way
+ * initSqlite and initPostgres already swallow it.
+ */
+export async function applyLedgerSchema(db: Db): Promise<void> {
+  await db.exec(SQLITE_SCHEMA);
+  for (const ddl of SQLITE_ALTERS) {
+    try {
+      await db.exec(ddl);
+    } catch {
+      // column already exists — the same no-op the two init paths rely on
+    }
+  }
+}
 /** Open the shared Postgres ledger (hosted, multi-tenant): connect, then run the
  *  same schema + migrations through the async driver, which translates each to the
  *  Postgres dialect. Selected by DATABASE_URL, mirroring the grant store. */
@@ -1022,6 +1062,26 @@ export async function listFlows(agentId: string, limit = 200): Promise<
   }[];
 }
 
+/**
+ * Record what the worker is doing, for surfaces that cannot read its files.
+ *
+ * Best-effort by design: a heartbeat that fails to write must never take the
+ * tick down with it. Called every tick, so it is a plain UPDATE on a primary
+ * key — no journal, no epoch, nothing derived from it.
+ */
+export async function setAgentMode(
+  agentId: string,
+  mode: "paper" | "live" | "idle",
+  atSec: number,
+): Promise<void> {
+  try {
+    await getDb()
+      .prepare("UPDATE agents SET mode = ?, beat_at = ? WHERE smart_account = ?")
+      .run(mode, atSec, agentId);
+  } catch {
+    /* a missing heartbeat is a worse thing to crash over than to lose */
+  }
+}
 /** Record one accrual event and roll it into the agent's running total. */
 export async function addFeeAccrual(
   agentId: string,


### PR DESCRIPTION
Stage 2 of the onboarding plan, and a prerequisite for Stage 3 (defaulting new users to mainnet). Practice mode was advertised, unreachable, and — where it was reachable — indistinguishable from real trading. Four defects, each of which alone made it useless.

## 1. Paper was the absence of a bundler key, not a capability

`paperActive()` was `!active.executor && cfg.paperTradingEnabled`. That works self-hosted, where a missing key is the normal starting state. Hosted, the orchestrator injects the house bundler key into every child, so `active.executor` is never null and **no hosted tenant could ever be in paper mode**. A hosted testnet tenant got a *live* executor building real swaps against router and token addresses that exist only on mainnet — neither trading nor simulating.

Now keyed on what the agent can actually do: no signer, or a chain with no venues, or an account read as empty.

**`paperTradingEnabled` keeps its meaning and its `true` default** — permission to simulate rather than idle, not a request to simulate instead of trade. Reading it as a mode selector would have been a catastrophe in the other direction: every funded mainnet agent in the fleet would have quietly stopped trading and started reporting pretend fills. I nearly shipped exactly that and caught it before committing.

**Unknown is not unfunded.** `lastCashUsdg` is null until the first balance read; a null must never push a funded live agent into simulation. Only a read zero counts.

## 2. Paper could not fill on testnet anyway

Prices come from mainnet (`mergePoolPrices` reads through `mainnetClient`, because the token registry only exists there) while multipliers were read on the **grant** chain. On a testnet grant: live prices, no multiplier — and `paperMultiplierOf` returns null for an unread token by design, so the fill path refused every simulated trade rather than guess a share count.

Practice mode looked implemented and produced nothing. Both halves now come from the same chain.

## 3. A simulated fill looked exactly like a real one

`Console.tsx`'s row fork was rejected / vault / everything-else, and `paper` fell into everything-else — same green class, same `↑`, same dollar figure as money that actually moved.

Nobody hit it because hosted couldn't reach paper mode. The moment paper starts working — it does now — an unfunded or testnet agent begins filling the tape with numbers that read as profit. Now amber with a 📜 and a `sim` tag, reusing the marker `TradesPanel.tsx:80-84` and `BandSection.tsx:175` have used for the same fact all along.

## 4. The dashboard could not see the mode

The heartbeat is a JSON file in the worker's own `MERRYMEN_HOME`, and the web service reads `homePaths.heartbeat()` — its **own** home. Self-hosted those are the same directory. Hosted they're different directories in different containers, so every tenant read as IDLE regardless of what their agent was doing, and the LIVE/PAPER chip was decorative exactly where it matters most.

The mode now also rides on the `agents` row, which is already mirrored to the shared database. **Both, not one:** the file is what the orchestrator's watchdog reads to decide a child is wedged, and it must keep beating even when the database is unreachable — otherwise a database blip gets a healthy worker SIGKILLed.

## A pre-existing hole this uncovered

**Nothing applied the ledger schema to the shared Postgres.** Children have `DATABASE_URL` stripped so their `initStore()` opens sqlite, and the orchestrator only ever created `mirror_state`. So every column the mirror copies had to already exist there by some other means, and any migration landing in the child schema would silently break that table's INSERT — caught, logged once, invisible.

`applyLedgerSchema` now runs on the mirror's own clock, so a fresh deploy heals itself. Without it, this PR's two new columns would have broken the agents mirror on the first pass.

## Verification

`npm test` 1,457 passing · `npm run typecheck` clean · `npm run build` clean.

The re-keyed predicate is modelled in `paper-mode.test.ts` **and pinned against the source it describes** — a model that has drifted from its subject is just a second opinion, so the test greps for the actual expressions.

Row styling checked in a browser: a paper row renders `rgb(251,191,36)` where a landed row is `rgb(233,242,236)`, with a bordered `sim` tag. I could not render a paper row end-to-end from real data without seeding a ledger, so that check is of the stylesheet plus a source assertion on the component branch — not a full render.
