### PR TITLE
Name the network wherever we ask for money

### DIFF
--- a/web/src/app/app/status-line.test.ts
+++ b/web/src/app/app/status-line.test.ts
@@ -57,6 +57,43 @@ test("NO MONEY AND NO GAS still gets the plain sentence", () => {
   assert.equal(l.tone, "waiting");
 });
 
+test("EVERY REQUEST FOR MONEY NAMES THE NETWORK", () => {
+  // A user sent ETH to his account address and it never showed. The address
+  // held 0.004268 ETH on ETHEREUM MAINNET; on Robinhood Chain it had never been
+  // touched (zero balance, nonce 0). He was given an address and no network, and
+  // an address is valid on every EVM chain — so the omission is the bug.
+  const asksForMoney: AgentSnapshot[] = [
+    { ...base, hasGas: false, cashUsdg: 15 }, // funded, ungassed
+    { ...base, hasGas: false, cashUsdg: 0 }, // empty, ungassed
+    { ...base, cashUsdg: 0 }, // live, no capital
+  ];
+  for (const s of asksForMoney) {
+    const l = statusLine(s);
+    assert.match(
+      l.next,
+      /Robinhood Chain/,
+      `asked for money without naming the network: ${l.next}`,
+    );
+  }
+});
+
+test("the wrong-chain warning is on the gas asks, where the mistake happens", () => {
+  // The observed failure was ETH on Ethereum, so the ETH asks say so outright.
+  for (const s of [
+    { ...base, hasGas: false, cashUsdg: 15 },
+    { ...base, hasGas: false, cashUsdg: 0 },
+  ]) {
+    assert.match(statusLine(s).next, /Ethereum/, "names the chain it actually lands on");
+  }
+});
+
+test("on the practice chain it does not say Robinhood Chain", () => {
+  // Rule 2: do not send somebody to mainnet from a testnet screen.
+  const l = statusLine({ ...base, testnet: true, hasGas: false, cashUsdg: 0 });
+  assert.match(l.next, /practice chain/);
+  assert.doesNotMatch(l.next, /Robinhood Chain/);
+});
+
 test("A STUCK AGENT SAYS SO, above everything else", () => {
   // The failure that hid a fleet-wide outage for hours: ten agents unable to
   // arm, every dashboard showing a calm page of stale numbers.

--- a/web/src/app/app/status-line.ts
+++ b/web/src/app/app/status-line.ts
@@ -79,8 +79,27 @@ function firstSentence(s: string, max = 160): string {
   return cut.length > max ? `${cut.slice(0, max - 1).trimEnd()}…` : cut;
 }
 
+/**
+ * NAME THE NETWORK, EVERY TIME WE ASK FOR MONEY.
+ *
+ * A user sent ETH to his account address and reported it “appearing in the
+ * wallet”, then “topped up a wallet but nothing's showing”. His address held
+ * 0.004268 ETH — on ETHEREUM MAINNET. On Robinhood Chain it had never been
+ * touched: zero balance, zero USDG, nonce 0.
+ *
+ * He did nothing wrong. He was given an address and no network, and an
+ * address is valid on every EVM chain — which is exactly why naming one is
+ * not decoration. The funds are not lost (he controls the key) but they are
+ * on the wrong chain, and nothing in this app ever told him which chain it
+ * wanted.
+ */
+function network(testnet: boolean): string {
+  return testnet ? "the practice chain" : "Robinhood Chain";
+}
+
 export function statusLine(a: AgentSnapshot): StatusLine {
   const name = a.name || "Your agent";
+  const net = network(a.testnet);
 
   // ── Stuck: it cannot work, and no amount of waiting changes that ─────────
   //
@@ -126,12 +145,15 @@ export function statusLine(a: AgentSnapshot): StatusLine {
           next:
             "Your money is there. This chain charges fees in ETH, which is a separate thing from " +
             "the dollars you trade with, so the account needs a little of both. A few dollars of ETH " +
-            "covers many trades — send it to the same account address.",
+            `covers many trades — send it to the same account address, on ${net}. ETH sent on ` +
+            "Ethereum, Base or any other network will not arrive here.",
           tone: "waiting",
         }
       : {
           headline: `${name} can't trade yet — the account has no ETH for fees.`,
-          next: "Send a little ETH to the account address. A few dollars covers many trades.",
+          next:
+            `Send a little ETH to the account address, on ${net} — not Ethereum or Base, which is ` +
+            "where it most often ends up. A few dollars covers many trades.",
           tone: "waiting",
         };
   }
@@ -188,7 +210,7 @@ export function statusLine(a: AgentSnapshot): StatusLine {
   if (a.cashUsdg <= 0) {
     return {
       headline: `${name} is live but has nothing to trade with.`,
-      next: "Send USDG to the account address and it starts working.",
+      next: `Send USDG to the account address, on ${net}, and it starts working.`,
       tone: "waiting",
     };
   }


### PR DESCRIPTION
A user, twice:

> "sent it but it's appearing in the wallet?"

and the next day:

> "Hey, I've topped up a wallet but nothings showing"
> `0x1102b20c835ff07DCA4eDC15F0B4C7d805bbB22F`

## Diagnosis

I checked that address on chain, read-only:

| chain | ETH | USDG | nonce |
|---|---|---|---|
| Robinhood Chain (4663) | 0 | 0 | **0 — never touched** |
| Robinhood testnet (46630) | 0 | — | — |
| Base / Arbitrum / Optimism | 0 | — | 0 |
| **Ethereum mainnet** | **0.004268** | — | 0 |

His money is on **Ethereum mainnet**. It is not lost — he controls the key — but it is on a chain the agent cannot see.

## The bug is ours

He did nothing wrong. He was handed an address and **no network**, and an address is valid on every EVM chain — which is exactly why naming one is not decoration.

Every branch that asks for money now names the network, and the two ETH asks name the chain the mistake actually lands on:

> …covers many trades — send it to the same account address, **on Robinhood Chain**. ETH sent on Ethereum, Base or any other network will not arrive here.

## Tested as an invariant, not three strings

```
for (const s of asksForMoney) assert.match(statusLine(s).next, /Robinhood Chain/)
```

so a future branch that forgets to name the network fails the suite rather than shipping. And on the practice chain it says "the practice chain" and must **not** say Robinhood Chain — sending somebody to mainnet from a testnet screen is the same bug pointed the other way.

---

Third funding-confusion report in two days (two assets, then wrong chain). Worth noting the structural fix separately: a paymaster would delete the ETH requirement entirely, and a "where is my money" check across common chains would have answered this in one click — I found it in three RPC calls.

Tests 1508/1508, web build clean.