### PR TITLE
Self-test button, bring-your-own LLM key, and an honest coins page

### DIFF
--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -328,14 +328,26 @@ export const HOUSE_KEY_FIELDS = [
   "bundlerUrl",
   "rpcMainnet",
   "rpcTestnet",
-  "groqApiKey",
-  "groqModel",
-  "anthropicApiKey",
-  "llmProvider",
-  "llmApiKey",
+  // THE LLM KEYS ARE NOT HERE ANY MORE — a tenant may bring their own.
+  //
+  // They were house-owned because the house pays for inference. That reasoning
+  // held right up until the house budget ran out: on 2026-08-31 the shared Groq
+  // key hit its daily limit and a user's CHAT stopped working, on a plan he had
+  // no way to top up, because the field was stripped before it reached the store.
+  //
+  // Now the house key is the DEFAULT and a tenant's own key OVERRIDES it — which
+  // falls out of `str(file, env)` for free: the settings file wins, env is the
+  // fallback. Bring a key and you get your own quota and your own choice of model;
+  // bring nothing and you get ours.
+  //
+  // Storing it is safe by the same mechanism that already holds a tenant's
+  // Telegram bot token: the settings blob is sealed at rest under a DEK held by
+  // the web and the orchestrator and never by a child (settings-store.ts).
+  //
+  // `llmBaseUrl` DOES stay house-owned, and the distinction is the whole point:
+  // a key is a credential the tenant pays with, a base URL is an address OUR
+  // egress would connect to. One is their money, the other is our SSRF.
   "llmBaseUrl",
-  "llmProviderModel",
-  "llmModel",
   "rialtoApiKey",
   "rialtoApiKeyHeader",
   "bitqueryApiKey",

--- a/web/src/app/app/Console.tsx
+++ b/web/src/app/app/Console.tsx
@@ -415,6 +415,11 @@ function Loaded({ feed, status }: { feed: FeedResponse | null; status: AgentStat
                   lastError: (feed?.events ?? []).find((e) => e.level === "err")?.message ?? null,
                 }}
               />
+              {/* Directly under the status line on purpose: the sentence says
+                  what it is doing, and this is how you check that sentence is
+                  true. Any further down and the person who doubts it never
+                  scrolls that far. */}
+              <SelftestButton />
               <section className="hero">
                 <div className="equity">
                   <div className="kick">Total equity</div>
@@ -603,6 +608,17 @@ function Loaded({ feed, status }: { feed: FeedResponse | null; status: AgentStat
                     <div className="cards">
                       {/* Said ONCE, above the grid — see DiscoveriesPayload.chain. */}
                       {chainGap(disc) && <div className="readfail">{chainGap(disc)}</div>}
+                      {/* THE ANSWER TO “why has it not bought anything”.
+                          Without this the page shows a wall of live coins and a busy
+                          agent and lets the owner conclude the agent is broken. It is
+                          not: there is nothing here it is able to buy. Say so. */}
+                      {disc.fresh.every((f) => (f.progressBps ?? 0) < 10_000) && (
+                        <div className="readfail">
+                          Your agent can&rsquo;t buy any of these yet — every one is still on its
+                          launch curve, and merrymen trades through Uniswap pools. There is
+                          nothing to change in settings; they become buyable if one graduates.
+                        </div>
+                      )}
                       {disc.fresh.map((f) => (
                         <FreshCard key={f.token} f={f} reachable={reach.has(f.token.toLowerCase())} />
                       ))}
@@ -636,6 +652,13 @@ function Loaded({ feed, status }: { feed: FeedResponse | null; status: AgentStat
                           {disc.verdictsWhy === "no-model"
                             ? "No model is wired up here, so nothing below has been looked at — these are the market’s numbers, not my opinion."
                             : "I tried to weigh these and the model turned me down, so no verdicts below. It retries on its own."}
+                        </div>
+                      )}
+                      {disc.rows.every((r) => r.onCurve) && (
+                        <div className="readfail">
+                          Your agent can&rsquo;t buy any of these yet — every one is still on its
+                          launch curve, so there is no pool to trade against. They become
+                          buyable if one graduates.
                         </div>
                       )}
                       {disc.rows.map((r) => (
@@ -706,6 +729,101 @@ function StatusBanner({ s }: { s: AgentSnapshot }) {
         <p className="sl-next">{line.next}</p>
       </div>
     </section>
+  );
+}
+
+/**
+ * PROVE IT CAN ACT — one real operation, for a fraction of a cent.
+ *
+ * The probe sends a policy-legal no-op through the whole pipeline: the bundler
+ * handshake, the session-key signature, the account contract's call policy, the
+ * EntryPoint prefund, account deployment, the receipt, the ledger row. It is
+ * the difference between an agent that LOOKS armed and one that has actually
+ * put a signed operation on-chain.
+ *
+ * Only reachable from a terminal until now (`merrymen selftest`), and hosted
+ * users have no terminal — which is how ten agents sat unable to arm for hours
+ * with nobody able to check.
+ *
+ * Three states, not two: queued and running look identical to somebody watching
+ * a spinner, and mean different things when it stops changing. Queued-forever is
+ * a worker that is not draining; running-forever is a probe that hung.
+ */
+function SelftestButton() {
+  const [state, setState] = useState<"idle" | "queued" | "running" | "done">("idle");
+  const [result, setResult] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Poll only while something is in flight. A dashboard that polls forever for
+  // a button nobody pressed is a cost with no reader.
+  useEffect(() => {
+    if (state !== "queued" && state !== "running") return;
+    let alive = true;
+    const tick = () =>
+      fetch("/api/selftest", { cache: "no-store" })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((d) => {
+          if (!alive || !d) return;
+          if (d.state === "done") {
+            setResult(d.result ?? "finished, with nothing to say");
+            setState("done");
+          } else if (d.state === "running" || d.state === "queued") {
+            setState(d.state);
+          }
+        })
+        .catch(() => {});
+    const t = setInterval(tick, 4_000);
+    tick();
+    return () => {
+      alive = false;
+      clearInterval(t);
+    };
+  }, [state]);
+
+  async function run() {
+    setErr(null);
+    setResult(null);
+    setState("queued");
+    try {
+      const r = await fetch("/api/selftest", { method: "POST" });
+      if (!r.ok) {
+        const d = await r.json().catch(() => ({}));
+        setErr(d.error ?? "couldn’t queue it");
+        setState("idle");
+      }
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setState("idle");
+    }
+  }
+
+  const busy = state === "queued" || state === "running";
+  const passed = result?.startsWith("PASSED") ?? false;
+
+  return (
+    <div className="selftest">
+      <button className="st-btn" onClick={() => void run()} disabled={busy}>
+        {state === "queued"
+          ? "queued — waiting for your agent to pick it up…"
+          : state === "running"
+            ? "running one real operation…"
+            : "check it can actually trade"}
+      </button>
+      {state === "idle" && !err && !result && (
+        <p className="st-note">
+          Sends one tiny real operation — a fraction of a cent of gas — to prove the whole
+          path works before you trust it with more.
+        </p>
+      )}
+      {err && <p className="st-note st-bad">{err}</p>}
+      {result && (
+        <p className={`st-note ${passed ? "st-good" : "st-bad"}`}>
+          {passed
+            ? "It works. A signed operation reached the chain and the ledger recorded it. (This proves the approve step, not the swap itself.)"
+            : result}
+        </p>
+      )}
+    </div>
   );
 }
 
@@ -966,7 +1084,34 @@ function CoinArt({ logo, symbol }: { logo: string; symbol: string }) {
 }
 
 /** Whether the agent could act on this coin at all, as a badge. */
-function Reach({ ok }: { ok: boolean }) {
+/**
+ * CAN THE AGENT ACTUALLY BUY THIS COIN.
+ *
+ * There are TWO different noes here and they used to render as one. A coin
+ * missing from the grant says "not added", and the fix is real: add it, re-sign,
+ * done. A coin still on its bonding curve has NO POOL, and merrymen trades one
+ * venue -- Uniswap v3 `exactInputSingle`. `curve-trade` exists as a type in
+ * policy.ts and nothing in this repo has ever produced one, so there is no code
+ * path that buys a curve token at any size, under any grant.
+ *
+ * Showing "not added" on a curve coin therefore promised a fix that does not
+ * work: the owner adds the token, pays for a re-sign, and the agent still cannot
+ * touch it. That is the exact shape of failure the rest of this codebase keeps
+ * refusing -- a screen that looks like it is telling you what to do while being
+ * wrong about what would happen. So the curve case is checked FIRST and says the
+ * true thing, which is that waiting is the only option.
+ */
+function Reach({ ok, onCurve }: { ok: boolean; onCurve: boolean }) {
+  if (onCurve) {
+    return (
+      <span
+        className="badge out"
+        title="This coin still trades on its launch curve, so there is no pool to trade against. merrymen buys through Uniswap only. Adding it to the grant will not help until it graduates."
+      >
+        no pool yet
+      </span>
+    );
+  }
   return ok ? (
     <span className="badge in" title="This coin is named in the signature the agent holds — it can trade it.">
       in range
@@ -1001,7 +1146,7 @@ function FreshCard({ f, reachable }: { f: FreshRow; reachable: boolean }) {
             <span>{f.trades} trades</span>
           </div>
         </div>
-        <Reach ok={reachable} />
+        <Reach ok={reachable} onCurve={(f.progressBps ?? 0) < 10_000} />
       </header>
 
       {pct !== null && (
@@ -1103,7 +1248,7 @@ function MarketCard({ r, reachable }: { r: DiscoveryRow; reachable: boolean }) {
 
       <footer>
         <span className="soc mute">{r.venue}</span>
-        <Reach ok={reachable} />
+        <Reach ok={reachable} onCurve={r.onCurve} />
       </footer>
     </article>
   );

--- a/web/src/app/app/console.css
+++ b/web/src/app/app/console.css
@@ -476,6 +476,29 @@
   font-family: var(--sans); font-size: 13px; line-height: 1.5;
   color: var(--text-dim); margin: 4px 0 0;
 }
+/* The prove-it button, sitting between the status line and the numbers. */
+.selftest { margin-bottom: 16px; }
+.st-btn {
+  font-family: var(--sans);
+  font-size: 13px;
+  color: var(--text-dim);
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 9px 14px;
+  cursor: pointer;
+  width: 100%;
+}
+.st-note {
+  font-family: var(--sans);
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-dim);
+  margin: 8px 2px 0;
+}
+.st-good { color: var(--green); }
+.st-bad { color: var(--red); }
+
 @media (max-width: 520px) {
   .sl-head { font-size: 14px; }
   .sl-next { font-size: 12.5px; }

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -290,7 +290,19 @@ export default function SettingsPage() {
   // One picker drives which key/model fields show. Groq & Anthropic reuse their
   // classic secret fields (old setups keep working); every other provider stores
   // its key in the generic llmApiKey.
-  const providers = view.llmProviders;
+  /**
+   * HOSTED, NOT EVERY PROVIDER IS OFFERABLE.
+   *
+   * `llmBaseUrl` stays in HOUSE_KEY_FIELDS, so a hosted tenant cannot point our
+   * egress anywhere -- which makes a custom endpoint a control that saves nothing,
+   * and a local model one our servers cannot reach at all. Listing either would be
+   * the same mistake as rendering thirty inert fields: an option that looks like it
+   * works. A KEY is offerable hosted because it is a credential the tenant pays
+   * with; an ADDRESS is not, because it is our SSRF.
+   */
+  const providers = view.llmProviders.filter(
+    (p) => hosted !== true || (p.id !== "custom" && p.needsKey !== false),
+  );
   const llmProviderVal = draft.llmProvider ?? view.values.llmProvider ?? "groq";
   const prov = providers.find((p) => p.id === llmProviderVal) ?? providers[0]!;
   const providerKeyField = prov.id === "groq" ? "groqApiKey" : prov.id === "anthropic" ? "anthropicApiKey" : "llmApiKey";
@@ -373,19 +385,25 @@ export default function SettingsPage() {
           {/* ── ESSENTIALS ─────────────────────────────────────────────── */}
           <div className="settings-section mono">essentials</div>
           <div className="grant-fields settings-grid">
-            {/* THE HOUSE RUNS THE BRAIN AND THE BUNDLER ON THE HOSTED SERVICE.
-                Everything between here and the strategy picker is stripped from
-                every hosted PUT by the settings API -- provider, key, model,
-                base URL, bundler, RPC. Rendering them anyway asked the owner to
-                configure a model and then told them it saved. One honest line
-                beats thirty inert controls. */}
-            {hosted === false && (
+            {/* THE BRAIN IS BRING-YOUR-OWN IN BOTH MODES.
+                This block used to be self-hosted only, on the reasoning that the
+                house pays for inference. That held until the house budget ran out:
+                the shared key hit its daily cap and a tenant's chat died on a plan
+                he had no way to top up, because the field was stripped before it
+                reached the store. The house key is now the DEFAULT and a tenant's
+                own key OVERRIDES it. Still gated on a RESOLVED `hosted` -- rendering
+                before we know would flash the wrong set of controls. */}
+            {hosted !== null && (
               <>
             {/* ── AI provider · bring any key ──────────────────────────── */}
               <Field
-                label="AI provider · the brain"
+                label={hosted ? "AI provider · optional, for a smarter brain" : "AI provider · the brain"}
                 action={prov.keyUrl ? { href: prov.keyUrl, label: providerNeedsKey ? "get a key" : "install" } : undefined}
-                hint={`Powers plain-English chat and the AI strategist. ${prov.blurb} Built-in strategies need no key at all. Blank keeps the saved key.`}
+                hint={`Powers plain-English chat and the AI strategist. ${prov.blurb} ${
+                  hosted
+                    ? "We run a free model for you, so this is optional — bring your own key for a faster, smarter one on your own quota."
+                    : "Built-in strategies need no key at all."
+                } Blank keeps the saved key.`}
               >
                 <select value={llmProviderVal} onChange={set("llmProvider")}>
                   {providers.map((p) => (
@@ -403,7 +421,11 @@ export default function SettingsPage() {
                 <Field
                   label={`${prov.label} API key`}
                   action={prov.keyUrl ? { href: prov.keyUrl, label: "get a key" } : undefined}
-                  hint="Paste the key for the provider you picked above. Never leaves your machine. Blank keeps the saved key."
+                  hint={
+                    hosted
+                      ? "Paste your own key and your agent uses it instead of ours — your quota, your choice of model, no daily cap shared with anyone. Stored encrypted and never shown again. Blank keeps the saved key."
+                      : "Paste the key for the provider you picked above. Never leaves your machine. Blank keeps the saved key."
+                  }
                 >
                   <input
                     type="password"
@@ -418,7 +440,9 @@ export default function SettingsPage() {
                   )}
                 </Field>
               )}
-              {prov.id === "custom" && (
+              {/* SELF-HOSTED ONLY, and deliberately. See the providers filter above:
+                  the key is the tenant's money, the URL is our egress. */}
+              {hosted === false && prov.id === "custom" && (
                 <Field label="base URL" hint="Any OpenAI-compatible endpoint, e.g. https://your-host/v1">
                   <input type="text" placeholder="https://…/v1" value={v("llmBaseUrl")} onChange={set("llmBaseUrl")} />
                 </Field>
@@ -453,8 +477,8 @@ export default function SettingsPage() {
             )}
             {hosted === true && (
               <Field
-                label="brain &amp; bundler"
-                hint="On merrymen.dev these are run for you -- the model that powers chat and the strategist, and the bundler that puts trades on chain. There is nothing to paste and nothing to pay for. Self-host if you want to bring your own."
+                label="bundler"
+                hint="The piece that puts your trades on chain. On merrymen.dev it is run for you -- nothing to paste and nothing to pay for. Self-host if you want to bring your own."
               >
                 <div className="settings-subtle mono" style={{ padding: "6px 0" }}>
                   run by the house

--- a/worker/src/settings-hosted.test.ts
+++ b/worker/src/settings-hosted.test.ts
@@ -47,7 +47,10 @@ describe("hosted mode strips house keys so server env wins", () => {
     });
     assert.equal(c.bundlerApiKey, "server-bundler-key", "tenant bundler key ignored");
     assert.equal(c.rpcMainnet, "https://server/rpc", "tenant RPC ignored");
-    assert.equal(c.groqApiKey, "server-groq-key", "tenant LLM key ignored");
+    // A TENANT MAY BRING THEIR OWN LLM KEY, hosted or not. The house key is the
+    // default, not the ceiling — see HOUSE_KEY_FIELDS. The SSRF-shaped sibling
+    // (`llmBaseUrl`) is asserted below and still cannot survive.
+    assert.equal(c.groqApiKey, "tenant-groq-key", "a tenant may bring their own LLM key");
     // No server env for these → they resolve to nothing, NOT the tenant's value.
     assert.equal(c.bundlerUrl, undefined, "tenant bundler URL cannot survive");
     assert.equal(c.llmBaseUrl, undefined, "tenant LLM base URL (SSRF vector) cannot survive");


### PR DESCRIPTION
Three things a user asked for, in the order he asked.

## 1. Where is the self-test button

`merrymen selftest` sends one policy-legal no-op through the entire pipeline — bundler handshake, session-key signature, the account contract's call policy, EntryPoint prefund, deployment, receipt, ledger row. It is the difference between an agent that *looks* armed and one that has put a signed operation on chain.

It was reachable only from a terminal. Hosted users have no terminal — which is how ten agents sat unable to arm for hours with nobody able to check.

It now sits **directly under the status line**. Any further down and the person who doubts that line never scrolls to it.

Three states, not two. Queued and running look identical to somebody watching a spinner and mean different things when it stops changing: queued-forever is a worker that is not draining, running-forever is a probe that hung.

## 2. Let users bring their own API key

The LLM keys were in `HOUSE_KEY_FIELDS`, so the hosted settings API deleted them on the way in and the settings page did not render the fields at all.

That was right while the house paid for inference, and stopped being right when the house budget ran out — the shared Groq key hit its daily cap and a user's chat died on a plan he had no way to top up.

The house key is now the **default**, and a tenant's own key **overrides** it. That falls out of `str(file, env)` for free: the settings file wins, env is the fallback. Storage is safe by the mechanism that already holds a tenant's Telegram bot token — the blob is sealed at rest under a DEK held by the web and orchestrator, never by a child.

`llmBaseUrl` **stays** house-owned, and the distinction is the whole point:

> a key is a credential the tenant pays with, a base URL is an address OUR egress would connect to. One is their money, the other is our SSRF.

For the same reason the hosted provider list drops `custom` and local models: a hosted tenant cannot point our egress anywhere, so offering those would be a control that saves nothing.

## 3. "It should pick up trades from the coins section"

**It cannot, and this PR makes the page say so rather than fixing it quietly.**

Every one of the 75 coins the scout has surfaced is pre-graduation — `no pool yet, trades on its curve`, 75/75, zero graduated. merrymen trades one venue: Uniswap v3 `exactInputSingle`. `curve-trade` exists as a type in `policy.ts` and **nothing in this repo has ever produced one**, so there is no code path that buys a curve token at any size, under any grant, on any strategy.

The badge said `not added`, whose tooltip promises a fix that does not work: add the token, pay for a re-sign, and the agent still cannot touch it. That is a screen that looks like it is telling you what to do while being wrong about what would happen.

It now says `no pool yet` and states that waiting is the only option, plus one line above the grid so an owner watching a busy agent buy nothing knows it is not broken.

Buying curve tokens is a real feature (Pons bonding-curve ABI, a buy path, wall permissions, grant sealing). It is not in this PR.

---

Tests 1503/1503, web build clean.