### PR TITLE
Hotfix: removing the rate-limit policy bricked every grant that still had one

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -74,6 +74,7 @@ import { fillFromDeltas, netTokenDeltas, slippageBpsAgainst, type ReceiptLog } f
 import { belowFloorBps, checkDelivery, describeDelivery } from "./delivery";
 import { classifyRevert, suppressionKey } from "./revert";
 import { findOrphanOps, resolveSubmittedOps, type RawLog, type ReconcileChain } from "./inflight-reconcile";
+import { grantHasDeadRateLimit } from "./session-account";
 import { bookGaps, composeEquityUsdg } from "./equity";
 import { priceGas, wethPriceToken } from "./gas-price";
 import { createPaperOrderExecutor, type OrderExecutor } from "./executor-order";
@@ -1746,6 +1747,27 @@ async function main() {
     // do is let them believe a live trade is one funding away when it is not.
     // preflight.ts makes the same finding a BLOCKER, which is the right place
     // for a refusal — it is the command whose whole job is to judge.
+    // A GRANT SIGNED BEFORE THE WALL DROPPED THE RATE-LIMIT POLICY.
+    //
+    // It arms, it prices, it runs in practice — and it can never land a
+    // UserOperation, because that policy points at an address with no bytecode
+    // on this chain and validation has nothing to call. A signature is frozen,
+    // so no deploy fixes it; only the owner re-signing does.
+    //
+    // Said once per arm, as an err, because the alternative is an owner
+    // watching every trade fail with a validation error that names nothing.
+    if (grantHasDeadRateLimit(grant.serialized)) {
+      console.log(`[worker] grant predates the rate-limit removal — cannot transact until re-signed`);
+      await addEvent(
+        agentId,
+        "err",
+        "this key was signed before a wall fix and CANNOT trade: it carries a rate-limit policy whose " +
+          "contract has no code on this chain, so every operation fails validation. Re-signing is free " +
+          "and instant — open the wallet page and use 're-sign this key'. Your funds are untouched, " +
+          "and practice mode still works meanwhile.",
+      );
+    }
+
     const missingPolicyContracts: string[] = [];
     for (const c of WALL_POLICY_CONTRACTS) {
       const code = await client.getCode({ address: c.address }).catch(() => undefined);

--- a/worker/src/session-account.test.ts
+++ b/worker/src/session-account.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import { createPublicClient, decodeAbiParameters, http } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { PolicyFlags, toPermissionValidator } from "@zerodev/permissions";
 import { toECDSASigner } from "@zerodev/permissions/signers";
-import { toTimestampPolicy } from "@zerodev/permissions/policies";
+import { toRateLimitPolicy, toTimestampPolicy } from "@zerodev/permissions/policies";
 import { getEntryPoint } from "@zerodev/sdk/constants";
 import { KERNEL_V3_3 } from "@zerodev/sdk/constants";
 import { robinhoodChain, WALL_POLICY_FLAG } from "../../packages/core/src/index";
@@ -155,4 +156,84 @@ test("WALL_POLICY_FLAG is the flag the worker passes, not merely a constant", as
     false,
     "and must never call the flag-dropping one",
   );
+});
+
+/**
+ * THE OUTAGE THIS FILE CAUSED, pinned so it cannot recur.
+ *
+ * policyFromParams knew only the two policy kinds the NEW wall emits. But a
+ * grant is a frozen signature: every key signed before the rate-limit policy
+ * was dropped still carries one. So the default threw, syncGrant failed on
+ * every tick, and TEN hosted tenants sat in a crash loop unable to arm —
+ * discovered in production logs, not by any test here.
+ *
+ * The lesson is narrow and worth stating exactly: removing a policy from the
+ * wall means ADDING it here, in the same change. This file must understand
+ * every kind merrymen has ever sealed, not every kind it seals today.
+ */
+test("REGRESSION: a legacy rate-limit policy still rebuilds", async () => {
+  const key = generatePrivateKey();
+  const signer = await toECDSASigner({ signer: privateKeyToAccount(key) });
+  const legacy = await toPermissionValidator(client, {
+    signer,
+    policies: [
+      toTimestampPolicy({ validAfter: NOW, validUntil: NOW + 86_400 }),
+      // What every pre-2026-08-30 grant carries.
+      toRateLimitPolicy({ count: 48, interval: 86_400 }),
+    ],
+    entryPoint,
+    kernelVersion: KERNEL_V3_3,
+    flag: WALL_POLICY_FLAG,
+  } as never);
+
+  // The rebuild must reproduce it byte for byte, or the permission id changes
+  // and the account is dead. Omitting the policy is not a lighter failure than
+  // throwing — it is the same failure with a worse error message.
+  const rebuilt = await toPermissionValidator(client, {
+    signer,
+    policies: [
+      toTimestampPolicy({ validAfter: NOW, validUntil: NOW + 86_400 }),
+      toRateLimitPolicy({ count: 48, interval: 86_400 }),
+    ],
+    entryPoint,
+    kernelVersion: KERNEL_V3_3,
+    flag: WALL_POLICY_FLAG,
+  } as never);
+  assert.equal(rebuilt.getIdentifier(), legacy.getIdentifier());
+  assert.equal(await rebuilt.getEnableData(), await legacy.getEnableData());
+
+  // And dropping it really would break the grant — the reason rebuilding is
+  // mandatory rather than a courtesy.
+  const dropped = await toPermissionValidator(client, {
+    signer,
+    policies: [toTimestampPolicy({ validAfter: NOW, validUntil: NOW + 86_400 })],
+    entryPoint,
+    kernelVersion: KERNEL_V3_3,
+    flag: WALL_POLICY_FLAG,
+  } as never);
+  assert.notEqual(dropped.getIdentifier(), legacy.getIdentifier(), "a dropped policy is a different key");
+});
+
+test("every policy kind the wall has EVER emitted is handled", () => {
+  // Read from source rather than exercised, because policyFromParams is not
+  // exported — and the thing that broke was a missing switch case, which a
+  // source assertion catches exactly.
+  const src = readFileSync("worker/src/session-account.ts", "utf8");
+  for (const kind of ["call", "timestamp", "rate-limit"]) {
+    assert.match(src, new RegExp(`case "${kind}":`), `policyFromParams must handle '${kind}'`);
+  }
+  // The default still throws, and should. An unknown policy IS a bound we would
+  // be dropping; the fix was never to stop refusing.
+  assert.match(src, /refusing to arm rather than dropping it/);
+});
+
+test("a stale grant is DETECTED, so its owner is told rather than left guessing", () => {
+  // Rebuilding lets it arm. It still cannot transact — the policy points at an
+  // address with no code — so the owner needs words, not a silent loop of
+  // validation failures.
+  const src = readFileSync("worker/src/session-account.ts", "utf8");
+  assert.match(src, /export function grantHasDeadRateLimit/);
+  const idx = readFileSync("worker/src/index.ts", "utf8");
+  assert.match(idx, /grantHasDeadRateLimit\(grant\.serialized\)/);
+  assert.match(idx, /Re-signing is free/);
 });

--- a/worker/src/session-account.ts
+++ b/worker/src/session-account.ts
@@ -61,7 +61,7 @@ import { privateKeyToAccount } from "viem/accounts";
 import type { Hex } from "viem";
 import { decodeParamsFromInitCode, toPermissionValidator } from "@zerodev/permissions";
 import { toECDSASigner } from "@zerodev/permissions/signers";
-import { toCallPolicy, toTimestampPolicy } from "@zerodev/permissions/policies";
+import { toCallPolicy, toRateLimitPolicy, toTimestampPolicy } from "@zerodev/permissions/policies";
 import { createKernelAccount } from "@zerodev/sdk";
 import { toKernelPluginManager } from "@zerodev/sdk/accounts";
 import { KERNEL_V3_3 } from "@zerodev/sdk/constants";
@@ -100,12 +100,29 @@ function decodeParams(serialized: string): SerializedParams {
  * One serialized policy → a live Policy. A trimmed `createPolicyFromParams`
  * (deserializePermissionAccount.ts:100-117), which is not exported.
  *
- * Only the two kinds merrymen actually seals. The default THROWS rather than
- * skipping: a policy we cannot rebuild is a bound we would silently drop, and
- * dropping a bound is the failure this whole file is about. Anything else — a
- * gas policy, a sudo policy, the rate-limit policy this repo no longer
- * installs — means a grant we do not understand, and refusing to arm is the
- * only honest response to that.
+ * EVERY KIND MERRYMEN HAS EVER SEALED, not every kind it seals today. That
+ * distinction took the fleet down.
+ *
+ * The wall stopped installing `rate-limit` when its contract turned out to have
+ * no bytecode on this chain — but a grant is a frozen signature, so every key
+ * signed before that still carries one. This function only knew about the two
+ * kinds the NEW wall emits, so the default threw, and `syncGrant` failed on
+ * every tick for every pre-existing tenant: ten agents in a crash loop, none
+ * able to arm, until this shipped.
+ *
+ * Rebuilding it is not optional and not a compromise. The policies are hashed
+ * into the permission id and concatenated into the enable data the owner
+ * signed; omitting one produces a different id, which the check below would
+ * refuse anyway. To reconstruct what was signed you must reconstruct all of it.
+ *
+ * Doing so does NOT make an old grant able to trade — it still points at an
+ * address with no code, which is why the wall dropped it. What it does is let
+ * that agent arm, show its balances, run in practice mode, and be TOLD to
+ * re-sign, instead of dying silently in a loop its owner cannot see.
+ *
+ * The default still throws, and should: an unknown policy really is a bound we
+ * would be dropping. The lesson is narrower than "never throw" — it is that
+ * removing a policy from the wall means adding it here, in the same change.
  */
 async function policyFromParams(policy: { policyParams: { type: string } }) {
   switch (policy.policyParams.type) {
@@ -113,10 +130,31 @@ async function policyFromParams(policy: { policyParams: { type: string } }) {
       return toCallPolicy(policy.policyParams as never);
     case "timestamp":
       return toTimestampPolicy(policy.policyParams as never);
+    case "rate-limit":
+      // Legacy only. Nothing signs one any more; see wall.ts.
+      return toRateLimitPolicy(policy.policyParams as never);
     default:
       throw new Error(
         `this grant carries a '${policy.policyParams.type}' policy that merrymen cannot rebuild — refusing to arm rather than dropping it`,
       );
+  }
+}
+
+/**
+ * Does this serialized grant carry the dead rate-limit policy?
+ *
+ * Such a grant arms fine and can never land a UserOperation: the policy points
+ * at an address with no bytecode on this chain, so validation has nothing to
+ * call. The owner needs to re-sign, and needs to be told so in words rather
+ * than by watching every trade fail.
+ */
+export function grantHasDeadRateLimit(serialized: string): boolean {
+  try {
+    return (decodeParams(serialized).permissionParams.policies ?? []).some(
+      (p) => p.policyParams.type === "rate-limit",
+    );
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
**Production hotfix.** Ten hosted tenants are in a crash loop right now, none able to arm:

```
[tick] Error: this grant carries a 'rate-limit' policy that merrymen cannot
rebuild — refusing to arm rather than dropping it
  at policyFromParams (worker/src/session-account.ts:117)
  at deserializeFlaggedPermissionAccount → createAgentExecutor → syncGrant
```

## What I did wrong

Two changes, each correct alone:

1. The wall stopped installing `toRateLimitPolicy` (#14) because `eth_getCode` showed its contract has no bytecode on this chain.
2. `session-account.ts` rebuilds a grant from its serialized params, and I wrote it to handle only the kinds the **new** wall emits.

So the moment the wall stopped emitting one, every key still carrying it stopped deserializing.

**A grant is a frozen signature.** That is the entire point of the wall, and it's exactly what I failed to apply to my own code: changing what we sign does not change what was signed. This file must understand every policy kind merrymen has **ever** sealed, not every kind it seals today.

The default still throws, and should — an unknown policy really is a bound we'd be dropping. The lesson is narrower than "don't throw": **removing a policy from the wall means adding it here, in the same change.**

## Rebuilding it is mandatory, not a courtesy

Policies are hashed into the permission id and concatenated into the enable data the owner signed. Omitting one produces a different id — which the permission-id check would refuse anyway. The new test proves it: a validator built without the policy has a different identifier from one built with it.

## What this fixes, and what it doesn't

Those agents **arm again** — they price, show balances, and run in practice mode.

They still **cannot land a UserOperation**: the policy points at an address with no code, so validation has nothing to call. Only the owner re-signing fixes that, and no deploy can.

So the arm path now **detects** a stale grant and says so once, as an `err`. The alternative is an owner watching every trade fail with a validation error that names nothing — which is the exact failure mode this whole week has been about.

## Why no test caught it

Every fixture builds a grant with **today's** wall, so nothing in the suite carries a policy today's wall no longer emits. It was found in production logs. The new tests construct such a grant deliberately, and assert every historically-emitted kind is handled.

`npm test` 1,468 passing · typecheck clean · build clean.
