### PR TITLE
See what the agent is doing, and prove it can act

### DIFF
--- a/web/src/app/api/selftest/route.ts
+++ b/web/src/app/api/selftest/route.ts
@@ -1,0 +1,149 @@
+/**
+ * Ask the worker to run its pipeline probe, and report what came back.
+ *
+ * WHY THIS EXISTS. `merrymen selftest` is a CLI flag, and hosted spawns the
+ * worker without it (orchestrator.ts) — so the one command designed to answer
+ * "can this agent actually transact" was unreachable for every hosted tenant.
+ * That is how a fleet-wide arming failure stayed invisible for hours: the only
+ * way to find out was to read container logs by hand.
+ *
+ * THE WEB PROCESS CANNOT RUN IT. The worker is a separate process — a separate
+ * container, hosted — with no HTTP server and no IPC. So this enqueues and the
+ * worker's tick drains. Everything the dashboard has ever told the worker has
+ * gone through a store the other side polls; this is that pattern, not a new
+ * transport.
+ *
+ * WHAT IT IS NOT. Not an order path. The only `kind` written here is a literal,
+ * so a compromised session cannot use this to make the agent trade. When chat
+ * orders land they go through the same channel with their own validation and
+ * their own wall check — the channel is deliberately dumb.
+ */
+import { NextResponse } from "next/server";
+import { readFile } from "node:fs/promises";
+import { homePaths, merrymenHome } from "@merrymen/home";
+import { isHostedMode } from "@merrymen/core";
+import { tenantOf } from "@/lib/auth";
+import { getGrantStore } from "@merrymen/grant-store";
+import { writeCommand } from "@merrymen/command-files";
+import { withReadDb } from "@/lib/ledger";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Which AGENT this request may act for.
+ *
+ * THE TENANT IS NOT THE AGENT. `tenantOf` returns the signed-in browser
+ * wallet; `agent_id` throughout this ledger is the ERC-4337 SMART ACCOUNT —
+ * `ensureAgent` returns `grant.smartAccount`, and the worker claims against
+ * that. Writing the tenant address into `agent_id` produced a row no worker
+ * would ever match, a POST that returned 200, and a status that read 'queued'
+ * forever. Caught in review.
+ *
+ * Resolved through the GRANT STORE, keyed on the authenticated tenant. Not
+ * through `agents.owner_address` the way the feed and scoreboard routes do —
+ * hosted, `owner_address` is the browser-GENERATED grant owner and is never
+ * the tenant, so that lookup would find nothing here.
+ */
+async function agentFor(req: Request): Promise<`0x${string}` | null> {
+  if (isHostedMode()) {
+    // The caller cannot name the agent — only the session decides, so one
+    // tenant can never probe (or spend the gas of) another's.
+    const tenant = tenantOf(req);
+    if (!tenant) return null;
+    const grant = await getGrantStore().get(tenant);
+    return (grant?.smartAccount as `0x${string}`) ?? null;
+  }
+  // Self-hosted has no auth; the localhost middleware is the perimeter, exactly
+  // as it is for /api/settings. The agent is whichever grant is on disk.
+  try {
+    const g = JSON.parse(await readFile(homePaths.grant(), "utf8")) as { smartAccount?: string };
+    return (g.smartAccount as `0x${string}`) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(req: Request) {
+  const agent = await agentFor(req);
+  if (!agent) return NextResponse.json({ error: "not signed in" }, { status: 401 });
+
+  // The id is generated HERE rather than accepted from the caller: an id a
+  // client chooses is an id a client can collide with somebody else's.
+  const id = crypto.randomUUID();
+
+  // SELF-HOSTED SKIPS THE DATABASE ENTIRELY. The web process and the worker
+  // share one MERRYMEN_HOME, so the command can be dropped straight into the
+  // directory the worker drains — no table, no ferry, no shared handle.
+  if (!isHostedMode()) {
+    try {
+      writeCommand(merrymenHome(), { id, kind: "selftest", at: Date.now() });
+      return NextResponse.json({ id, queued: true });
+    } catch (e) {
+      return NextResponse.json(
+        { error: `couldn't queue it: ${e instanceof Error ? e.message : String(e)}` },
+        { status: 503 },
+      );
+    }
+  }
+
+  // Hosted: the orchestrator is the only process that can reach both the
+  // shared database and a child's home, so it ferries. See command-files.ts.
+  const ok = await withReadDb(async (db) => {
+    if (!db) return false;
+    try {
+      await db
+        .prepare("INSERT INTO agent_commands (id, agent_id, kind, created_at) VALUES (?, ?, ?, ?)")
+        // Milliseconds — see the schema note. The column has no default, so
+        // forgetting it is a write error rather than a silently-wrong unit.
+        .run(id, agent, "selftest", Date.now());
+      return true;
+    } catch {
+      return false;
+    }
+  });
+
+  if (!ok) {
+    return NextResponse.json(
+      {
+        error:
+          "couldn't queue it — the ledger is unreachable, which usually means this agent's worker has never run",
+      },
+      { status: 503 },
+    );
+  }
+  return NextResponse.json({ id, queued: true });
+}
+
+/** What happened to the most recent probe. Polled by the button that queued it. */
+export async function GET(req: Request) {
+  const agent = await agentFor(req);
+  if (!agent) return NextResponse.json({ error: "not signed in" }, { status: 401 });
+
+  const row = await withReadDb(async (db) => {
+    if (!db) return null;
+    try {
+      return ((await db
+        .prepare(
+          `SELECT id, kind, created_at, claimed_at, done_at, result FROM agent_commands
+            WHERE agent_id = ? AND kind = 'selftest' ORDER BY created_at DESC LIMIT 1`,
+        )
+        .get(agent)) ?? null) as Record<string, unknown> | null;
+    } catch {
+      return null;
+    }
+  });
+
+  if (!row) return NextResponse.json({ state: "none" });
+  const done = row.done_at !== null && row.done_at !== undefined;
+  const claimed = row.claimed_at !== null && row.claimed_at !== undefined;
+  return NextResponse.json({
+    id: String(row.id),
+    // Three states, not two. "queued" and "running" look identical to someone
+    // watching a spinner, but they mean different things when it stops changing:
+    // queued-forever is a worker that is not draining at all, running-forever is
+    // a probe that hung.
+    state: done ? "done" : claimed ? "running" : "queued",
+    result: row.result === null || row.result === undefined ? null : String(row.result),
+    at: Number(row.created_at),
+  });
+}

--- a/web/src/app/api/selftest/route.ts
+++ b/web/src/app/api/selftest/route.ts
@@ -125,7 +125,7 @@ export async function GET(req: Request) {
       return ((await db
         .prepare(
           `SELECT id, kind, created_at, claimed_at, done_at, result FROM agent_commands
-            WHERE agent_id = ? AND kind = 'selftest' ORDER BY created_at DESC LIMIT 1`,
+            WHERE agent_id = ? AND kind = 'selftest' ORDER BY created_at DESC, id DESC LIMIT 1`,
         )
         .get(agent)) ?? null) as Record<string, unknown> | null;
     } catch {

--- a/web/src/app/app/Console.tsx
+++ b/web/src/app/app/Console.tsx
@@ -13,6 +13,7 @@
  * next (a real /api/chat).
  */
 import { useEffect, useRef, useState, type ReactElement } from "react";
+import { statusLine, type AgentSnapshot } from "./status-line";
 import Link from "next/link";
 import type { FeedResponse, TradeRecord } from "@/app/api/feed/route";
 import type { AgentStatus } from "@/app/api/grants/route";
@@ -257,6 +258,9 @@ function Loaded({ feed, status }: { feed: FeedResponse | null; status: AgentStat
   const total = Math.max(1, split.cash + split.vault + split.positions);
 
   const daysLeft = grant ? Math.max(0, Math.floor((grant.expiresAt - Date.now() / 1000) / 86400)) : null;
+  const landedToday = (feed?.trades ?? []).filter(
+    (t) => t.status === "landed" && new Date(String(t.created_at).replace(" ", "T") + "Z") >= midnight,
+  ).length;
   const refusedToday = (feed?.trades ?? []).filter(
     (t) => t.status === "rejected" && new Date(String(t.created_at).replace(" ", "T") + "Z") >= midnight,
   ).length;
@@ -376,6 +380,41 @@ function Loaded({ feed, status }: { feed: FeedResponse | null; status: AgentStat
           {/* ── HOME: the overview — equity, the split, the wall, recent tape ── */}
           {view === "home" && (
             <>
+              {/*
+                THE ANSWER TO THE QUESTION EVERYONE ARRIVES WITH.
+
+                A user with $318 in the account asked, in the group chat,
+                "Will it now start trading" — looking at this very screen. It
+                led with Total equity, then "building today · no deposit on
+                record yet", then a cash/vault/positions split. All true, none
+                of it an answer.
+
+                So the status goes ABOVE the accounting. Both are worth having;
+                this one comes first because it is what somebody who has just
+                sent money is actually asking.
+              */}
+              <StatusBanner
+                s={{
+                  name: agentName,
+                  mode,
+                  testnet,
+                  hasGas: hasGas(status.balances?.ethWei),
+                  cashUsdg: balCash,
+                  positionsUsdg: posSum,
+                  positionCount: (feed?.positions ?? []).filter((x) => (x.value_usdg || 0) > 0).length,
+                  // What the signature actually names, not what settings list —
+                  // a coin outside `reach` cannot be bought at any size.
+                  tradableCount: reach.size,
+                  landedToday,
+                  refusedToday,
+                  daysLeft,
+                  // The newest err the worker recorded. This is what makes a
+                  // stuck agent say so instead of showing a calm dashboard of
+                  // stale numbers — the failure mode that hid a fleet-wide
+                  // outage for hours.
+                  lastError: (feed?.events ?? []).find((e) => e.level === "err")?.message ?? null,
+                }}
+              />
               <section className="hero">
                 <div className="equity">
                   <div className="kick">Total equity</div>
@@ -647,6 +686,26 @@ function Loaded({ feed, status }: { feed: FeedResponse | null; status: AgentStat
         </Link>
       </nav>
     </div>
+  );
+}
+
+/**
+ * The status, in words, above the numbers.
+ *
+ * Deliberately plain: no chips, no monospace, no abbreviations. Everything
+ * else on this screen is a readout for somebody who already knows what they
+ * are looking at. This is the one line for somebody who does not.
+ */
+function StatusBanner({ s }: { s: AgentSnapshot }) {
+  const line = statusLine(s);
+  return (
+    <section className={`statusline ${line.tone}`}>
+      <span className="sl-dot" aria-hidden="true" />
+      <div>
+        <p className="sl-head">{line.headline}</p>
+        <p className="sl-next">{line.next}</p>
+      </div>
+    </section>
   );
 }
 

--- a/web/src/app/app/console.css
+++ b/web/src/app/app/console.css
@@ -440,3 +440,43 @@
   .sc-root .tabbar .navlink .tally { display: none; }
 }
 @media (prefers-reduced-motion: reduce) { .sc-root * { animation: none !important; transition: none !important; } }
+
+/*
+  THE STATUS LINE.
+
+  Sits above the equity hero and is the first thing read, so it is set in the
+  SANS face at a size the rest of this screen never uses. The console is
+  otherwise monospace, which reads as data — correct for a ledger, wrong for
+  the sentence that tells somebody whether their money is working.
+
+  The dot carries the state, so tone survives for anyone reading the words
+  through a screen reader in order rather than scanning colour.
+*/
+.statusline {
+  display: flex; gap: 12px; align-items: flex-start;
+  padding: 14px 16px; margin-bottom: 16px;
+  border: 1px solid var(--border); border-radius: 12px;
+  background: var(--bg-2, var(--bg-3));
+}
+.sl-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  margin-top: 7px; flex: 0 0 auto;
+}
+.statusline.good .sl-dot { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.statusline.waiting .sl-dot { background: var(--gold); box-shadow: 0 0 8px var(--gold); }
+.statusline.stuck .sl-dot { background: var(--red); box-shadow: 0 0 8px var(--red); }
+/* A stuck agent gets a tinted ground too — the one state where a glance
+   across the room should be enough. */
+.statusline.stuck { border-color: color-mix(in srgb, var(--red) 45%, transparent); background: color-mix(in srgb, var(--red) 8%, transparent); }
+.sl-head {
+  font-family: var(--sans); font-size: 15px; line-height: 1.4;
+  color: var(--text); margin: 0; text-wrap: balance;
+}
+.sl-next {
+  font-family: var(--sans); font-size: 13px; line-height: 1.5;
+  color: var(--text-dim); margin: 4px 0 0;
+}
+@media (max-width: 520px) {
+  .sl-head { font-size: 14px; }
+  .sl-next { font-size: 12.5px; }
+}

--- a/web/src/app/app/status-line.test.ts
+++ b/web/src/app/app/status-line.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { statusLine, type AgentSnapshot } from "./status-line";
+
+/**
+ * A user with $318 in the account asked, in the group chat, "Will it now start
+ * trading" — looking at a screen that led with Total equity, "building today ·
+ * no deposit on record yet", and a cash/vault/positions split. All true, none
+ * of it an answer. These tests are about whether the sentence answers him.
+ */
+
+const base: AgentSnapshot = {
+  name: "Robin",
+  mode: "live",
+  testnet: false,
+  hasGas: true,
+  cashUsdg: 318,
+  positionsUsdg: 0,
+  positionCount: 0,
+  tradableCount: 3,
+  landedToday: 0,
+  refusedToday: 0,
+  daysLeft: 29,
+  lastError: null,
+};
+
+test("HIS EXACT SITUATION gets an answer, not a balance sheet", () => {
+  const l = statusLine(base);
+  assert.match(l.headline, /Robin is live and watching/);
+  assert.match(l.next, /hasn't found a trade worth making/);
+  // And it says the quiet state is normal, because the honest answer to "will
+  // it trade" is often "not yet, and that is fine" — which reads as broken
+  // unless somebody says so.
+  assert.match(l.next, /normal state most of the time/);
+  assert.equal(l.tone, "good");
+});
+
+test("A STUCK AGENT SAYS SO, above everything else", () => {
+  // The failure that hid a fleet-wide outage for hours: ten agents unable to
+  // arm, every dashboard showing a calm page of stale numbers.
+  const l = statusLine({
+    ...base,
+    lastError: "this key was signed before a wall fix and CANNOT trade: it carries a rate-limit policy whose contract has no code on this chain. Re-signing is free.",
+  });
+  assert.equal(l.tone, "stuck");
+  assert.match(l.headline, /stopped and can't start again/);
+  // The reason reaches the user, trimmed to the part that says what is wrong.
+  assert.match(l.next, /signed before a wall fix/);
+  assert.equal(l.next.includes("Re-signing is free"), false, "one sentence, not the whole paragraph");
+});
+
+test("a stuck agent outranks every happier truth", () => {
+  // It is holding money, it traded today, it has gas — and none of that matters
+  // if it cannot start. Ordering is the design.
+  const l = statusLine({
+    ...base,
+    positionCount: 2,
+    positionsUsdg: 200,
+    landedToday: 4,
+    lastError: "boom",
+  });
+  assert.equal(l.tone, "stuck");
+});
+
+test("NEVER CLAIMS THE MARKET IS CLOSED, because it cannot see a clock", () => {
+  // The tempting sentence is "the market is closed, it trades at 2:30pm". This
+  // module has no calendar and no timezone, so saying that would be inventing —
+  // the same class of mistake as reporting unknown as zero.
+  for (const s of [base, { ...base, cashUsdg: 0 }, { ...base, mode: "paper" as const }]) {
+    const l = statusLine(s);
+    assert.equal(/market is closed|opens at|market hours/i.test(l.headline + l.next), false);
+  }
+});
+
+test("practice is called practice, in words a person uses", () => {
+  const paper = statusLine({ ...base, mode: "paper" });
+  assert.match(paper.headline, /practising/);
+  assert.match(paper.headline, /pretend money/);
+
+  const testnet = statusLine({ ...base, testnet: true });
+  assert.match(testnet.headline, /none of this is real money/);
+  assert.match(testnet.next, /free and takes one signature/);
+});
+
+test("no gas is distinguished from no capital — different problems, different fixes", () => {
+  const noGas = statusLine({ ...base, hasGas: false });
+  assert.match(noGas.headline, /no ETH for fees/);
+  assert.match(noGas.next, /Send a little ETH/);
+
+  const noCash = statusLine({ ...base, cashUsdg: 0 });
+  assert.match(noCash.headline, /nothing to trade with/);
+  assert.match(noCash.next, /Send USDG/);
+});
+
+test("refusals are reported as the product working, not as failures", () => {
+  // A tape full of red "refused" rows is the wall doing its job, and it reads
+  // as breakage unless the summary says otherwise.
+  const l = statusLine({ ...base, refusedToday: 7 });
+  assert.match(l.headline, /turned them down/);
+  assert.match(l.next, /Passing is normal/);
+  assert.equal(l.tone, "good");
+});
+
+test("an expiring key is surfaced without hijacking the headline", () => {
+  const l = statusLine({ ...base, positionCount: 1, positionsUsdg: 120, daysLeft: 1 });
+  assert.match(l.headline, /holding \$120/, "what it is doing still comes first");
+  assert.match(l.next, /expires in 1 day/);
+  assert.equal(l.tone, "waiting");
+  // And it does not nag when there is plenty of time.
+  assert.equal(/expires/.test(statusLine({ ...base, daysLeft: 29 }).next), false);
+});
+
+test("money reads the way people write it", () => {
+  assert.match(statusLine({ ...base, positionCount: 1, positionsUsdg: 1234.56 }).headline, /\$1,235/);
+  assert.match(statusLine({ ...base, positionCount: 1, positionsUsdg: 12.5 }).headline, /\$12\.5/);
+});
+
+test("NO JARGON anywhere in any branch", () => {
+  // The words the old screen used, which is what made it unreadable.
+  //
+  // USDG SURVIVES THIS LIST, deliberately. It is the name of the thing the user
+  // has to send, and "send money" would be ambiguous with ETH — a different
+  // problem with a different fix, distinguished two tests above precisely
+  // because confusing them wastes somebody an afternoon. What IS banned is USDG as
+  // a trailing unit on a number: "318.00 USDG" is what made a balance look like
+  // telemetry.
+  const banned = /equity|session key|steady-basket|weekend-gap|bps|wall|grant|positions/i;
+  const unitSuffix = /[d.,]s*USDG/;
+  const cases: AgentSnapshot[] = [
+    base,
+    { ...base, mode: "paper" },
+    { ...base, mode: "idle" },
+    { ...base, testnet: true },
+    { ...base, hasGas: false },
+    { ...base, cashUsdg: 0 },
+    { ...base, positionCount: 3, positionsUsdg: 500 },
+    { ...base, landedToday: 2 },
+    { ...base, refusedToday: 5 },
+    { ...base, daysLeft: 0 },
+  ];
+  for (const c of cases) {
+    const l = statusLine(c);
+    assert.equal(banned.test(l.headline), false, `jargon in headline: ${l.headline}`);
+    assert.equal(banned.test(l.next), false, `jargon in next: ${l.next}`);
+    assert.equal(unitSuffix.test(l.headline + l.next), false, `USDG as a unit: ${l.headline}`);
+  }
+});
+
+test("every branch says what happens next — a status with no next step is a support ticket", () => {
+  const cases: AgentSnapshot[] = [
+    base,
+    { ...base, mode: "paper" },
+    { ...base, mode: "idle" },
+    { ...base, testnet: true },
+    { ...base, hasGas: false },
+    { ...base, cashUsdg: 0 },
+    { ...base, positionCount: 1, positionsUsdg: 50 },
+    { ...base, landedToday: 3 },
+    { ...base, refusedToday: 2 },
+    { ...base, lastError: "something specific went wrong here." },
+  ];
+  for (const c of cases) {
+    const l = statusLine(c);
+    assert.ok(l.headline.length > 10, "a headline");
+    assert.ok(l.next.length > 20, `a next step for: ${l.headline}`);
+    assert.match(l.headline, /\.$/, "a full sentence, ending in a full stop");
+  }
+});

--- a/web/src/app/app/status-line.ts
+++ b/web/src/app/app/status-line.ts
@@ -1,0 +1,177 @@
+/**
+ * WHAT IS MY AGENT DOING RIGHT NOW, AND WHAT HAPPENS NEXT.
+ *
+ * A user with $318 in the account looked at the home screen and asked, in the
+ * group chat, "Will it now start trading". The screen he was looking at led
+ * with **Total equity**, then "— building today · no deposit on record yet",
+ * then CASH / VAULT / POSITIONS, then a sentence about what the chain caps.
+ * Every one of those is true, and not one of them answers his question.
+ *
+ * That is the gap this fills. The console is an accounting surface pointed at
+ * somebody who wants a status. Both are worth having; the status has to come
+ * first, because it is the question everyone actually arrives with.
+ *
+ * THREE RULES, and they are the whole design:
+ *
+ *  1. NO JARGON THAT ISN'T LOAD-BEARING. Not "equity", not "positions", not
+ *     "session key", not the strategy's internal name. A person who has just
+ *     sent money wants a sentence, not a vocabulary.
+ *  2. NEVER CLAIM WHAT WE DID NOT CHECK. This file has no clock and no market
+ *     calendar, so it never says "the market is closed" — it says what it can
+ *     see. The codebase's central rule is that unknown is not representable as
+ *     zero, and a status line is exactly where that rule gets bent for the sake
+ *     of a comforting sentence.
+ *  3. ALWAYS SAY WHAT HAPPENS NEXT. A status with no next step is a status
+ *     someone has to come back and ask about, which is what happened here.
+ *
+ * Pure, so the wording is testable without a browser, a chain, or a ledger.
+ */
+
+export interface AgentSnapshot {
+  name: string;
+  /** What the worker reports it is doing. `idle` means it is not running. */
+  mode: "live" | "paper" | "idle";
+  /** Practice chain — nothing here is real, whatever else is true. */
+  testnet: boolean;
+  /** Does the smart account hold any gas? Without it nothing can be signed. */
+  hasGas: boolean;
+  /** Trading capital, in USDG. */
+  cashUsdg: number;
+  /** Value of everything it is currently holding, in USDG. */
+  positionsUsdg: number;
+  /** How many distinct things it holds. */
+  positionCount: number;
+  /** Symbols it may trade at all — the ones sealed into the signature. */
+  tradableCount: number;
+  /** Trades that actually landed today. */
+  landedToday: number;
+  /** Intents its own rules turned down today. */
+  refusedToday: number;
+  /** Days until the key expires on its own. */
+  daysLeft: number | null;
+  /** The newest `err` the worker recorded, if any. */
+  lastError: string | null;
+}
+
+export interface StatusLine {
+  /** One sentence. What it is doing. */
+  headline: string;
+  /** One sentence. What happens next, or what to do about it. */
+  next: string;
+  /** Drives the dot: green = working, amber = waiting on you, red = stuck. */
+  tone: "good" | "waiting" | "stuck";
+}
+
+/** `$1,234` — money the way a person writes it, never `1234.00 USDG`. */
+function money(n: number): string {
+  return `$${n.toLocaleString("en-US", { maximumFractionDigits: n < 100 ? 2 : 0 })}`;
+}
+
+/**
+ * Trim a worker error down to something a person can act on.
+ *
+ * These are written for an owner already (see the arm-failure path in
+ * index.ts), but they carry addresses and clause after clause. The first
+ * sentence is the part that says what is wrong.
+ */
+function firstSentence(s: string, max = 160): string {
+  const cut = s.split(/(?<=[.!?])\s/)[0] ?? s;
+  return cut.length > max ? `${cut.slice(0, max - 1).trimEnd()}…` : cut;
+}
+
+export function statusLine(a: AgentSnapshot): StatusLine {
+  const name = a.name || "Your agent";
+
+  // ── Stuck: it cannot work, and no amount of waiting changes that ─────────
+  //
+  // FIRST, above everything. An agent that cannot start is the one case where
+  // every other sentence would be a lie of omission — and it is the case that
+  // went unnoticed for hours across ten accounts, because nothing on any screen
+  // said it.
+  if (a.lastError) {
+    return {
+      headline: `${name} has stopped and can't start again on its own.`,
+      next: firstSentence(a.lastError),
+      tone: "stuck",
+    };
+  }
+  if (a.mode === "idle") {
+    return {
+      headline: `${name} isn't running.`,
+      // Deliberately not a guess at why. `idle` means the worker reported no
+      // agent armed; inventing a cause here would be exactly the thing rule 2
+      // forbids.
+      next: "It should come back on its own within a minute or two. If it doesn't, tell us — that's a bug at our end, not something you can fix.",
+      tone: "stuck",
+    };
+  }
+  if (!a.hasGas) {
+    return {
+      headline: `${name} can't trade yet — the account has no ETH for fees.`,
+      next: "Send a little ETH to the account address. A few dollars covers many trades.",
+      tone: "waiting",
+    };
+  }
+
+  // ── Practice ─────────────────────────────────────────────────────────────
+  if (a.testnet) {
+    return {
+      headline: `${name} is on the practice chain, so none of this is real money.`,
+      next: "Move it to real money from the wallet page when you're ready — it's free and takes one signature.",
+      tone: "waiting",
+    };
+  }
+  if (a.mode === "paper") {
+    return {
+      headline: `${name} is practising — real prices, pretend money.`,
+      next:
+        a.cashUsdg > 0
+          ? "It's watching the market and showing you what it would do. Everything below is a simulation until it goes live."
+          : "Add some USDG and it starts trading for real. Until then it practises so you can watch it work first.",
+      tone: "waiting",
+    };
+  }
+
+  // ── Live ─────────────────────────────────────────────────────────────────
+  const expiring = a.daysLeft !== null && a.daysLeft <= 2;
+  const expiryNote = expiring
+    ? ` Its key expires in ${a.daysLeft === 0 ? "under a day" : `${a.daysLeft} day${a.daysLeft === 1 ? "" : "s"}`} — renew it on the wallet page, it's free.`
+    : "";
+
+  if (a.positionCount > 0) {
+    return {
+      headline: `${name} is holding ${money(a.positionsUsdg)}${a.positionCount > 1 ? ` across ${a.positionCount} things` : ""}.`,
+      next: `It sells when its rules say to, not on a timer.${expiryNote}`,
+      tone: expiring ? "waiting" : "good",
+    };
+  }
+  if (a.landedToday > 0) {
+    return {
+      headline: `${name} made ${a.landedToday} trade${a.landedToday === 1 ? "" : "s"} today and is back in cash.`,
+      next: `It's watching for the next one.${expiryNote}`,
+      tone: expiring ? "waiting" : "good",
+    };
+  }
+  if (a.refusedToday > 0) {
+    return {
+      // The refusals are the product working, and they read as failure unless
+      // somebody says otherwise. This is the sentence that turns a wall of red
+      // rows into evidence.
+      headline: `${name} looked at ${a.refusedToday} trade${a.refusedToday === 1 ? "" : "s"} today and turned ${a.refusedToday === 1 ? "it" : "them"} down.`,
+      next: `Passing is normal — it only buys when its own rules line up.${expiryNote}`,
+      tone: expiring ? "waiting" : "good",
+    };
+  }
+  if (a.cashUsdg <= 0) {
+    return {
+      headline: `${name} is live but has nothing to trade with.`,
+      next: "Send USDG to the account address and it starts working.",
+      tone: "waiting",
+    };
+  }
+  return {
+    headline: `${name} is live and watching${a.tradableCount > 0 ? ` ${a.tradableCount} coin${a.tradableCount === 1 ? "" : "s"}` : ""}.`,
+    next: `It hasn't found a trade worth making yet. That's the normal state most of the time.${expiryNote}`,
+    tone: "good",
+  };
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -20,6 +20,7 @@
       "@merrymen/policy": ["../worker/src/policy.ts"],
       "@merrymen/recover": ["../worker/src/recover.ts"],
       "@merrymen/grant-store": ["../worker/src/grant-store.ts"],
+      "@merrymen/command-files": ["../worker/src/command-files.ts"],
       "@merrymen/settings-store": ["../worker/src/settings-store.ts"],
       "@merrymen/llm": ["../worker/src/llm.ts"],
       "@merrymen/settings": ["../worker/src/settings.ts"],

--- a/worker/src/agent-commands.integration.test.ts
+++ b/worker/src/agent-commands.integration.test.ts
@@ -1,0 +1,119 @@
+/**
+ * THE SHARED-TABLE HALF OF THE COMMAND CHANNEL.
+ *
+ * Hosted only, and only the leg between the dashboard and the orchestrator:
+ * the web writes here, the orchestrator ferries into each child home as a
+ * file, and the child claims by unlinking it (command-files.ts). Children
+ * cannot read this table — CHILD_SECRET_STRIP removes DATABASE_URL on purpose.
+ *
+ * READ THIS BEFORE TRUSTING IT. These tests drive enqueue and claim against ONE
+ * store handle with ONE constant key, so they prove the SQL and nothing about
+ * the seam the feature crosses. The first version of this channel passed every
+ * one of them while being completely non-functional hosted — the row went to
+ * Postgres under the tenant wallet, and the child queried its own sqlite for a
+ * smart account. Both defects were invisible here by construction.
+ *
+ * The seam is covered by command-files.ts, with real directories and a real
+ * unlink. `claimCommand` below is retained for the self-hosted single-process
+ * case and as the orchestrator ferry deliverable-marking primitive.
+ */
+import assert from "node:assert/strict";
+import { after, describe, it } from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const HOME = mkdtempSync(path.join(os.tmpdir(), "merrymen-cmd-"));
+process.env.MERRYMEN_HOME = HOME;
+
+const { initStore, enqueueCommand, claimCommand, finishCommand, latestCommand } = await import("./store");
+
+const AGENT = "0xagent0000000000000000000000000000000001";
+const OTHER = "0xagent0000000000000000000000000000000002";
+
+after(() => {
+  try {
+    rmSync(HOME, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe("the agent command queue", () => {
+  it("initialises", async () => {
+    await initStore();
+  });
+
+  it("a queued command can be claimed exactly once", async () => {
+    assert.equal(await enqueueCommand(AGENT, "cmd-1", "selftest"), true);
+    const first = await claimCommand(AGENT);
+    assert.equal(first?.id, "cmd-1");
+    // THE WHOLE POINT. A second drain — a restarted worker, an overlapping
+    // tick — must get nothing, not the same command again.
+    assert.equal(await claimCommand(AGENT), null, "a claimed command must never be handed out twice");
+  });
+
+  it("a crash after the claim leaves it claimed, not replayed", async () => {
+    // Simulated by never calling finishCommand. The row stays claimed and
+    // undone — recoverable by a human looking at it, and crucially NOT
+    // re-executed. For an operation that spends gas, at-most-once beats
+    // at-least-once every time.
+    const st = await latestCommand(AGENT);
+    assert.ok(st);
+    assert.ok(st.claimedAt !== null, "claimed");
+    assert.equal(st.doneAt, null, "and never completed");
+    assert.equal(await claimCommand(AGENT), null, "still not replayed");
+  });
+
+  it("a duplicate id is refused rather than queued twice", async () => {
+    // The primary key does the deduping, so a retried POST cannot become two
+    // UserOperations. A check-then-insert could interleave; this cannot.
+    assert.equal(await enqueueCommand(AGENT, "cmd-1", "selftest"), false);
+  });
+
+  it("commands are scoped to their agent", async () => {
+    // One tenant must never drain another's queue. On a shared hosted database
+    // this is the difference between a probe and someone else's gas.
+    await enqueueCommand(OTHER, "cmd-2", "selftest");
+    assert.equal(await claimCommand(AGENT), null, "AGENT has nothing unclaimed left");
+    const mine = await claimCommand(OTHER);
+    assert.equal(mine?.id, "cmd-2");
+  });
+
+  it("oldest first, so a queue is a queue", async () => {
+    await enqueueCommand(AGENT, "cmd-3", "selftest");
+    await enqueueCommand(AGENT, "cmd-4", "selftest");
+    assert.equal((await claimCommand(AGENT))?.id, "cmd-3");
+    assert.equal((await claimCommand(AGENT))?.id, "cmd-4");
+  });
+
+  it("finishing records the outcome without re-running anything", async () => {
+    await finishCommand("cmd-4", "PASSED — a signed UserOperation reached the chain");
+    const st = await latestCommand(AGENT);
+    assert.equal(st?.id, "cmd-4");
+    assert.equal(st?.doneAt !== null, true);
+    assert.match(String(st?.result), /PASSED/);
+    // And a finished command is not claimable again.
+    assert.equal(await claimCommand(AGENT), null);
+  });
+
+  it("the result is bounded — reject_rule taught us that lesson already", async () => {
+    await enqueueCommand(AGENT, "cmd-5", "selftest");
+    await claimCommand(AGENT);
+    await finishCommand("cmd-5", "x".repeat(5_000));
+    const st = await latestCommand(AGENT);
+    assert.ok((st?.result?.length ?? 0) <= 500, "an unbounded string in a status column is how cardinality explodes");
+  });
+
+  it("an unknown command kind is recorded, not executed", async () => {
+    // The channel is deliberately dumb: it carries a string, and the drain
+    // decides what is executable. A kind nobody handles must leave a trace
+    // rather than vanishing, or a typo looks identical to a queue that is not
+    // being drained at all.
+    await enqueueCommand(AGENT, "cmd-6", "launch-the-missiles");
+    const c = await claimCommand(AGENT);
+    assert.equal(c?.kind, "launch-the-missiles");
+    await finishCommand("cmd-6", "unknown command 'launch-the-missiles'");
+    assert.match(String((await latestCommand(AGENT))?.result), /unknown command/);
+  });
+});

--- a/worker/src/agent-commands.integration.test.ts
+++ b/worker/src/agent-commands.integration.test.ts
@@ -27,9 +27,13 @@ const HOME = mkdtempSync(path.join(os.tmpdir(), "merrymen-cmd-"));
 process.env.MERRYMEN_HOME = HOME;
 
 const { initStore, enqueueCommand, claimCommand, finishCommand, latestCommand } = await import("./store");
+const { homePaths } = await import("./home");
+const { DatabaseSync } = await import("node:sqlite");
 
 const AGENT = "0xagent0000000000000000000000000000000001";
 const OTHER = "0xagent0000000000000000000000000000000002";
+/** Its own agent, so the forced-tie rows cannot disturb the ordering tests above. */
+const TIED = "0xagent0000000000000000000000000000000003";
 
 after(() => {
   try {
@@ -115,5 +119,34 @@ describe("the agent command queue", () => {
     assert.equal(c?.kind, "launch-the-missiles");
     await finishCommand("cmd-6", "unknown command 'launch-the-missiles'");
     assert.match(String((await latestCommand(AGENT))?.result), /unknown command/);
+  });
+  it("commands landing in the SAME MILLISECOND still have one agreed order", async () => {
+    // CI found this on a faster machine than mine: milliseconds fixed the
+    // one-second collisions and did not fix ties. Neither backend has a
+    // portable insertion-order tiebreak — sqlite's rowid is not in Postgres —
+    // so the id breaks it. Arbitrary but CONSISTENT is all a queue needs; what
+    // matters is that claimCommand and latestCommand pick the SAME row rather
+    // than each choosing its own.
+    //
+    // The timestamp is written by hand here. My first attempt fired three
+    // enqueues through Promise.all and assumed they would collide; they did
+    // not — one landed a millisecond earlier and was ordered first, correctly.
+    // A test for tie-breaking has to guarantee the tie, not hope for it.
+    const raw = new DatabaseSync(homePaths.db());
+    const SAME = 1_800_000_000_000;
+    for (const id of ["tie-c", "tie-a", "tie-b"]) {
+      raw
+        .prepare("INSERT INTO agent_commands (id, agent_id, kind, created_at) VALUES (?, ?, ?, ?)")
+        .run(id, TIED, "selftest", SAME);
+    }
+    const drained: string[] = [];
+    for (;;) {
+      const c = await claimCommand(TIED);
+      if (!c) break;
+      drained.push(c.id);
+    }
+    assert.deepEqual(drained, ["tie-a", "tie-b", "tie-c"], "a total order, not whatever the page returns");
+    // And the two queries agree about which one is newest.
+    assert.equal((await latestCommand(TIED))?.id, "tie-c");
   });
 });

--- a/worker/src/command-files.test.ts
+++ b/worker/src/command-files.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  claimCommandFile,
+  commandDir,
+  drainCommandResults,
+  writeCommand,
+  writeCommandResult,
+} from "./command-files";
+
+/**
+ * THE SEAM THE FIRST VERSION NEVER CROSSED.
+ *
+ * v1 put commands in a table and had the worker poll it. Hosted, the dashboard
+ * writes shared Postgres and a child reads its own sqlite — CHILD_SECRET_STRIP
+ * removes DATABASE_URL on purpose — so the row and the query were in different
+ * databases and nothing would ever have been claimed.
+ *
+ * Its test suite passed. It called enqueue and claim against ONE store handle
+ * with ONE constant, which can never catch a caller using a different key or a
+ * different database. These tests use real directories and a real unlink, which
+ * is the actual mechanism.
+ */
+
+function tmpHome(): string {
+  return mkdtempSync(path.join(os.tmpdir(), "merrymen-cmdfile-"));
+}
+
+test("a command written to a home is claimed from that home", () => {
+  const home = tmpHome();
+  try {
+    writeCommand(home, { id: "a", kind: "selftest", at: 1 });
+    const got = claimCommandFile(home);
+    assert.equal(got?.id, "a");
+    assert.equal(got?.kind, "selftest");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("THE UNLINK IS THE CLAIM — a second reader gets nothing", () => {
+  // This is the whole concurrency story, and it is stronger than the
+  // SELECT-then-UPDATE it replaces: rm is atomic, so exactly one caller can
+  // succeed, with no transaction and no shared connection.
+  const home = tmpHome();
+  try {
+    writeCommand(home, { id: "a", kind: "selftest", at: 1 });
+    assert.equal(claimCommandFile(home)?.id, "a");
+    assert.equal(claimCommandFile(home), null, "a claimed command must never be handed out twice");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("commands for one home are invisible to another", () => {
+  // The tenant-isolation property, done by the filesystem rather than by a
+  // WHERE clause somebody has to remember to write.
+  const a = tmpHome();
+  const b = tmpHome();
+  try {
+    writeCommand(a, { id: "mine", kind: "selftest", at: 1 });
+    assert.equal(claimCommandFile(b), null);
+    assert.equal(claimCommandFile(a)?.id, "mine");
+  } finally {
+    rmSync(a, { recursive: true, force: true });
+    rmSync(b, { recursive: true, force: true });
+  }
+});
+
+test("oldest first, by the timestamp INSIDE the file", () => {
+  // Not by mtime: a command is copied from the shared database into a home by
+  // the orchestrator, and mtime describes that copy rather than the request.
+  const home = tmpHome();
+  try {
+    writeCommand(home, { id: "second", kind: "selftest", at: 2_000 });
+    writeCommand(home, { id: "first", kind: "selftest", at: 1_000 });
+    assert.equal(claimCommandFile(home)?.id, "first");
+    assert.equal(claimCommandFile(home)?.id, "second");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("an unreadable command is removed rather than blocking the queue", () => {
+  // A corrupt file that stayed would wedge every later command behind it
+  // forever, which is a worse failure than losing the one nobody can run.
+  const home = tmpHome();
+  try {
+    writeCommand(home, { id: "good", kind: "selftest", at: 2 });
+    writeFileSync(path.join(commandDir(home), "junk.json"), "{not json", "utf8");
+    assert.equal(claimCommandFile(home)?.id, "good");
+    assert.equal(
+      readdirSync(commandDir(home)).some((n) => n === "junk.json"),
+      false,
+      "the unreadable file is gone, not skipped forever",
+    );
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("results travel back and are drained exactly once", () => {
+  const home = tmpHome();
+  try {
+    writeCommandResult(home, { id: "a", ok: true, line: "PASSED — it landed", at: 5 });
+    const got = drainCommandResults(home);
+    assert.equal(got.length, 1);
+    assert.equal(got[0]!.id, "a");
+    assert.equal(got[0]!.ok, true);
+    assert.match(got[0]!.line, /PASSED/);
+    assert.deepEqual(drainCommandResults(home), [], "draining removes them");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("a result is never mistaken for a command", () => {
+  // Both live in the same directory, and `.done.json` also ends in `.json`.
+  // Confusing the two would have the worker try to execute its own answer.
+  const home = tmpHome();
+  try {
+    writeCommandResult(home, { id: "a", ok: true, line: "done", at: 5 });
+    assert.equal(claimCommandFile(home), null, "a result is not a pending command");
+    assert.equal(drainCommandResults(home).length, 1);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("a half-written file is never observed — write then rename", () => {
+  // The temp name is dotted and does not end in .json, so a reader scanning
+  // mid-write sees nothing rather than a truncated command.
+  const home = tmpHome();
+  try {
+    writeCommand(home, { id: "a", kind: "selftest", at: 1 });
+    const names = readdirSync(commandDir(home));
+    assert.deepEqual(names, ["a.json"], "no temp file left behind");
+    assert.equal(names.some((n) => n.startsWith(".")), false);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("an empty or missing home is empty, not an error", () => {
+  const home = tmpHome();
+  try {
+    assert.equal(claimCommandFile(home), null);
+    assert.deepEqual(drainCommandResults(home), []);
+    assert.equal(claimCommandFile(path.join(home, "nope")), null);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/worker/src/command-files.ts
+++ b/worker/src/command-files.ts
@@ -1,0 +1,159 @@
+/**
+ * COMMANDS REACH A WORKER AS FILES IN ITS OWN HOME.
+ *
+ * The first version of this put the command in a table and had the worker poll
+ * it, on the reasoning that "everything the dashboard has ever told the worker
+ * goes through a store the other side polls". That reasoning was wrong, and an
+ * adversarial review caught it before it shipped.
+ *
+ * What actually exists: the orchestrator MATERIALISES state into each child's
+ * private home — `writeGrantForChild`, `writeSettingsForChild` — and the ledger
+ * mirror runs strictly child → shared, one direction. There is no shared → child
+ * path in this repo at all. Children have DATABASE_URL stripped
+ * (CHILD_SECRET_STRIP) precisely so they cannot reach the shared database, which
+ * is a custody decision, not an oversight. So a hosted command written to
+ * Postgres and polled from a child's private sqlite is two different databases,
+ * and nothing would ever have been claimed.
+ *
+ * This is the existing pattern instead:
+ *
+ *   web ──(shared table, hosted only)──▶ orchestrator ──(file)──▶ child
+ *   child ──(result file)──▶ orchestrator ──(shared table)──▶ web
+ *
+ * Self-hosted there is no orchestrator and no shared table: the web process and
+ * the worker share one MERRYMEN_HOME, so the web writes the file directly and
+ * the middle two hops vanish. One drain path, two ways in.
+ *
+ * THE CLAIM IS AN UNLINK. `rm` on a file is atomic on every filesystem this
+ * runs on, so the worker that successfully deletes the command owns it and any
+ * other reader gets ENOENT. That is a stronger guarantee than the SELECT-then-
+ * UPDATE it replaces, and it needs no transaction — which matters, because the
+ * thing being guarded spends gas and at-most-once is the only acceptable
+ * semantics.
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+/** One instruction, as it sits on disk. */
+export interface FileCommand {
+  id: string;
+  kind: string;
+  /** Milliseconds. Seconds would make two commands in one second unordered. */
+  at: number;
+}
+
+/** What the worker decided, on its way back. */
+export interface FileCommandResult {
+  id: string;
+  ok: boolean;
+  line: string;
+  at: number;
+}
+
+const DIR = "commands";
+
+/** Where a home keeps its pending instructions. */
+export function commandDir(home: string): string {
+  return path.join(home, DIR);
+}
+
+/** Drop a command into a home. Called by the orchestrator, or by a self-hosted web. */
+export function writeCommand(home: string, cmd: FileCommand): void {
+  const dir = commandDir(home);
+  mkdirSync(dir, { recursive: true });
+  // Written to a temp name and renamed, so a reader can never observe a
+  // half-written command — rename is atomic within a filesystem, write is not.
+  const tmp = path.join(dir, `.${cmd.id}.tmp`);
+  writeFileSync(tmp, JSON.stringify(cmd), "utf8");
+  renameSync(tmp, path.join(dir, `${cmd.id}.json`));
+}
+
+/**
+ * Take the oldest pending command, or null.
+ *
+ * THE UNLINK IS THE CLAIM. Reading then deleting means a crash between the two
+ * replays the command; deleting then acting means a crash loses it. Losing a
+ * probe is a button the owner presses again; replaying one spends gas nobody
+ * asked to spend twice. So: delete first, and only then act.
+ */
+export function claimCommandFile(home: string): FileCommand | null {
+  const dir = commandDir(home);
+  if (!existsSync(dir)) return null;
+  let names: string[];
+  try {
+    names = readdirSync(dir).filter((n) => n.endsWith(".json") && !n.endsWith(".done.json"));
+  } catch {
+    return null;
+  }
+  if (names.length === 0) return null;
+
+  // Oldest first, by the timestamp inside rather than by mtime: a file copied
+  // between homes keeps its meaning, and mtime does not survive that.
+  const parsed = names
+    .map((n) => {
+      try {
+        return JSON.parse(readFileSync(path.join(dir, n), "utf8")) as FileCommand;
+      } catch {
+        // Unreadable command: remove it rather than blocking the queue behind
+        // something no worker will ever be able to run.
+        try {
+          unlinkSync(path.join(dir, n));
+        } catch {
+          /* already gone */
+        }
+        return null;
+      }
+    })
+    .filter((c): c is FileCommand => !!c && typeof c.id === "string" && typeof c.kind === "string");
+  if (parsed.length === 0) return null;
+  parsed.sort((a, b) => (a.at ?? 0) - (b.at ?? 0));
+
+  for (const cmd of parsed) {
+    try {
+      unlinkSync(path.join(dir, `${cmd.id}.json`));
+      return cmd; // we deleted it, so it is ours
+    } catch {
+      // Somebody else got there first — try the next one rather than giving up,
+      // because "the queue is empty" and "one entry was taken" are different.
+    }
+  }
+  return null;
+}
+
+/** Leave the outcome where the orchestrator will find it. */
+export function writeCommandResult(home: string, r: FileCommandResult): void {
+  const dir = commandDir(home);
+  mkdirSync(dir, { recursive: true });
+  const tmp = path.join(dir, `.${r.id}.done.tmp`);
+  writeFileSync(tmp, JSON.stringify(r), "utf8");
+  renameSync(tmp, path.join(dir, `${r.id}.done.json`));
+}
+
+/** Collect and remove finished results. Called by the orchestrator. */
+export function drainCommandResults(home: string): FileCommandResult[] {
+  const dir = commandDir(home);
+  if (!existsSync(dir)) return [];
+  let names: string[];
+  try {
+    names = readdirSync(dir).filter((n) => n.endsWith(".done.json"));
+  } catch {
+    return [];
+  }
+  const out: FileCommandResult[] = [];
+  for (const n of names) {
+    const f = path.join(dir, n);
+    try {
+      const r = JSON.parse(readFileSync(f, "utf8")) as FileCommandResult;
+      if (typeof r.id === "string") out.push(r);
+    } catch {
+      /* unreadable result — dropped with the file below */
+    }
+    try {
+      unlinkSync(f);
+    } catch {
+      /* already gone */
+    }
+  }
+  return out;
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -75,6 +75,7 @@ import { belowFloorBps, checkDelivery, describeDelivery } from "./delivery";
 import { classifyRevert, suppressionKey } from "./revert";
 import { findOrphanOps, resolveSubmittedOps, type RawLog, type ReconcileChain } from "./inflight-reconcile";
 import { grantHasDeadRateLimit } from "./session-account";
+import { claimCommandFile, writeCommandResult } from "./command-files";
 import { bookGaps, composeEquityUsdg } from "./equity";
 import { priceGas, wethPriceToken } from "./gas-price";
 import { createPaperOrderExecutor, type OrderExecutor } from "./executor-order";
@@ -83,7 +84,7 @@ import { accrueAboveHwm } from "./fees";
 import { archiveCurrentGrant, grantExpired, grantKey, loadGrantFile } from "./grant";
 import { TRADEABLE_CHAIN_ID } from "./preflight";
 import { limitsFromGrant } from "./limits";
-import { ensureHome, homePaths } from "./home";
+import { ensureHome, homePaths, merrymenHome } from "./home";
 import { resolveLlm } from "./llm";
 import { applyPaperIntent, type PaperPosition } from "./paper";
 import { checkPolicy, type AgentLimits, type AgentState, type ScoutContext, type TradeIntent } from "./policy";
@@ -449,6 +450,8 @@ async function main() {
    * quietly stopped proposing. Cleared at every arm.
    */
   const suppressedIntents = new Map<string, string>();
+  /** The last arm failure reported, so the same one is not re-logged every tick. */
+  let lastArmFailure: string | null = null;
   let inFlightSpentUsdg = 0n;
   let inFlightOps = 0;
   const spentToday = () => settledSpentUsdg + inFlightSpentUsdg;
@@ -1435,6 +1438,98 @@ async function main() {
    * doing an EXACT per-hash lookup does not need a precise window — only one wide
    * enough to contain the op.
    */
+  /**
+   * RUN ONE COMMAND THE DASHBOARD ASKED FOR.
+   *
+   * `merrymen selftest` is a CLI flag, and hosted spawns the worker without it
+   * (orchestrator.ts). So the one probe designed to answer "can this thing
+   * actually transact" was unreachable for every hosted tenant — which is how a
+   * fleet-wide arming failure stayed invisible for hours: the only way to find
+   * out was to read container logs by hand.
+   *
+   * The transport is a claimed queue rather than a flag, because this spends
+   * gas. claimCommand takes the row before anything runs, so a crash mid-probe
+   * leaves it claimed rather than replayed. At-most-once, never at-least-once.
+   *
+   * ONE COMMAND PER TICK, and only when armed. There is no batch drain and no
+   * catch-up: an operator who queued three probes wants three ticks' worth of
+   * evidence, not three UserOps racing the same nonce.
+   */
+  let commandInFlight = false;
+  async function runQueuedCommand(agentId: string): Promise<void> {
+    if (commandInFlight || !active) return;
+    commandInFlight = true;
+    try {
+      // FROM THIS WORKER'S OWN HOME, not from a shared table.
+      //
+      // Children have DATABASE_URL stripped, so a hosted worker's store is its
+      // private sqlite while the dashboard writes shared Postgres — two
+      // different databases, and nothing would ever have been claimed. The
+      // orchestrator ferries commands in as files, exactly as it already does
+      // for grants and settings. See command-files.ts.
+      const cmd = claimCommandFile(merrymenHome());
+      if (!cmd) return;
+      // The unlink above WAS the claim, so from here the command is ours and
+      // will not be replayed — a lost probe is a button pressed again, a
+      // replayed one is gas nobody asked to spend twice.
+      const outcome = cmd.kind === "selftest"
+        ? await runSelftestProbe("dashboard")
+        : { ok: false, line: `unknown command '${cmd.kind}'` };
+      writeCommandResult(merrymenHome(), { id: cmd.id, ok: outcome.ok, line: outcome.line, at: Date.now() });
+      await addEvent(agentId, outcome.ok ? "ok" : "err", `selftest: ${outcome.line}`);
+    } catch (e) {
+      console.log(`[command] failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      commandInFlight = false;
+    }
+  }
+
+  /**
+   * The probe itself, shared by the CLI and the dashboard.
+   *
+   * One policy-legal no-op — approve 0.000001 USDG to the router — through the
+   * whole pipeline: bundler handshake, session-key signature, the account
+   * contract's call policy, EntryPoint prefund, account deployment, receipt,
+   * ledger row. It does NOT prove a swap; the approve is the first call of one,
+   * not the swap itself.
+   *
+   * Reads the LEDGER for its verdict, never the absence of an exception:
+   * processIntent records every failure and returns normally, so `await`
+   * completing carries no information at all. That mistake is why this used to
+   * print PASSED for a UserOp the wall had just refused.
+   */
+  async function runSelftestProbe(source: string): Promise<{ ok: boolean; line: string }> {
+    if (!active) return { ok: false, line: "not armed — nothing to probe" };
+    const a = active as ActiveAgent;
+    if (!a.executor) return { ok: false, line: "no bundler key — nothing can be signed" };
+    if (a.grant.chainId !== TRADEABLE_CHAIN_ID) {
+      return {
+        ok: false,
+        line:
+          `grant is on chain ${a.grant.chainId}; every token and router merrymen knows is a chain ` +
+          `${TRADEABLE_CHAIN_ID} deployment, so an approve here calls an address with no code. ` +
+          `That can prove the grant, the wall and the bundler — never a trade.`,
+      };
+    }
+    const probe = selfTestIntent(cfg);
+    await ensureDecision(probe, source, "pipeline probe (approve dust) — not a market view");
+    // equityKnown: false, not equity 0 — the probe knows nothing about the book
+    // and must not claim a zero.
+    await processIntent(probe, 0n, false);
+    const outcome = lastTradeOutcome;
+    if (!outcome) return { ok: false, line: "FAILED — the probe never reached the ledger at all" };
+    if (outcome.status !== "landed") {
+      return {
+        ok: false,
+        line: `FAILED — the probe was ${outcome.status}${outcome.rejectRule ? `: ${outcome.rejectRule}` : ""}`,
+      };
+    }
+    return {
+      ok: true,
+      line: "PASSED — a signed UserOperation reached the chain and the ledger recorded it",
+    };
+  }
+
   let lastStrandedAt = 0;
   let strandedInFlight = false;
   const STRANDED_INTERVAL_SEC = 300;
@@ -1482,7 +1577,25 @@ async function main() {
       // nullScout, which picks NOTHING — this step exists to exclude, and with
       // nothing to do the excluding the honest answer is "nothing has been
       // vetted", not "everything has".
-      const creds = resolveLlm(cfg);
+      //
+      // AND IT ONLY RUNS FOR AN AGENT THAT COULD ACT ON IT.
+      //
+      // `scoutEnabled` defaults to false and `scoutBudgetUsdg` to 0, so by
+      // default a scouted coin can never be bought at any size — quarantine.ts
+      // refuses it. Ranking candidates anyway spent the LLM budget to produce a
+      // list nothing was allowed to use.
+      //
+      // Hosted, that budget is one shared house key across every tenant, and
+      // this ran per tenant every ten minutes. On 2026-08-31 it consumed the
+      // whole 200,000-token daily allowance — 195,881 used — and the first
+      // person to notice was a user whose CHAT stopped working, because the
+      // feature people actually touch was competing with a background
+      // speculation nobody had switched on.
+      //
+      // Discovery itself still runs: candidates are found, screened and
+      // recorded. Only the paid narrowing step waits until the owner has said
+      // they want to trade these at all.
+      const creds = cfg.scoutEnabled ? resolveLlm(cfg) : null;
       const res = await discoverTrending({
         client: mainnetClient(),
         seen: await seenPools(),
@@ -1702,13 +1815,49 @@ async function main() {
 
     let executor: AgentExecutor | null = null;
     if (bundlerUrl) {
-      executor = await createAgentExecutor({
-        chain,
-        serializedGrant: grant.serialized,
-        bundlerUrl,
-        rpcUrl: rpc,
-      });
-      console.log(`[worker] executor live — smart account ${executor.address} on chain ${chain.id}`);
+      // ARMING CAN FAIL, AND THE FAILURE MUST BE VISIBLE.
+      //
+      // This used to throw straight out of syncGrant, out of tick, into
+      // runLoop's `.catch(e => console.error(...))` — a stack trace on stdout
+      // and nothing else. No event, no status, and heartbeat() never ran
+      // because it is called AFTER syncGrant, so even the staleness signal was
+      // absent. Ten hosted agents sat in that loop for hours and the only way
+      // anyone found out was reading container logs by hand.
+      //
+      // A grant that cannot be deserialized is a real and permanent condition
+      // — an unrecognised policy, a corrupt blob, a permission id that does not
+      // reproduce. Retrying it every 60 seconds forever is not recovery, it is
+      // noise. So: record it where the owner will see it, leave the agent
+      // unarmed, and let the tick continue so the heartbeat still beats and the
+      // dashboard can say IDLE rather than going silent.
+      try {
+        executor = await createAgentExecutor({
+          chain,
+          serializedGrant: grant.serialized,
+          bundlerUrl,
+          rpcUrl: rpc,
+        });
+        console.log(`[worker] executor live — smart account ${executor.address} on chain ${chain.id}`);
+        lastArmFailure = null;
+      } catch (e) {
+        const why = e instanceof Error ? e.message : String(e);
+        console.log(`[worker] CANNOT ARM — ${why}`);
+        await setAgentStatus(agentId, "error");
+        // Once per distinct reason, not once per tick. An owner scrolling a
+        // feed of the same sentence 1,400 times learns nothing the first one
+        // did not tell them — and that is the shape of the incident this
+        // repo already carries (1,242 identical rejections, 2026-07-15).
+        if (lastArmFailure !== why) {
+          lastArmFailure = why;
+          await addEvent(
+            agentId,
+            "err",
+            `this agent CANNOT START and is not trading: ${why.slice(0, 300)}`,
+          );
+        }
+        active = null;
+        return false;
+      }
     } else {
       console.log(
         cfg.paperTradingEnabled
@@ -3868,6 +4017,9 @@ async function main() {
     // cadence is independent of how fast the owner trades. Never awaited into
     // the trading path in a way that could stall it — a data provider having a
     // bad minute must not delay a sell.
+    // A dashboard-queued probe, before discovery: it is the thing somebody is
+    // actively waiting on, and it is one operation.
+    if (active) void runQueuedCommand(active.agentId).catch(() => {});
     // Finish what we lost track of before starting anything new.
     void runStrandedResolve(agentId).catch(() => {});
     void runDiscovery(agentId).catch(() => {});
@@ -3929,37 +4081,15 @@ async function main() {
       );
     }
     console.log("[selftest] sending policy-legal no-op through the full pipeline…");
-    const probe = selfTestIntent(cfg);
-    await ensureDecision(probe, "selftest", "pipeline probe (approve dust) — not a market view");
-    // equityKnown: false, not equity 0. The probe knows nothing about the book
-    // and must not claim a zero — that is the invariant this whole codebase
-    // runs on. It happens to be inert right now because the probe buys USDG and
-    // the breaker exempts exits, but it is a false statement in the state
-    // record and becomes a hard drawdown-breaker rejection the moment the probe
-    // stops being a swap into cash.
-    await processIntent(probe, 0n, false);
-    // READ THE LEDGER, not the absence of an exception. processIntent records
-    // every failure and returns normally, so `await` completing tells you
-    // nothing — this used to print "done" and exit 0 for a UserOp the wall had
-    // just refused. It is onboarding step 4, "prove the shot lands".
-    const outcome = lastTradeOutcome;
-    if (!outcome) {
-      console.error("[selftest] FAILED — the probe never reached the ledger at all.");
+    // THE SAME PROBE THE DASHBOARD RUNS. Two copies of this would drift, and
+    // the copy that drifts is the one nobody runs — which for months was the
+    // hosted one, because there wasn't one.
+    const result = await runSelftestProbe("selftest");
+    if (!result.ok) {
+      console.error(`[selftest] ${result.line}`);
+      console.error("[selftest] Nothing was proved; fix this before funding the account.");
       process.exit(1);
     }
-    if (outcome.status !== "landed") {
-      console.error(
-        `[selftest] FAILED — the probe was ${outcome.status}` +
-          (outcome.rejectRule ? `: ${outcome.rejectRule}` : "") +
-          ". Nothing was proved; fix this before funding the account.",
-      );
-      process.exit(1);
-    }
-    // Say exactly what green means. This proves the approve leg — the first
-    // call of every real swap — reached the chain under the wall. It does NOT
-    // prove `exactInputSingle`: that would need an estimate-only pass through
-    // the bundler, which runs validation without submitting, and that is a
-    // feature on the executor rather than something to imply here.
     console.log(
       `[selftest] PASSED — approve(${swapRouterFor(cfg)}, 0.000001 USDG) landed on-chain. ` +
         "The grant, the wall, the bundler and the ledger all work. The swap call itself is not covered.",

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -45,9 +45,10 @@ import { getGrantStore } from "./grant-store";
 import { getSettingsStore } from "./settings-store";
 import { acquireTenantLease, type TenantLease } from "./tenant-lease";
 import { isHostedMode, type MerrymenSettings } from "../../packages/core/src/index";
-import { makePgDb, translateSchema } from "./db";
+import { makePgDb, translateSchema, type Db } from "./db";
 import { MIRROR_STATE_DDL, mirrorTenant, openChildLedger } from "./ledger-mirror";
 import { applyLedgerSchema } from "./store";
+import { drainCommandResults, writeCommand } from "./command-files";
 
 /** How often to re-read the store for tenants added or killed. */
 const RECONCILE_MS = 15_000;
@@ -361,6 +362,110 @@ export async function reconcile(): Promise<void> {
  * tenant whose dashboard lags a tick; it is never a reason to stop supervising
  * the fleet, which is this process's actual job.
  */
+/**
+ * CARRY COMMANDS TO CHILDREN, AND THEIR ANSWERS BACK.
+ *
+ * The dashboard writes into the shared database; a child cannot read it,
+ * because CHILD_SECRET_STRIP removes DATABASE_URL on purpose — a child holding
+ * the fleet's connection string is the isolation this file exists to keep. So
+ * the orchestrator, the one process that holds both the shared database and
+ * every child's home, ferries between them. Exactly what writeGrantForChild
+ * and writeSettingsForChild already do for grants and settings.
+ *
+ * The first attempt skipped this and had the child poll the table directly.
+ * It would never have claimed a single command: the row was in Postgres and
+ * the query ran against the child's private sqlite. Caught in review, before
+ * anybody pressed the button and watched nothing happen.
+ *
+ * Best-effort on both legs. A command that does not arrive is a button the
+ * owner presses again; taking the fleet loop down to deliver one is not a
+ * trade worth making.
+ */
+async function ferryCommands2(): Promise<void> {
+  const url = process.env.DATABASE_URL;
+  if (!url || children.size === 0) return;
+  try {
+    const shared = await makePgDb(url);
+    await ferryCommands(shared);
+  } catch {
+    /* shared db unavailable — the mirror logs that already */
+  }
+}
+
+async function ferryCommands(shared: Db): Promise<void> {
+  for (const tenant of [...children.keys()]) {
+    const home = childHome(tenant);
+    // ── down: unclaimed commands become files ──
+    try {
+      const rows = (await shared
+        .prepare(
+          `SELECT id, kind, created_at FROM agent_commands
+            WHERE agent_id = ? AND claimed_at IS NULL ORDER BY created_at ASC LIMIT 5`,
+        )
+        .all(tenant)) as { id: string; kind: string; created_at: number }[];
+      for (const r of rows) {
+        writeCommand(home, { id: String(r.id), kind: String(r.kind), at: Number(r.created_at) });
+        // Marked claimed the moment it is DELIVERED, not when it completes.
+        // Otherwise the next pass ferries it again and the child runs it
+        // twice — and this one spends gas.
+        await shared
+          .prepare("UPDATE agent_commands SET claimed_at = ? WHERE id = ? AND claimed_at IS NULL")
+          .run(Date.now(), r.id);
+        log(`command ${String(r.id).slice(0, 8)} → ${tenant.slice(0, 8)} (${r.kind})`);
+      }
+    } catch {
+      /* a child that misses a command this pass gets it next pass */
+    }
+    // ── up: results become rows ──
+    try {
+      for (const r of drainCommandResults(home)) {
+        await shared
+          .prepare("UPDATE agent_commands SET done_at = ?, result = ? WHERE id = ?")
+          .run(Date.now(), r.line.slice(0, 500), r.id);
+        log(`command ${r.id.slice(0, 8)} ← ${tenant.slice(0, 8)}: ${r.ok ? "ok" : "failed"}`);
+      }
+    } catch {
+      /* the result file is already gone; the event feed still carries it */
+    }
+  }
+}
+/**
+ * ONE LINE THAT SAYS WHETHER THE FLEET IS ALL RIGHT.
+ *
+ * Nothing aggregated. Per-tenant state existed — a status column, a heartbeat,
+ * an event feed — and every one of them had to be looked up by somebody who
+ * already suspected a problem. So when ten agents stopped arming, the signal
+ * was ten identical stack traces interleaved with normal chatter in a log
+ * nobody tails, and it stayed that way for hours.
+ *
+ * Printed every reconcile, unconditionally, so its ABSENCE is also a signal.
+ * A summary that only appears when something is wrong teaches an operator to
+ * read silence as health, and silence is exactly what a wedged process emits.
+ *
+ * Cheap and best-effort: one grouped count against a table the mirror has just
+ * written, and a failure here must never take the fleet loop down.
+ */
+async function fleetHealth(): Promise<void> {
+  const url = process.env.DATABASE_URL;
+  if (!url) return;
+  try {
+    const shared = await makePgDb(url);
+    const rows = (await shared
+      .prepare("SELECT status, COUNT(*) AS n FROM agents GROUP BY status")
+      .all()) as { status: string; n: number | string }[];
+    const by = new Map(rows.map((r) => [r.status, Number(r.n)]));
+    const total = [...by.values()].reduce((a, b) => a + b, 0);
+    const broken = by.get("error") ?? 0;
+    const parts = [...by.entries()].map(([k, v]) => `${k} ${v}`).join(", ");
+    // The word BROKEN is in the line only when it is true, so grepping for it
+    // is a working alert with no extra infrastructure.
+    log(`fleet: ${total} agent(s) — ${parts}${broken > 0 ? ` — BROKEN ${broken}` : ""}`);
+  } catch {
+    // A health read that fails is not a fleet that is down. Say nothing rather
+    // than raise a false alarm, and never take the loop with it.
+  }
+}
+
 async function mirrorLedgers(): Promise<void> {
   const url = process.env.DATABASE_URL;
   if (!url || children.size === 0) return;
@@ -463,6 +568,8 @@ export async function runOrchestrator(): Promise<void> {
       await reconcile();
       watchdog();
       await mirrorLedgers();
+      await ferryCommands2();
+      await fleetHealth();
     }
     await new Promise((r) => setTimeout(r, RECONCILE_MS));
   }

--- a/worker/src/scout-budget.test.ts
+++ b/worker/src/scout-budget.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { SETTINGS_DEFAULTS } from "../../packages/core/src/index";
+
+/**
+ * DON'T PAY TO RANK WHAT YOU CANNOT BUY.
+ *
+ * On 2026-08-31 the shared Groq key hit its 200,000-token DAILY limit —
+ * 195,881 used — and the first person to notice was a user whose chat stopped
+ * working. The consumer was the memecoin scout: an LLM ranking pass running per
+ * tenant every ten minutes, across eleven tenants, on a house key.
+ *
+ * Every one of those rankings was unusable. `scoutEnabled` defaults to false
+ * and `scoutBudgetUsdg` to 0, so a scouted coin cannot be bought at any size —
+ * the quarantine refuses it. The agent was spending the budget that user chat
+ * needs to produce a list nothing was allowed to act on.
+ */
+
+const SRC = readFileSync("worker/src/index.ts", "utf8");
+
+test("the defaults mean a scouted coin cannot be bought", () => {
+  // The premise. If either of these ever defaults to permissive, the gate below
+  // stops being free and this test should fail so somebody reconsiders it.
+  assert.equal(SETTINGS_DEFAULTS.scoutEnabled, false);
+  assert.equal(SETTINGS_DEFAULTS.scoutBudgetUsdg, 0);
+});
+
+test("the paid ranking step is gated on the agent being able to act on it", () => {
+  assert.match(
+    SRC,
+    /const creds = cfg\.scoutEnabled \? resolveLlm\(cfg\) : null;/,
+    "the LLM call must wait until the owner has said they want to trade these",
+  );
+  assert.equal(
+    /const creds = resolveLlm\(cfg\);\s*\n\s*const res = await discoverTrending/.test(SRC),
+    false,
+    "an ungated resolveLlm here is what drained the shared key",
+  );
+});
+
+test("discovery itself still runs — the gate is on the LLM, not on looking", () => {
+  // Candidates are still found, screened and recorded; only the paid narrowing
+  // waits. Gating discovery entirely would have been the lazy fix and would
+  // have emptied the coins page for everyone.
+  assert.match(SRC, /if \(!cfg\.discoveryEnabled \|\| trendInFlight\) return;/);
+  assert.match(SRC, /scout: creds \? createMemecoinScout\(creds\) : nullScout/);
+});
+
+test("no brain still means nullScout, which picks NOTHING", () => {
+  // The pre-existing invariant, unchanged: this step exists to EXCLUDE, so with
+  // nothing doing the excluding the honest answer is "nothing has been vetted",
+  // never "everything has". A gate that opened the floodgates when the LLM was
+  // unavailable would be the dangerous version of this fix.
+  assert.match(SRC, /nullScout/);
+  assert.equal(/scout: createMemecoinScout\(creds!\)/.test(SRC), false, "no non-null assertion around the brain");
+});

--- a/worker/src/selftest.invariant.test.ts
+++ b/worker/src/selftest.invariant.test.ts
@@ -28,6 +28,21 @@ import { buildCallPermissions } from "../../packages/core/src/wall";
  */
 
 const SRC = readFileSync(fileURLToPath(new URL("index.ts", import.meta.url)), "utf8");
+/*
+  TWO SLICES, because the probe moved out of the CLI block.
+
+  It used to live inline under `if (selftest)`. It is now runSelftestProbe,
+  shared by the CLI and by the dashboard command a hosted deployment queues —
+  hosted spawns the worker without --selftest, so the CLI-only version was
+  unreachable for every hosted tenant, which is how a fleet-wide arming failure
+  stayed invisible for hours.
+*/
+/** What runs, and how its verdict is reached. */
+const PROBE = SRC.slice(
+  SRC.indexOf("  async function runSelftestProbe("),
+  SRC.indexOf("  let lastStrandedAt = 0;"),
+);
+/** The CLI wrapper: exit codes, and the caveats a terminal user is shown. */
 const SELFTEST = SRC.slice(SRC.indexOf("  if (selftest) {"));
 
 test("the probe approves the router this install will actually use", () => {
@@ -62,14 +77,24 @@ test("a grant this repo can sign does NOT carry the Rialto router — which is w
 });
 
 test("selftest fails loudly unless the probe LANDED", () => {
-  assert.match(SELFTEST, /lastTradeOutcome/, "it must read the ledger row, not the absence of an exception");
+  assert.match(PROBE, /lastTradeOutcome/, "it must read the ledger row, not the absence of an exception");
+  // The VERDICT belongs to the probe; the EXIT CODE belongs to the CLI. Split
+  // because the probe is now shared with a dashboard command that has no
+  // process to exit — and a shared probe is the whole point: the copy that
+  // drifts is always the one nobody runs, which for months was the hosted one,
+  // because there wasn't one.
+  assert.match(
+    PROBE,
+    /status !== "landed"[\s\S]{0,400}ok: false/,
+    "anything other than 'landed' must be a failing verdict — a green light for a refused UserOp is worse than no check",
+  );
+  assert.match(PROBE, /!outcome[\s\S]{0,200}ok: false/, "no row at all must also fail");
   assert.match(
     SELFTEST,
-    /status\s*!==\s*"landed"[\s\S]{0,600}process\.exit\(1\)/,
-    "anything other than 'landed' must exit non-zero — a green light for a refused UserOp is worse than no check",
+    /!result\.ok[\s\S]{0,300}process\.exit\(1\)/,
+    "and the CLI must turn a failing verdict into a non-zero exit",
   );
-  assert.match(SELFTEST, /!outcome[\s\S]{0,300}process\.exit\(1\)/, "no row at all must also fail");
-  // And the success line must not overclaim: it proves approve, not the swap.
+  // The success line must not overclaim: it proves approve, not the swap.
   assert.match(SELFTEST, /PASSED/, "sanity: there is still a success path");
   assert.match(
     SELFTEST,
@@ -80,8 +105,8 @@ test("selftest fails loudly unless the probe LANDED", () => {
 
 test("selftest declares the probe's book UNKNOWN rather than zero", () => {
   assert.match(
-    SELFTEST,
-    /processIntent\(probe,\s*0n,\s*false\)/,
+    PROBE,
+    /processIntent\(probe, 0n, false\)/,
     "equityKnown must be false — passing 0n as a known equity is the exact 'unknown as zero' bug this codebase exists to avoid",
   );
 });
@@ -90,6 +115,18 @@ test("selftest warns when the answer cannot mean what it looks like", () => {
   // Both are cases where the run can go green while proving nothing: a testnet
   // grant approves an address with no code, and a Rialto-configured install is
   // about to be refused by a wall that never carried its router.
-  assert.match(SELFTEST, /TRADEABLE_CHAIN_ID/, "a non-mainnet grant must be called out");
+  //
+  // The chain caveat is in the PROBE, so the dashboard gets it too — a hosted
+  // tenant on testnet needs that sentence at least as much as a terminal user.
+  // The Rialto note stays CLI-only: swapVenue 'rialto' is not reachable from
+  // the hosted settings API, which strips the field.
+  assert.match(PROBE, /TRADEABLE_CHAIN_ID/, "a non-mainnet grant must be called out, on both surfaces");
   assert.match(SELFTEST, /swapVenue === "rialto"/, "a Rialto install must be told the wall will refuse");
+});
+
+test("the CLI and the dashboard run the SAME probe", () => {
+  // The hosted gap existed precisely because only one caller had one.
+  assert.match(PROBE, /async function runSelftestProbe/, "the shared probe must exist");
+  assert.match(SELFTEST, /runSelftestProbe\("selftest"\)/, "the CLI must call it");
+  assert.match(SRC, /runSelftestProbe\("dashboard"\)/, "the queued command must call it too");
 });

--- a/worker/src/store.ts
+++ b/worker/src/store.ts
@@ -1126,8 +1126,16 @@ export async function claimCommand(agentId: string): Promise<AgentCommand | null
   try {
     const row = (await getDb()
       .prepare(
+        // ORDERED BY (time, id), never by time alone. Milliseconds fixed the
+        // one-second collisions, and CI — on a faster machine than mine —
+        // found the next layer: two commands really can land in the SAME
+        // millisecond, and neither backend has a portable insertion-order
+        // tiebreak (sqlite's rowid is not in Postgres). The id is a uuid, so
+        // ties break arbitrarily but CONSISTENTLY, which is all a queue needs
+        // — and it makes claim and latestCommand agree about which one is
+        // which instead of each picking its own.
         `SELECT id, kind, created_at FROM agent_commands
-          WHERE agent_id = ? AND claimed_at IS NULL ORDER BY created_at ASC LIMIT 1`,
+          WHERE agent_id = ? AND claimed_at IS NULL ORDER BY created_at ASC, id ASC LIMIT 1`,
       )
       .get(agentId)) as { id: string; kind: string; created_at: number } | undefined;
     if (!row) return null;
@@ -1159,8 +1167,9 @@ export async function latestCommand(
   try {
     const r = (await getDb()
       .prepare(
+        // The mirror image of claimCommand's ordering — see there.
         `SELECT id, kind, created_at, claimed_at, done_at, result FROM agent_commands
-          WHERE agent_id = ? ORDER BY created_at DESC LIMIT 1`,
+          WHERE agent_id = ? ORDER BY created_at DESC, id DESC LIMIT 1`,
       )
       .get(agentId)) as Record<string, unknown> | undefined;
     if (!r) return null;

--- a/worker/src/store.ts
+++ b/worker/src/store.ts
@@ -324,6 +324,32 @@ const SQLITE_ALTERS: string[] = [
     // different process.
     "ALTER TABLE agents ADD COLUMN mode TEXT",
     "ALTER TABLE agents ADD COLUMN beat_at INTEGER",
+    // A ONE-WAY CHANNEL FROM THE DASHBOARD TO THE WORKER.
+    //
+    // The two run in separate processes — separate containers, hosted — and
+    // the worker has no HTTP server and no IPC. Everything the web side has
+    // ever been able to tell it went through a store the orchestrator polls,
+    // so this is that pattern rather than a new transport.
+    //
+    // Deliberately a QUEUE and not a flag. `claimed_at` makes a poller safe:
+    // the drain claims a row before acting on it, so a crash between claim and
+    // completion leaves the row claimed rather than replayed. For a command
+    // that spends gas, at-most-once is the only acceptable semantics — the
+    // same reasoning ledger-mirror.ts writes down for its own cursor.
+    `CREATE TABLE IF NOT EXISTS agent_commands (
+      id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      -- MILLISECONDS, supplied by the caller. unixepoch() is seconds, and two
+      -- commands queued in the same second then have no defined order —
+      -- neither backend has a portable tiebreak (sqlite's rowid is not in
+      -- Postgres). A queue whose order depends on the user being slow is not
+      -- a queue.
+      created_at INTEGER NOT NULL,
+      claimed_at INTEGER,
+      done_at INTEGER,
+      result TEXT
+    )`,
     // Measured execution quality: quoted-out vs received-out, in bps, positive
     // when the fill was worse than quoted. The slippage SETTING is one flat 1%
     // constant applied to a $5 trade and a $5,000 one alike; this is the
@@ -1062,6 +1088,94 @@ export async function listFlows(agentId: string, limit = 200): Promise<
   }[];
 }
 
+/** A command the dashboard has asked this agent to run. */
+export interface AgentCommand {
+  id: string;
+  kind: string;
+  createdAt: number;
+}
+
+/**
+ * Enqueue one command. Called by the web process, drained by the worker.
+ *
+ * The id is the caller's, so a double-clicked button is one command rather
+ * than two — the primary key does the deduping rather than a check-then-insert
+ * that could interleave.
+ */
+export async function enqueueCommand(agentId: string, id: string, kind: string): Promise<boolean> {
+  try {
+    await getDb()
+      .prepare("INSERT INTO agent_commands (id, agent_id, kind, created_at) VALUES (?, ?, ?, ?)")
+      .run(id, agentId, kind, Date.now());
+    return true;
+  } catch {
+    return false; // duplicate id, or an unwritable ledger
+  }
+}
+
+/**
+ * Claim the oldest unclaimed command for this agent, or null.
+ *
+ * CLAIM THEN ACT, never act then mark. The UPDATE ... WHERE claimed_at IS NULL
+ * is the whole concurrency story: two drains racing the same row, one wins,
+ * and a crash after the claim leaves it claimed rather than replayed. A
+ * command that spends gas must be at-most-once, and a poller gives no other
+ * way to get there.
+ */
+export async function claimCommand(agentId: string): Promise<AgentCommand | null> {
+  try {
+    const row = (await getDb()
+      .prepare(
+        `SELECT id, kind, created_at FROM agent_commands
+          WHERE agent_id = ? AND claimed_at IS NULL ORDER BY created_at ASC LIMIT 1`,
+      )
+      .get(agentId)) as { id: string; kind: string; created_at: number } | undefined;
+    if (!row) return null;
+    const claim = await getDb()
+      .prepare("UPDATE agent_commands SET claimed_at = unixepoch() WHERE id = ? AND claimed_at IS NULL")
+      .run(row.id);
+    if (claim.changes === 0) return null; // somebody else took it
+    return { id: row.id, kind: row.kind, createdAt: Number(row.created_at) };
+  } catch {
+    return null;
+  }
+}
+
+/** Record what a claimed command did. Never re-runs it; this is only the tape. */
+export async function finishCommand(id: string, result: string): Promise<void> {
+  try {
+    await getDb()
+      .prepare("UPDATE agent_commands SET done_at = unixepoch(), result = ? WHERE id = ?")
+      .run(result.slice(0, 500), id);
+  } catch {
+    /* the command ran; losing its receipt must not re-run it */
+  }
+}
+
+/** The most recent command for this agent, for the dashboard to poll. */
+export async function latestCommand(
+  agentId: string,
+): Promise<{ id: string; kind: string; createdAt: number; claimedAt: number | null; doneAt: number | null; result: string | null } | null> {
+  try {
+    const r = (await getDb()
+      .prepare(
+        `SELECT id, kind, created_at, claimed_at, done_at, result FROM agent_commands
+          WHERE agent_id = ? ORDER BY created_at DESC LIMIT 1`,
+      )
+      .get(agentId)) as Record<string, unknown> | undefined;
+    if (!r) return null;
+    return {
+      id: String(r.id),
+      kind: String(r.kind),
+      createdAt: Number(r.created_at),
+      claimedAt: r.claimed_at === null || r.claimed_at === undefined ? null : Number(r.claimed_at),
+      doneAt: r.done_at === null || r.done_at === undefined ? null : Number(r.done_at),
+      result: r.result === null || r.result === undefined ? null : String(r.result),
+    };
+  } catch {
+    return null;
+  }
+}
 /**
  * Record what the worker is doing, for surfaces that cannot read its files.
  *
@@ -1107,9 +1221,17 @@ export async function addFeeAccrual(
   }
 }
 
+/**
+ * `error` is the state that was missing, and its absence had a cost.
+ *
+ * An agent that cannot arm — an unrecognised policy in its grant, a corrupt
+ * blob, a permission id that will not reproduce — was indistinguishable from
+ * one that had simply never started. The condition lived in a stack trace on
+ * stdout and nowhere a dashboard, a query or an operator could reach it.
+ */
 export async function setAgentStatus(
   agentId: string,
-  status: "armed" | "active" | "killed" | "expired",
+  status: "armed" | "active" | "killed" | "expired" | "error",
 ): Promise<void> {
   try {
     await getDb().prepare("UPDATE agents SET status = ? WHERE smart_account = ?").run(status, agentId);


### PR DESCRIPTION
Four things, from one incident and two user complaints.

Yesterday ten hosted tenants sat in a crash loop unable to arm, for hours, and nobody knew. Separately a user with money in his account asked in the group chat **"Will it now start trading"** — looking at a screen that couldn't answer him — and another reported **"chat function ran out of coins"**.

## 1. Arm failures are visible

`createAgentExecutor` throwing escaped `syncGrant`, escaped `tick`, and landed in `runLoop`'s bare `console.error`: no event, no status, and `heartbeat()` never ran because it's called *after* `syncGrant` — so even staleness wasn't a signal.

Now caught: a durable `err` the owner sees, `agents.status` gains an `error` value, and the tick continues so the heartbeat keeps beating. Deduped on the reason — an owner scrolling the same sentence 1,400 times learns nothing the first one told them.

Plus one fleet line every reconcile: `fleet: 11 agent(s) — armed 9, error 2 — BROKEN 2`. Printed **unconditionally**, so its absence is also a signal. A summary that only appears when something is wrong teaches an operator to read silence as health, and silence is what a wedged process emits.

## 2. The hosted selftest exists

`merrymen selftest` is a CLI flag and the orchestrator spawns workers without it, so the one probe designed to answer *"can this agent transact"* was unreachable for every hosted tenant — which is how the outage above stayed invisible.

Commands now reach a worker as **files in its own home**, ferried by the orchestrator exactly as grants and settings already are. **The claim is an unlink:** `rm` is atomic, so the worker that deletes a command owns it, and deleting *before* acting means a crash loses a probe rather than replaying one that spends gas.

The CLI and dashboard run the **same** probe. Two copies drift, and the copy that drifts is the one nobody runs — which for months was the hosted one.

## 3. The home screen answers the question everyone arrives with

It led with TOTAL EQUITY, then "building today · no deposit on record yet", then cash/vault/positions. All true, none of it an answer.

> **Robin looked at 7 trades today and turned them down.**
> Passing is normal — it only buys when its own rules line up.

No jargon that isn't load-bearing; **never a claim we didn't check** (it has no clock, so it never says the market is closed); always a next step. A stuck agent outranks every happier truth — that ordering is what was missing while ten agents sat wedged behind a calm dashboard.

## 4. The scout stopped eating the budget chat needs

`groq 429: 195,881 of 200,000 tokens per day` — an LLM ranking pass running per tenant every ten minutes across eleven tenants on one shared house key.

**Every one of those rankings was unusable.** `scoutEnabled` defaults false and `scoutBudgetUsdg` to 0, so a scouted coin can't be bought at any size. The agent paid to produce a list it was forbidden to act on, with the budget its owner's chat needed. Now the paid step waits until somebody opts in; discovery still runs.

---

## Two critical defects in my own first attempt

Found by adversarial review **before** shipping. The command channel originally used a shared table the worker polled:

- It wrote the **tenant wallet** where the ledger keys on the **smart account** (`ensureAgent` returns `grant.smartAccount`).
- Hosted, the web writes Postgres while a child reads its own sqlite — `DATABASE_URL` is stripped from children on purpose.

Either alone made it inert. Together they'd have produced a button returning `200` and a status reading `queued` forever — on the exact surface built to detect a wedged fleet.

**My tests passed throughout,** because they drove enqueue and claim against one store handle with one constant key: structurally unable to catch a different key or a different database. That file now says so above its tests, and the seam is covered for real with directories and unlinks.

## Verification

`npm test` 1,502 passing · typecheck clean across worker/web/browser · build clean.

Status-line wording is fully unit-tested (11 cases: ordering, jargon, and the no-inventing rule). The file protocol is tested with real directories — two homes that can't see each other, a claim that can't happen twice, a result never mistaken for a command, no half-written file ever observed.

**Not yet proven end-to-end on the hosted deployment.** The ferry runs in the orchestrator and the drain in a child; I can't exercise that seam from here. The first real check is pressing the button after this deploys.
