### PR TITLE
Stop telling a funded owner his money is missing

### DIFF
--- a/web/src/app/app/status-line.test.ts
+++ b/web/src/app/app/status-line.test.ts
@@ -35,6 +35,28 @@ test("HIS EXACT SITUATION gets an answer, not a balance sheet", () => {
   assert.equal(l.tone, "good");
 });
 
+test("MONEY IN, NO GAS: it does not tell him his money is missing", () => {
+  // Verbatim from the group chat, $15 in the account:
+  //   “It says it can't trade” / “Because no ETH” / “But there is 15 bucks in it”
+  // The old line named only the missing asset, so a person who had just
+  // funded the account read it as a denial that he had.
+  const l = statusLine({ ...base, hasGas: false, cashUsdg: 15 });
+  assert.match(l.headline, /\$15/, "names the money he actually sent");
+  assert.match(l.headline, /no ETH to pay the fees/);
+  assert.match(l.next, /Your money is there/, "answers the objection before he makes it");
+  // The load-bearing explanation: two assets, not one.
+  assert.match(l.next, /separate thing from the dollars you trade with/);
+  assert.equal(l.tone, "waiting");
+});
+
+test("NO MONEY AND NO GAS still gets the plain sentence", () => {
+  // The empty-account case must not claim a balance that is not there.
+  const l = statusLine({ ...base, hasGas: false, cashUsdg: 0 });
+  assert.match(l.headline, /no ETH for fees/);
+  assert.doesNotMatch(l.next, /Your money is there/);
+  assert.equal(l.tone, "waiting");
+});
+
 test("A STUCK AGENT SAYS SO, above everything else", () => {
   // The failure that hid a fleet-wide outage for hours: ten agents unable to
   // arm, every dashboard showing a calm page of stale numbers.
@@ -83,9 +105,16 @@ test("practice is called practice, in words a person uses", () => {
 });
 
 test("no gas is distinguished from no capital — different problems, different fixes", () => {
+  // FUNDED but ungassed — the case the group chat hit. Names the money first,
+  // because the person reading it has already sent some.
   const noGas = statusLine({ ...base, hasGas: false });
-  assert.match(noGas.headline, /no ETH for fees/);
-  assert.match(noGas.next, /Send a little ETH/);
+  assert.match(noGas.headline, /no ETH to pay the fees/);
+  assert.match(noGas.next, /separate thing from the dollars you trade with/);
+
+  // EMPTY and ungassed — the plain sentence, claiming no balance it cannot see.
+  const bare = statusLine({ ...base, hasGas: false, cashUsdg: 0 });
+  assert.match(bare.headline, /no ETH for fees/);
+  assert.match(bare.next, /Send a little ETH/);
 
   const noCash = statusLine({ ...base, cashUsdg: 0 });
   assert.match(noCash.headline, /nothing to trade with/);
@@ -125,7 +154,12 @@ test("NO JARGON anywhere in any branch", () => {
   // a trailing unit on a number: "318.00 USDG" is what made a balance look like
   // telemetry.
   const banned = /equity|session key|steady-basket|weekend-gap|bps|wall|grant|positions/i;
-  const unitSuffix = /[d.,]s*USDG/;
+  // ESCAPES COLLAPSED HERE ONCE ALREADY. This read /[d.,]s*USDG/ -- a literal
+  // 'd', '.' or ',' followed by literal 's' characters -- so it matched none of
+  // the strings it exists to ban. "318.00 USDG", the exact example the comment
+  // above names, sailed through it. A guard that cannot fire is worse than no
+  // guard, because the suite reports it as passing.
+  const unitSuffix = /[\d.,]\s*USDG/;
   const cases: AgentSnapshot[] = [
     base,
     { ...base, mode: "paper" },

--- a/web/src/app/app/status-line.ts
+++ b/web/src/app/app/status-line.ts
@@ -105,12 +105,35 @@ export function statusLine(a: AgentSnapshot): StatusLine {
       tone: "stuck",
     };
   }
+  // NO GAS — and this branch has to survive the fact that the owner has
+  // usually ALREADY SENT MONEY.
+  //
+  // A user in the group chat, with $15 in the account: “It says it can't
+  // trade. Because no ETH. But there is 15 bucks in it.” Both statements
+  // were true. On this chain the money you TRADE with (USDG) and the money
+  // you pay FEES with (ETH) are different assets, and a sentence that names
+  // only the missing one reads as “your money is not there” to the person
+  // who just sent it. He is not confused about his balance; the screen is
+  // confused about what he already did.
+  //
+  // So when there IS cash, say so first and name the two-asset thing
+  // outright. Rule 2 still holds: this claims nothing it did not check —
+  // `cashUsdg` and `hasGas` are both read from the same snapshot.
   if (!a.hasGas) {
-    return {
-      headline: `${name} can't trade yet — the account has no ETH for fees.`,
-      next: "Send a little ETH to the account address. A few dollars covers many trades.",
-      tone: "waiting",
-    };
+    return a.cashUsdg > 0
+      ? {
+          headline: `${name} has ${money(a.cashUsdg)} to trade with, but no ETH to pay the fees.`,
+          next:
+            "Your money is there. This chain charges fees in ETH, which is a separate thing from " +
+            "the dollars you trade with, so the account needs a little of both. A few dollars of ETH " +
+            "covers many trades — send it to the same account address.",
+          tone: "waiting",
+        }
+      : {
+          headline: `${name} can't trade yet — the account has no ETH for fees.`,
+          next: "Send a little ETH to the account address. A few dollars covers many trades.",
+          tone: "waiting",
+        };
   }
 
   // ── Practice ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
A user in the group chat, $15 in the account:

> "It says it can't trade"
> "Because no ETH"
> "But there is 15 bucks in it"

Every statement true. On this chain the money you **trade** with (USDG) and the money you pay **fees** with (ETH) are different assets, and the status line named only the missing one. To someone who had just funded the account, that reads as *"your money is not there"*. He is not confused about his balance — the screen is confused about what he already did.

**Funded but ungassed** now leads with the money:

> Robin has $15 to trade with, but no ETH to pay the fees.
> Your money is there. This chain charges fees in ETH, which is a separate thing from the dollars you trade with, so the account needs a little of both. A few dollars of ETH covers many trades — send it to the same account address.

**Empty and ungassed** keeps the old plain sentence. Claiming a balance we cannot see is exactly what this file's rule 2 forbids, and both cases are now tested separately.

## A test guard that could never fire

While in the file: `unitSuffix` read

```
/[d.,]s*USDG/
```

That is a literal `d`, `.` or `,` followed by literal `s` characters — not the character classes it meant. It exists to ban "USDG as a trailing unit", and `"318.00 USDG"` — the precise example its own comment names as what made a balance look like telemetry — sailed straight through it.

```
"318.00 USDG"   broken: false   fixed: true
"15 USDG"       broken: false   fixed: true
"200USDG"       broken: false   fixed: true
```

Now `/[\d.,]\s*USDG/`, and the current copy passes it honestly.

This is the **third** escape-collapse of this shape in this repo — after `/s+/g` (which deleted every letter "s" from pre-submit error messages) and `\b` written one layer short (which became a literal U+0008 BACKSPACE in the revert table). The pattern is always a regex written through a generator, and the tell is always that the guard goes **quiet** rather than loud.

---

Tests 1505/1505, web build clean.