### PR TITLE
Default to a chain that can actually trade

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,13 +189,13 @@ Open `localhost:3100/grant`. There's nothing to connect — merrymen generates a
 fresh account, shows you the owner key to **back up** (lose it and the funds are
 gone), and lets you fund it. **Pick your ground:**
 
-- **testnet · 46630** (default) — the sandbox. Free **gas** from the faucet, and
+- **testnet · 46630** — the sandbox, one click away and no longer the default. Free **gas** from the faucet, and
   the grant, the caps, the policy checks, the live prices and the journal all run
   for real. Two things don't: the token registry is mainnet-only, so **any USDG
   you send to testnet reads as 0 and is never used**, and the trading venues
   aren't deployed there, so swaps simulate and no-route by design. Send gas, not
   capital — paper mode is already trading a simulated book at live prices.
-- **mainnet · 4663** — **real funds.** Real USDG, real Stock Tokens, real
+- **mainnet · 4663** (default) — **real funds.** Real USDG, real Stock Tokens, real
   execution. The page makes you acknowledge it first: keys are generated and
   stored **in plain text on your machine** (TEE custody is on the roadmap), so
   treat the account like a hot wallet — your caps are the seatbelt, start small.

--- a/web/src/app/app/Console.tsx
+++ b/web/src/app/app/Console.tsx
@@ -159,7 +159,12 @@ export default function Console() {
   const connected = !hosted || !!address; // self-hosted's perimeter is localhost
   const exists = !!status?.exists;
   const funded = hasGas(status?.balances?.ethWei);
-  const chainId = status?.grant?.chainId ?? 46630;
+  // NO GRANT YET MEANS ONBOARDING, and this fallback fired precisely then —
+  // stamping "testnet 46630" into the footer and offering a testnet faucet to
+  // someone who has not chosen a chain at all. The grant page now defaults to
+  // mainnet, so the placeholder has to agree with it or the two screens
+  // contradict each other before the user has done anything.
+  const chainId = status?.grant?.chainId ?? 4663;
 
   // The guided first run — ONE step on screen, derived from real state. Connect
   // and create are hard gates; fund is soft (skippable and remembered). When

--- a/web/src/app/grant/page.tsx
+++ b/web/src/app/grant/page.tsx
@@ -238,8 +238,37 @@ function WalletRow({ w }: { w: SavedWallet }) {
 }
 
 export default function GrantPage() {
-  const [caps, setCaps] = useState<GrantCaps>(DEFAULTS);
-  const [chainId, setChainId] = useState<number>(TESTNET);
+  /*
+    THE SCOUT, not the outlaw. Caps are sealed into the signature BEFORE the
+    account has any money in it, so the default cannot be sized to capital
+    nobody has deposited yet. The outlaw's 50/trade x 48 ops is a four-figure
+    ceiling to hand someone who has not yet seen the thing trade once.
+
+    Raising a cap is a free, instant re-sign from the panel further down, so
+    the cost of starting small is one click later. The cost of starting large
+    is not symmetric.
+  */
+  const [caps, setCaps] = useState<GrantCaps>(PRESETS[0]!.caps);
+  /*
+    MAINNET BY DEFAULT, because the old default produced an agent that could
+    never trade. preflight.ts classifies a non-4663 grant as a hard BLOCKER for
+    a reason that is not a policy choice: every token and router address
+    merrymen knows is a mainnet deployment, so on testnet a balance reads as
+    zero and every route is refused. The most common outcome of the old default
+    was a user who did everything right and got an agent that does nothing —
+    and a new user on a faucet asking "how to do leave testnet?", which is what
+    prompted this.
+
+    This only became safe once paper mode was keyed on capability rather than
+    on a missing bundler key: a new mainnet grant with no funds is now genuinely
+    in practice mode, so "watch it work before risking anything" survives the
+    flip instead of being deleted by it. Do not restore this default without
+    also reverting that.
+
+    Practice stays on the menu, one click away, and the real-money
+    acknowledgement is untouched.
+  */
+  const [chainId, setChainId] = useState<number>(MAINNET);
   const [mainnetAck, setMainnetAck] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -874,7 +903,7 @@ export default function GrantPage() {
                     <div className="restore-confirm">
                       {previewFunding && previewFunding.usdg > 0
                         ? "✓ Funds found — restore it below and your band rides again."
-                        : "This account is empty on this chain. Check the chain selector, or try your other owner key."}
+                        : "This account is empty on this chain. Pick the other chain above, or try your other owner key."}
                     </div>
                   </div>
                 )}
@@ -960,14 +989,20 @@ export default function GrantPage() {
                 the worker — the process a compromise owns. Saying so costs a sentence and is the
                 difference between a promise and a claim.
               */}
-              <b>What the chain itself enforces:</b> the per-trade cap, the number of trades, the
-              expiry, and the fact that value can only land back in your own account. Those the
-              agent cannot exceed no matter what happens to the software. The{" "}
-              <b>daily total</b> and the <b>drawdown breaker</b> are counters kept by merrymen on
-              your own machine, so an agent that had been tampered with could ignore them and still
-              reach <b>{caps.perTradeUsdg * caps.maxOpsPerDay} USDG</b> in a day before the chain
-              stopped it. If that is the number that matters to you, lower the per-trade cap or the
-              trades-per-day — not the daily figure.
+              <b>What the chain itself enforces:</b> the per-trade cap, the expiry, and the fact
+              that value can only land back in your own account. Those the agent cannot exceed no
+              matter what happens to the software. The <b>daily total</b>, the{" "}
+              <b>drawdown breaker</b> and the <b>trades-per-day</b> count are counters kept by
+              merrymen, so a tampered-with agent could ignore all three — which is why the lever
+              that bounds a loss is the <b>per-trade cap</b> and a <b>short expiry</b>, not the
+              daily figure.
+              {/*
+                The second copy of this sentence. Trades-per-day was corrected on the
+                loaded-grant panel, in the README, in WallPanel and in Console — and missed
+                here, in the create flow, which is the one place every single user reads it.
+                It rested on ZeroDev's rate-limit policy, whose contract has no bytecode on
+                Robinhood Chain.
+              */}
             </div>
 
             {mode === "create" ? (
@@ -978,18 +1013,38 @@ export default function GrantPage() {
                     : `Create my agent (${isMainnet ? "real money" : "practice"})`)}
               </button>
             ) : (
-              <button
-                className="grant-btn"
-                onClick={() => void onRestore()}
-                disabled={status !== null || createBlocked || !preview}
-              >
-                {status ??
-                  (createBlocked
-                    ? "acknowledge the real-funds warning above first"
-                    : !preview
-                      ? "check your owner key above first"
-                      : `Restore & arm ${short(preview.smartAccount)}`)}
-              </button>
+              <>
+                {/*
+                  RESTORE RE-SIGNS THE LIMITS ON SCREEN, and the old ones are not
+                  recoverable — they lived in the grant blob this browser lost, not
+                  on the chain. So a disk-wipe recovery silently re-signs whatever
+                  the form happens to hold.
+
+                  The default is the scout preset, so the silent direction is now
+                  NARROWER than most people's previous wall, which is the safe way
+                  round. Saying so is still better than relying on that: someone
+                  restoring a warlord wallet should know their caps just shrank,
+                  and someone who had tighter limits should know to set them again.
+                */}
+                <p className="field-lead" style={{ marginTop: 12 }}>
+                  This signs the limits shown above — <b>{caps.perTradeUsdg} USDG</b> a trade,{" "}
+                  <b>{caps.dailyUsdg}</b> a day, key for <b>{caps.expiryDays} days</b>. Your old
+                  limits lived in the key you lost, so nothing can read them back; set them here
+                  if they mattered. Your funds are untouched either way.
+                </p>
+                <button
+                  className="grant-btn"
+                  onClick={() => void onRestore()}
+                  disabled={status !== null || createBlocked || !preview}
+                >
+                  {status ??
+                    (createBlocked
+                      ? "acknowledge the real-funds warning above first"
+                      : !preview
+                        ? "check your owner key above first"
+                        : `Restore & arm ${short(preview.smartAccount)}`)}
+                </button>
+              </>
             )}
             {error && <div className="grant-error mono">{error}</div>}
 

--- a/web/src/lib/session.ts
+++ b/web/src/lib/session.ts
@@ -74,7 +74,8 @@ import {
   WALL_POLICY_FLAG,
   usableExtraTokens,
   chainForId,
-  robinhoodTestnet,
+  robinhoodChain,
+  
   GRANT_V4,
   GRANT_V4_ADAPTER,
   GRANT_PONS_ADAPTER,
@@ -469,7 +470,13 @@ export function listSavedWallets(): SavedWallet[] {
       out.push({
         smartAccount: g.smartAccount as Address,
         owner: g.owner as Address,
-        chainId: typeof g.chainId === "number" ? g.chainId : robinhoodTestnet.id,
+        // A grant with no readable chainId is a corrupt record, not a testnet
+        // one. Defaulting it to the sandbox meant a mainnet wallet with a
+        // damaged field silently became "practice" — funds on one chain, a UI
+        // describing another. Mainnet is both the product default and the
+        // conservative guess: it makes the page say REAL MONEY about a wallet
+        // that may hold some, rather than the reverse.
+        chainId: typeof g.chainId === "number" ? g.chainId : robinhoodChain.id,
         ownerKey: g.demoOwnerPrivateKey,
         current,
       });
@@ -623,7 +630,7 @@ export async function createAgentWallet(o: MintOptions): Promise<MintedGrant> {
     generatePrivateKey(),
     o.caps,
     o.onStatus,
-    o.chainId ?? robinhoodTestnet.id,
+    o.chainId ?? robinhoodChain.id,
     o.extraTokens ?? [],
     o.v4AdapterAddress,
     o.ponsAdapterAddress,
@@ -651,7 +658,7 @@ export async function restoreAgentWallet(
     ownerPrivateKey,
     o.caps,
     o.onStatus,
-    o.chainId ?? robinhoodTestnet.id,
+    o.chainId ?? robinhoodChain.id,
     o.extraTokens ?? [],
     o.v4AdapterAddress,
     o.ponsAdapterAddress,
@@ -713,7 +720,7 @@ export interface OwnerPreview {
  */
 export async function previewOwnerAccount(
   ownerPrivateKey: `0x${string}`,
-  chainId: number = robinhoodTestnet.id,
+  chainId: number = robinhoodChain.id,
 ): Promise<OwnerPreview> {
   const chain = chainForId(chainId);
   const publicClient = createPublicClient({ chain, transport: http() });
@@ -739,7 +746,7 @@ export interface Funding {
   usdg: number;
 }
 
-export async function readFunding(smartAccount: Address, chainId: number = robinhoodTestnet.id): Promise<Funding> {
+export async function readFunding(smartAccount: Address, chainId: number = robinhoodChain.id): Promise<Funding> {
   const publicClient = createPublicClient({ chain: chainForId(chainId), transport: http() });
   const [gasWei, usdgUnits] = await Promise.all([
     publicClient.getBalance({ address: smartAccount }).catch(() => 0n),

--- a/worker/src/mainnet-default.test.ts
+++ b/worker/src/mainnet-default.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { GAS_FLOOR_USDG, preflight, verdict, type PreflightInput } from "./preflight";
+import { SETTINGS_DEFAULTS } from "../../packages/core/src/index";
+
+/**
+ * THE DEFAULT MUST LEAD SOMEWHERE.
+ *
+ * /grant defaulted to testnet 46630, and preflight classifies exactly that as a
+ * hard BLOCKER — not as a policy choice but as a fact: every token and router
+ * address merrymen knows is a mainnet deployment, so on testnet a balance reads
+ * as zero and every route is refused. The most likely outcome of accepting every
+ * default was an agent that could never trade, and a user asking why.
+ */
+
+const NOW = 1_800_000_000;
+const ACCOUNT = "0x00000000000000000000000000000000000000a1";
+
+/** A fresh install that has done nothing but sign and fund. */
+function freshInstall(over: Partial<PreflightInput> = {}): PreflightInput {
+  return {
+    settings: {
+      bundlerApiKey: "pim_x",
+      basketSymbols: SETTINGS_DEFAULTS.basketSymbols as string[],
+      buyPerTickUsdg: SETTINGS_DEFAULTS.buyPerTickUsdg,
+      idleFloorUsdg: SETTINGS_DEFAULTS.idleFloorUsdg,
+    },
+    grant: {
+      smartAccount: ACCOUNT,
+      owner: ACCOUNT,
+      sessionKeyAddress: ACCOUNT,
+      serialized: "x",
+      caps: { perTradeUsdg: 10, dailyUsdg: 50, expiryDays: 7, maxDrawdownPct: 5, maxOpsPerDay: 24 },
+      grantedAt: NOW,
+      expiresAt: NOW + 7 * 86_400,
+      chainId: 4663,
+      grantFeatures: ["tradeable-v2"],
+    } as never,
+    nowSec: NOW,
+    usdg: 100,
+    ethWei: 10n ** 16n,
+    bundlerReachable: true,
+    missingPolicyContracts: [],
+    ...over,
+  };
+}
+
+const ids = (i: PreflightInput, level: string) =>
+  preflight(i).filter((c) => c.level === level).map((c) => c.id);
+
+test("the shipped chain default is one preflight calls tradeable", () => {
+  const src = readFileSync("web/src/app/grant/page.tsx", "utf8");
+  assert.match(src, /useState<number>\(MAINNET\)/, "the grant page must open on mainnet");
+  assert.equal(
+    /useState<number>\(TESTNET\)/.test(src),
+    false,
+    "the old default produced an agent that could never trade",
+  );
+});
+
+test("a fresh mainnet install has NO blockers", () => {
+  const v = verdict(preflight(freshInstall()));
+  assert.equal(v.ready, true, `blockers: ${ids(freshInstall(), "blocker").join(", ")}`);
+});
+
+test("the same install on the OLD default is blocked — which is the point", () => {
+  const onTestnet = freshInstall({ grant: { ...freshInstall().grant!, chainId: 46630 } as never });
+  assert.ok(ids(onTestnet, "blocker").includes("chain"));
+});
+
+test("the caps default is the scout, sized for an account with nothing in it yet", () => {
+  // Caps are sealed BEFORE funding, so the default cannot be sized to capital
+  // nobody has deposited. The outlaw's 50 x 48 is a four-figure ceiling to hand
+  // someone who has not seen the thing trade once.
+  const src = readFileSync("web/src/app/grant/page.tsx", "utf8");
+  assert.match(src, /useState<GrantCaps>\(PRESETS\[0\]!\.caps\)/);
+  assert.equal(/useState<GrantCaps>\(DEFAULTS\)/.test(src), false);
+});
+
+test("nothing in web/ still falls back to testnet when a chain is unknown", () => {
+  // These fired precisely during onboarding — before a chain had been chosen —
+  // so the console stamped "testnet 46630" into its footer and offered a faucet
+  // to someone the grant page was about to put on mainnet.
+  for (const f of ["web/src/lib/session.ts", "web/src/app/app/Console.tsx"]) {
+    const src = readFileSync(f, "utf8");
+    assert.equal(/robinhoodTestnet\.id/.test(src), false, `${f} still defaults to testnet`);
+    assert.equal(/\?\?\s*46630/.test(src), false, `${f} still falls back to 46630`);
+  }
+});
+
+test("practice is still reachable — simplification is not removal", () => {
+  // The owner's decision was to fix paper and KEEP practice, not to delete it.
+  // A user who wants to watch before risking anything must still be able to.
+  const src = readFileSync("web/src/app/grant/page.tsx", "utf8");
+  assert.match(src, /setChainId\(TESTNET\)/, "the practice card must still be clickable");
+  assert.match(src, /Practice \(testnet\)/);
+});
+
+test("the real-money acknowledgement survives the flip", () => {
+  // Mainnet-by-default makes this MORE load-bearing, not less: it is now the
+  // first thing standing between a new user and a real-funds wall. Deleting it
+  // and calling that "one less step" would be trading a warning for a metric.
+  const src = readFileSync("web/src/app/grant/page.tsx", "utf8");
+  assert.match(src, /const createBlocked = isMainnet && !mainnetAck;/);
+  assert.match(src, /acknowledge the real-funds warning above first/);
+});
+
+test("GAS_FLOOR_USDG is still the floor Stage 4 has to clear", () => {
+  // Not fixed here — recorded so the next stage has a failing expectation to
+  // aim at rather than a paragraph to remember.
+  const legs = (SETTINGS_DEFAULTS.basketSymbols as string[]).length;
+  const perLeg = SETTINGS_DEFAULTS.buyPerTickUsdg / legs;
+  assert.ok(perLeg < GAS_FLOOR_USDG, "if this ever passes, delete this test and the Stage 4 item");
+});


### PR DESCRIPTION
Stage 3. Depends on #19 (already merged) — do not revert that without reverting this.

## The default produced an agent that could never trade

`/grant` opened on testnet 46630, and `preflight.ts` classifies exactly that as a hard **blocker**. Not a policy choice — a fact: every token and router address merrymen knows is a mainnet deployment, so on testnet a balance reads as zero and every route is refused.

So the most likely outcome of accepting every default was an agent that does nothing, and a user asking why. One did, in as many words: *"how to do leave testnet? still understanding UI"*.

This only became safe once #19 keyed paper mode on capability rather than on a missing bundler key. **A new mainnet grant with no funds is now genuinely in practice mode**, so "watch it work before risking anything" survives the flip instead of being deleted by it.

## Caps default to the scout, not the outlaw

Caps are sealed into the signature **before** the account holds anything, so the default cannot be sized to capital nobody has deposited. The outlaw's 50/trade × 48 ops is a four-figure ceiling to hand someone who hasn't seen the thing trade once.

Raising a cap is a free, instant re-sign from the panel further down. The cost of starting small is one click later; the cost of starting large isn't symmetric.

## The acknowledgement stays

Mainnet-by-default makes it **more** load-bearing, not less — it's now the first thing between a new user and a real-funds wall. Deleting it and calling that "one less step" would be trading a warning for a metric.

## The latent fallbacks, in the same change-set

Leaving these makes two screens contradict each other before the user has done anything.

- `Console.tsx`'s `?? 46630` fires precisely when there's **no grant** — i.e. during onboarding — stamping "testnet 46630" into the footer and offering a testnet faucet to someone the grant page just put on mainnet.
- `session.ts` had four more. A grant with an unreadable `chainId` is a **corrupt** record, not a testnet one, and defaulting it to the sandbox made a mainnet wallet with a damaged field silently read as practice: funds on one chain, a UI describing another.

## Restore now says what it signs

It re-signs the caps **on screen**, and the old ones aren't recoverable — they lived in the grant blob the browser lost, not on the chain. So a disk-wipe recovery silently re-signs whatever the form holds.

The new default makes that direction *narrower* than most people's previous wall, which is the safe way round. But relying on that isn't the same as saying it, so the panel now prints the three numbers it's about to seal.

## And a second copy of a claim I'd already corrected

> "What the chain itself enforces: the per-trade cap, **the number of trades**, the expiry…"

Fixed in the README, `WallPanel`, `Console` and the loaded-grant panel — and missed here, in the **create flow**, which is the one place every single user reads it. Trades-per-day rested on ZeroDev's rate-limit policy, whose contract has no bytecode on this chain.

## Verification

`npm test` 1,465 passing · typecheck clean · build clean.

In a browser as a genuinely new user (storage cleared): mainnet selected, caps `10 / 50 / 7d / 24 / 5%`, practice still one click away, and the create button **disabled** reading "acknowledge the real-funds warning above first" until the box is ticked — then "Create my agent (real money)".

One test deliberately asserts a **failing** condition: `GAS_FLOOR_USDG` vs the shipped `buyPerTickUsdg`. That's Stage 4's job, and it's better as an executable expectation than a paragraph someone has to remember.
