### PR TITLE
Curve buying, stages 1-10: quote, mirror, config, producer, books, venue

### DIFF
--- a/contracts/scripts/deploy-ponsselftrade.ts
+++ b/contracts/scripts/deploy-ponsselftrade.ts
@@ -25,6 +25,12 @@
  * verify — and the deployment one less thing to get wrong.
  */
 import hre from "hardhat";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ESM has no __dirname; deployments.json sits beside contracts/scripts.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /** The only chains this should ever touch. Anything else is a mistake. */
 const KNOWN_CHAINS: Record<number, string> = {
@@ -100,8 +106,38 @@ async function main() {
     throw new Error("tradeExactIn is not non-payable — do NOT use this deployment.");
   }
 
+  // PERSIST THE ADDRESS. This script only ever printed it, which is why the
+  // question "is the adapter deployed?" could not be answered from the repo, from
+  // git history on any branch, or from a running worker's home -- an audit had to
+  // conclude "there is no candidate address to even check". A deployment that
+  // exists only in a shell's scrollback is a deployment nobody can verify, and
+  // re-deploying to find out produces a DIFFERENT address that invalidates any
+  // grant already sealed against the old one.
+  //
+  // Keyed by chain id, because one flat value cannot serve two chains that
+  // produce different addresses and /grant offers a two-click chain switch.
+  const file = path.join(__dirname, "..", "deployments.json");
+  let book: Record<string, Record<string, { address: string; deployedAt: string; codeBytes: number }>> = {};
+  try {
+    book = JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    /* first deployment on any chain */
+  }
+  const chainKey = String(chainId);
+  book[chainKey] = {
+    ...(book[chainKey] ?? {}),
+    PonsSelfTrade: {
+      address: adapter.address,
+      deployedAt: new Date().toISOString(),
+      codeBytes: (code.length - 2) / 2,
+    },
+  };
+  writeFileSync(file, JSON.stringify(book, null, 2) + "
+");
+
   console.log("");
   console.log(`✓ PonsSelfTrade deployed at ${adapter.address}`);
+  console.log(`  recorded in contracts/deployments.json under chain ${chainKey} — COMMIT THIS`);
   console.log(`  code : ${(code.length - 2) / 2} bytes`);
   console.log("");
   console.log("next steps:");
@@ -111,7 +147,7 @@ async function main() {
   console.log("  3. unset MERRYMEN_DEPLOYER_PRIVATE_KEY / close this shell");
   console.log("");
   console.log("what this does NOT unlock, so it is not a surprise later:");
-  console.log("  - native-ETH-quoted curves (53.6% of launches). The adapter is non-payable;");
+  console.log("  - native-ETH-quoted curves (~47% of launches, measured over 5,730 across four");
   console.log("    those need a different selector and a different threat model.");
   console.log("  - any curve whose token you have not added in /settings and re-signed for.");
 }

--- a/web/src/app/api/settings/route.ts
+++ b/web/src/app/api/settings/route.ts
@@ -231,7 +231,11 @@ export async function PUT(req: Request) {
   const stored = await readStored(tenant);
   const next: MerrymenSettings = { ...stored };
 
+  // Every settings key this request actually processed. Used at the end to
+  // name what was DROPPED — see the note above the `ignored` computation.
+  const touched = new Set<string>();
   const setOrClear = <K extends keyof MerrymenSettings>(key: K, value: MerrymenSettings[K] | undefined) => {
+    touched.add(key as string);
     if (value === undefined) delete next[key];
     else next[key] = value;
   };
@@ -375,6 +379,19 @@ export async function PUT(req: Request) {
       setOrClear("v4AdapterAddress", v.trim());
     else errors.push("v4AdapterAddress: must be a 0x… address");
   }
+  // THE PONS ADAPTER. Absent from this allowlist until now, which made the
+  // deploy script's own instruction ("paste the address into /settings") and
+  // docs/owner-runbook-pons.md impossible to follow: this handler is the only
+  // writer of the hosted tenant store, and an unknown key returned {ok:true}
+  // with the field silently dropped. See the unknown-key rejection below —
+  // silent success is why a documented-but-unwired field went unnoticed.
+  if ("ponsAdapterAddress" in body) {
+    const v = body.ponsAdapterAddress;
+    if (v === "" || v === null || v === undefined) setOrClear("ponsAdapterAddress", undefined);
+    else if (typeof v === "string" && /^0x[0-9a-fA-F]{40}$/.test(v.trim()))
+      setOrClear("ponsAdapterAddress", v.trim());
+    else errors.push("ponsAdapterAddress: must be a 0x… address");
+  }
   // $MERRYMEN holder wallet — a read-only address for the Merry Circle fee tier.
   if ("holderAddress" in body) {
     const v = body.holderAddress;
@@ -515,6 +532,30 @@ export async function PUT(req: Request) {
     }
   }
 
+  // NAME WHAT WE DROPPED, so a documented-but-unwired field cannot hide again.
+  //
+  // This handler is an allowlist with no else, and it is the ONLY writer of the
+  // hosted tenant store. A key it does not know about produced {ok:true} and
+  // vanished. Not hypothetical: deploy-ponsselftrade.ts and the Pons runbook both
+  // told the owner to save `ponsAdapterAddress` here, and for as long as that
+  // branch was missing the instruction was impossible to follow and said so to
+  // nobody.
+  //
+  // REPORTED, NOT REJECTED, deliberately. A 400 on unknown keys is the stricter
+  // fix and would break every client that round-trips a settings blob containing
+  // a field this build does not know — an older dashboard tab open against a
+  // newer server, every hosted tenant at once. Trading a silent drop for a
+  // fleet-wide save failure is a bad trade. Visibility is the property that was
+  // actually missing.
+  //
+  // A key that FAILED validation is not ignored — it is in `errors`, which is
+  // already loud — so those are excluded rather than reported twice.
+  const errored = new Set(errors.map((e) => e.split(":")[0]?.trim()).filter(Boolean));
+  const ignored = Object.keys(body).filter((k) => !touched.has(k) && !errored.has(k));
+  if (ignored.length > 0) {
+    console.warn(`[settings] ignored unknown keys: ${ignored.join(", ")}`);
+  }
+
   if (errors.length > 0) return NextResponse.json({ errors }, { status: 400 });
 
   if (tenant) {
@@ -529,5 +570,11 @@ export async function PUT(req: Request) {
     await writeFile(SETTINGS_FILE, JSON.stringify(next, null, 2), { encoding: "utf8", mode: 0o600 });
     await chmod(SETTINGS_FILE, 0o600).catch(() => {});
   }
-  return NextResponse.json({ ok: true, appliesWithin: "one worker tick" });
+  return NextResponse.json({
+    ok: true,
+    appliesWithin: "one worker tick",
+    // Present only when something was dropped, so a caller can tell the
+    // difference between 'saved' and 'saved, minus the field you cared about'.
+    ...(ignored.length > 0 ? { ignored } : {}),
+  });
 }

--- a/web/src/app/grant/page.tsx
+++ b/web/src/app/grant/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
-import { formatEther } from "viem";
+import { createPublicClient, formatEther, http } from "viem";
 import { Info } from "@/components/Info";
 import { LogoMark } from "@/components/Logo";
 import {
@@ -14,7 +14,7 @@ import {
   tokenCoverage,
   TRADEABLE_V2,
   uncoveredBasketSymbols,
-  type CustomToken,
+  type CustomToken,  PONS_SELFTRADE_ABI,
 } from "@merrymen/core";
 import {
   clearGrant,
@@ -133,6 +133,101 @@ const sameCaps = (a: GrantCaps, b: GrantCaps) =>
 
 const BACKUP_KEY = "merrymen.grant.backedup.v1";
 const TESTNET = robinhoodTestnet.id; // 46630 — the sandbox
+
+/**
+ * VERIFY AN ADAPTER ADDRESS BEFORE IT IS SEALED, not after.
+ *
+ * WHY THIS IS NOT PARANOIA. Sealing an adapter does two things, and the second
+ * is easy to miss: `allowedSpenders()` appends the address to the spender ONE_OF
+ * of EVERY approve permission in the grant (packages/core/src/wall.ts), and the
+ * non-USDG approves pass `null` as the amount condition — which wall.ts itself
+ * calls "a standing licence to move every share the agent holds". So one wrong
+ * or stale value typed into one dashboard field becomes an unbounded pull target
+ * across the whole token book, sealed into a signature, unseen.
+ *
+ * The worker already checks this — and too late. Its `eth_getCode` gate runs at
+ * ARM time, which is after the owner has signed, after the grant is stored, and
+ * after the only cheap moment to say no has passed. The cost of catching it
+ * there is a wasted re-sign; the cost of not catching it at all is the paragraph
+ * above.
+ *
+ * TWO CHECKS, because they fail differently:
+ *   1. code exists at the address on THIS chain — catches a typo, an address
+ *      from the other chain, an EOA pasted by mistake, and a contract that was
+ *      never actually deployed;
+ *   2. the code answers the shape we expect — `tradeExactIn` is present. Catches
+ *      a real, live, wrong contract, which check 1 waves straight through. The
+ *      deploy script performs the same ABI check for the same reason.
+ *
+ * REFUSES RATHER THAN SEALING SOMETHING UNVERIFIED. Returning `undefined` on
+ * failure would mint a grant with no curve route, quietly — the owner would
+ * think they had sealed it and find out at the first trade. Throwing puts the
+ * failure where the owner is already looking.
+ */
+async function verifiedAdapter(
+  address: `0x${string}` | undefined,
+  chainId: number,
+  onStatus: (s: string) => void,
+): Promise<`0x${string}` | undefined> {
+  if (!address) return undefined;
+  onStatus("checking the curve adapter before sealing it…");
+  const chain = chainId === robinhoodTestnet.id ? robinhoodTestnet : robinhoodChain;
+  const client = createPublicClient({ chain, transport: http() });
+
+  let code: string;
+  try {
+    code = (await client.getCode({ address })) ?? "0x";
+  } catch (e) {
+    throw new Error(
+      `Could not check the curve adapter ${address} on ${chain.name}: ${
+        e instanceof Error ? e.message : String(e)
+      }. Refusing to seal an address nobody has verified — it would become an approved spender for every token in this grant.`,
+    );
+  }
+  if (!code || code === "0x") {
+    throw new Error(
+      `No contract at ${address} on ${chain.name}. That is usually an address from the other chain, ` +
+        `a typo, or a deploy that never happened. Sealing it would make it an approved spender for every ` +
+        `token in this grant, so nothing is signed. Fix it at /settings and try again.`,
+    );
+  }
+
+  // SHAPE CHECK. A live contract at the right address on the right chain can
+  // still be the wrong contract entirely, and check 1 cannot tell.
+  try {
+    await client.readContract({
+      address,
+      abi: PONS_SELFTRADE_ABI,
+      functionName: "tradeExactIn",
+      args: [
+        "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000",
+        0n,
+        0n,
+        0n,
+      ],
+    });
+  } catch (e) {
+    // A REVERT IS A PASS. The call is deliberately invalid — zero addresses, zero
+    // amount, a deadline in 1970 — so the real adapter MUST reject it. What we
+    // are testing is that it rejected it as that function rather than failing to
+    // find one. viem reports a missing function differently from a revert, and
+    // only the former disqualifies the address.
+    const msg = e instanceof Error ? e.message : String(e);
+    if (/does not exist|not found|returned no data|function.*selector/i.test(msg)) {
+      throw new Error(
+        `The contract at ${address} on ${chain.name} is not a PonsSelfTrade adapter — it has no ` +
+          `tradeExactIn function. Sealing it would make the wrong contract an approved spender for every ` +
+          `token in this grant, so nothing is signed.`,
+      );
+    }
+  }
+
+  onStatus("curve adapter verified.");
+  return address;
+}
+
 const MAINNET = robinhoodChain.id; // 4663 — real funds
 
 function short(a: string): string {
@@ -304,6 +399,7 @@ export default function GrantPage() {
   // The deployed V4SelfSwap for this install, read from /settings. Sealed into
   // the wall at signing — which is why it is read here and not at trade time.
   const [v4Adapter, setV4Adapter] = useState<`0x${string}` | undefined>(undefined);
+  const [ponsAdapter, setPonsAdapter] = useState<`0x${string}` | undefined>(undefined);
   // The basket matters here for the same reason: /settings offers every registry
   // symbol, but only the ones sealed into the signature can be sold.
   const [basketSymbols, setBasketSymbols] = useState<string[]>([]);
@@ -341,12 +437,14 @@ export default function GrantPage() {
       .catch(() => setSession(null));
     fetch("/api/settings")
       .then((r) => (r.ok ? r.json() : null))
-      .then((v: { values?: { customTokens?: unknown[]; basketSymbols?: string[]; v4AdapterAddress?: string }; defaults?: { basketSymbols?: string[] } } | null) => {
+      .then((v: { values?: { customTokens?: unknown[]; basketSymbols?: string[]; v4AdapterAddress?: string; ponsAdapterAddress?: string }; defaults?: { basketSymbols?: string[] } } | null) => {
         const list = (v?.values?.customTokens ?? []).filter(isValidCustomToken);
         setCustomTokens(list as CustomToken[]);
         setBasketSymbols(v?.values?.basketSymbols ?? v?.defaults?.basketSymbols ?? []);
         const a = v?.values?.v4AdapterAddress;
         setV4Adapter(typeof a === "string" && /^0x[0-9a-fA-F]{40}$/.test(a) ? (a as `0x${string}`) : undefined);
+        const pa = v?.values?.ponsAdapterAddress;
+        setPonsAdapter(typeof pa === "string" && /^0x[0-9a-fA-F]{40}$/.test(pa) ? (pa as `0x${string}`) : undefined);
       })
       .catch(() => {
         setCustomTokens([]);
@@ -447,6 +545,7 @@ export default function GrantPage() {
         chainId,
         extraTokens: customTokens,
         v4AdapterAddress: v4Adapter,
+        ponsAdapterAddress: await verifiedAdapter(ponsAdapter, chainId, setStatus),
         hostedAs: session.hosted ? (session.address ?? undefined) : undefined,
       });
       setGrant(g);
@@ -497,6 +596,7 @@ export default function GrantPage() {
         chainId,
         extraTokens: customTokens,
         v4AdapterAddress: v4Adapter,
+        ponsAdapterAddress: await verifiedAdapter(ponsAdapter, chainId, setStatus),
         hostedAs: session?.hosted ? (session.address ?? undefined) : undefined,
       });
       // They just pasted the owner key, so it's demonstrably backed up — skip the
@@ -542,17 +642,21 @@ export default function GrantPage() {
       // they just added, with nothing failing until the first no-exit reject.
       let freshTokens = customTokens;
       let freshAdapter = v4Adapter;
+      let freshPons = ponsAdapter;
       try {
         const r = await fetch("/api/settings");
         if (r.ok) {
           const v = (await r.json()) as {
-            values?: { customTokens?: unknown[]; v4AdapterAddress?: string };
+            values?: { customTokens?: unknown[]; v4AdapterAddress?: string; ponsAdapterAddress?: string };
           };
           freshTokens = (v?.values?.customTokens ?? []).filter(isValidCustomToken) as CustomToken[];
           const a = v?.values?.v4AdapterAddress;
           freshAdapter = typeof a === "string" && /^0x[0-9a-fA-F]{40}$/.test(a) ? (a as `0x${string}`) : undefined;
+          const pa = v?.values?.ponsAdapterAddress;
+          freshPons = typeof pa === "string" && /^0x[0-9a-fA-F]{40}$/.test(pa) ? (pa as `0x${string}`) : undefined;
           setCustomTokens(freshTokens);
           setV4Adapter(freshAdapter);
+          setPonsAdapter(freshPons);
         }
       } catch {
         /* unreachable settings: sign with what the page already had, as before */
@@ -568,6 +672,7 @@ export default function GrantPage() {
         chainId,
         extraTokens: freshTokens,
         v4AdapterAddress: freshAdapter,
+        ponsAdapterAddress: await verifiedAdapter(freshPons, chainId, setStatus),
         hostedAs: session?.hosted ? (session.address ?? undefined) : undefined,
       });
       setGrant(g);

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -1176,6 +1176,12 @@ export default function SettingsPage() {
               <input type="text" placeholder="0x…" value={v("v4AdapterAddress")} onChange={set("v4AdapterAddress")} />
             </Field>
             <Field
+              label="Pons curve adapter contract"
+              hint="Deployed PonsSelfTrade address for THIS chain — it opens the Pons launchpad, where tokens trade on a bonding curve before they graduate to a pool. Does nothing until you re-sign the grant: the address is sealed into the signature, and sealing it also makes that contract an approved spender for every token in the grant."
+            >
+              <input type="text" placeholder="0x…" value={v("ponsAdapterAddress")} onChange={set("ponsAdapterAddress")} />
+            </Field>
+            <Field
               label="Rialto integrator key"
               hint="From Rialto's wallet-signed onboarding (docs.rialto.xyz). Enables real stock-token routing through their propAMMs."
             >

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3635,7 +3635,25 @@ async function main() {
         const px = paperPriceOf(p.token);
         const mul = mults.multipliers.get(p.symbol);
         if (!px || mul === undefined) {
-          missingPrice.push(p.symbol);
+          // UNPRICEABLE BY DESIGN IS NOT A MISSING PRICE, and conflating them
+          // freezes the tick.
+          //
+          // readPositions makes this split on the live path (positions.ts): a
+          // token with no Chainlink feed AT ALL — which is every memecoin, and
+          // every bonding-curve token — is `unpricedByDesign`, a structural gap
+          // that never resolves. `missingPrice` means the holding is known and
+          // the price is temporarily absent, and it HOLDS THE TICK on purpose,
+          // because valuing a book you cannot value is how a drawdown breaker
+          // fires on a number nobody computed.
+          //
+          // The paper path had no such split, so one simulated memecoin holding
+          // stopped the tick forever — equity, the breaker, and the strategy
+          // that would have SOLD it, all waiting on a price that is never
+          // coming. Practice mode is where an owner is meant to find out how
+          // this behaves, so it is the worst place to hang.
+          const known = watchTokens.find((t) => t.symbol === p.symbol);
+          if (known && known.chainlinkFeed === null) unpricedByDesign.push(p.symbol);
+          else missingPrice.push(p.symbol);
           continue;
         }
         // `shares` is split-invariant, so it IS the raw balance in 18dp terms and

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -152,7 +152,14 @@ import { buildCurveTradeCalls } from "./venues/pons-trade";
  * the exact failure this bounds.
  */
 const CURVE_DEADLINE_SEC = 60;
-import { CURVE_GUARD_DEFAULTS } from "./venues/pons-price";
+import {
+  CURVE_GUARD_DEFAULTS,
+  curveGraduated,
+  curveBuyImpactBps,
+  curveBuyOut,
+  curveSellOut,
+  curveMinOut,
+} from "./venues/pons-price";
 import { mainnetClient, readAccountBalances, readMarketSafety, setMainnetRpc } from "./snapshot";
 import { applyFill } from "./basis";
 import {
@@ -203,6 +210,7 @@ import {
   setPositions,
   type TradeRow,  knownCurves,
 } from "./store";
+import { quoteDecimalsOf, readCurveReserves } from "./venues/pons";
 
 const BREAKER_ABI = parseAbi(["function isTripped(address account) view returns (bool)"]);
 const VAULT_ABI = parseAbi([
@@ -2116,6 +2124,25 @@ async function main() {
 
   /** Derive a decision's {action, symbol, size} from a typed intent — no model
    * text, just the structure, so deterministic strategies + chat are attributable. */
+  /**
+   * The token legs of an intent, for the ledger row.
+   *
+   * SEVEN COPIES OF `intent.kind === "swap" ? … : undefined` said the same thing
+   * in seven places, and every one of them was wrong for a curve trade: a landed
+   * curve buy wrote both columns NULL, so the row could not say what was bought.
+   * audit.ts then skips its on-chain cross-check when those columns are absent
+   * and raises no finding, so the trade passes verification vacuously — a
+   * position that exists on chain, at zero recorded cost, verified by nothing.
+   *
+   * One function so the next venue is added in one place rather than seven, and
+   * so a kind that has legs cannot quietly keep failing to name them.
+   */
+  function tokenLegs(intent: TradeIntent): { sell_token?: string; buy_token?: string } {
+    if (intent.kind === "swap") return { sell_token: intent.sellToken, buy_token: intent.buyToken };
+    if (intent.kind === "curve-trade") return { sell_token: intent.assetIn, buy_token: intent.assetOut };
+    return {};
+  }
+
   function describeIntent(intent: TradeIntent): { action: string; symbol?: string; sizeUsdg: number } {
     if (intent.kind === "swap") {
       const buyingStock = intent.buyToken.toLowerCase() !== (CASH.USDG as string).toLowerCase();
@@ -2131,8 +2158,19 @@ async function main() {
     }
     // A curve trade is sized in USDG-equivalent like a swap, not in an
     // amountUsdg field it does not have.
+    //
+    // NAMED, not labelled `curve-trade`. This returned the literal kind as the
+    // action and no symbol at all, and ensureDecision writes that straight into
+    // the decisions table — so every attribution surface (the dashboard, /why,
+    // the scoreboard) would show a nameless action for the trades most in need
+    // of an explanation. Derived from assetOut the way the swap branch does it.
     if (intent.kind === "curve-trade") {
-      return { action: intent.kind, sizeUsdg: usdgNum(intent.notionalUsdg) };
+      const buying = intent.assetOut.toLowerCase() !== (CASH.USDG as string).toLowerCase();
+      return {
+        action: buying ? "buy" : "sell",
+        symbol: symbolOfToken(buying ? intent.assetOut : intent.assetIn),
+        sizeUsdg: usdgNum(intent.notionalUsdg),
+      };
     }
     return { action: intent.kind, sizeUsdg: usdgNum(intent.amountUsdg) };
   }
@@ -2555,8 +2593,7 @@ async function main() {
           agent_id: agentId,
           kind: intent.kind,
           target: tradeTarget,
-          sell_token: intent.kind === "swap" ? intent.sellToken : undefined,
-          buy_token: intent.kind === "swap" ? intent.buyToken : undefined,
+          ...tokenLegs(intent),
           amount_usdg: usdgNum(notional),
           status: "rejected",
           reject_rule: "no-executor",
@@ -2639,8 +2676,7 @@ async function main() {
           agent_id: agentId,
           kind: intent.kind,
           target: intent.target,
-          sell_token: intent.kind === "swap" ? intent.sellToken : undefined,
-          buy_token: intent.kind === "swap" ? intent.buyToken : undefined,
+          ...tokenLegs(intent),
           amount_usdg: usdgNum(notional),
           status: "paper",
           sim_quote_out: fill.receipt,
@@ -2674,8 +2710,7 @@ async function main() {
         agent_id: agentId,
         kind: intent.kind,
         target: tradeTarget,
-        sell_token: intent.kind === "swap" ? intent.sellToken : undefined,
-        buy_token: intent.kind === "swap" ? intent.buyToken : undefined,
+        ...tokenLegs(intent),
         amount_usdg: usdgNum(notional),
         status: "rejected",
         reject_rule: "no-gas",
@@ -2728,8 +2763,7 @@ async function main() {
             agent_id: agentId,
             kind: intent.kind,
             target: tradeTarget,
-            sell_token: intent.kind === "swap" ? intent.sellToken : undefined,
-            buy_token: intent.kind === "swap" ? intent.buyToken : undefined,
+            ...tokenLegs(intent),
             amount_usdg: usdgNum(notional),
             user_op_hash: userOpHash,
             status: "submitted",
@@ -3279,8 +3313,7 @@ async function main() {
         agent_id: agentId,
         kind: intent.kind,
         target: intent.target,
-        sell_token: intent.kind === "swap" ? intent.sellToken : undefined,
-        buy_token: intent.kind === "swap" ? intent.buyToken : undefined,
+        ...tokenLegs(intent),
         amount_usdg: usdgNum(notional),
         tx_hash: txHash,
         user_op_hash: exec.userOpHash,
@@ -3347,8 +3380,7 @@ async function main() {
           agent_id: agentId,
           kind: intent.kind,
           target: tradeTarget,
-          sell_token: intent.kind === "swap" ? intent.sellToken : undefined,
-          buy_token: intent.kind === "swap" ? intent.buyToken : undefined,
+          ...tokenLegs(intent),
           amount_usdg: usdgNum(notional),
           status: "rejected",
           reject_rule: e.rule,
@@ -3459,8 +3491,7 @@ async function main() {
         agent_id: agentId,
         kind: intent.kind,
         target: intent.target,
-        sell_token: intent.kind === "swap" ? intent.sellToken : undefined,
-        buy_token: intent.kind === "swap" ? intent.buyToken : undefined,
+        ...tokenLegs(intent),
         amount_usdg: usdgNum(notional),
         // Resolves the pre-broadcast row in place when there is one — a revert
         // has a hash; a failure before submit does not, and inserts.
@@ -4194,6 +4225,173 @@ async function main() {
     }
   }
 
+  /**
+   * An owner-directed curve buy or sell, from chat.
+   *
+   * THE FIRST PRODUCER OF A curve-trade INTENT IN THIS REPO. Everything below it
+   * — the wall permission, the call builder, the executor arm, the policy rules —
+   * has existed and been unreachable, because nothing constructed the object.
+   *
+   * OWNER-DIRECTED ON PURPOSE, and it sidesteps pre-authorisation rather than
+   * pretending to solve it. The wall pins assetOut ONE_OF the list sealed at
+   * signing, so the token has to be in the GRANT before this can work. That is a
+   * real limit and this function says so in words instead of letting the chain
+   * say it in gas.
+   *
+   * THE PRECONDITION IS grant.grantTokens, NOT /settings. `watchTokens` is
+   * settings-derived and hot-reloads with no signature (see the settings apply
+   * path), while `sellableAssets` comes from the signature. An owner who adds a
+   * token and does not re-sign would otherwise pass every check here and revert
+   * at the wall, having paid for the attempt.
+   */
+  async function submitChatCurveTrade(
+    side: "buy" | "sell",
+    symbol: string,
+    token: `0x${string}`,
+    usdgAmount: number,
+  ): Promise<string> {
+    if (!active) return "no agent armed — sign a grant in the dashboard first.";
+
+    const adapter = grantPonsAdapter(active.grant);
+    if (!adapter) {
+      return (
+        `${symbol} trades on a bonding curve, and this grant does not carry the curve adapter. ` +
+        `Add the adapter address in /settings and re-sign at /grant — the address is sealed into the ` +
+        `signature, so setting it alone changes nothing.`
+      );
+    }
+    if (!active.ponsAdapterLive) {
+      return (
+        `${symbol} trades on a bonding curve, but the adapter this grant sealed has no code on this chain. ` +
+        `That usually means the address came from the other chain or was never deployed. Nothing was sent.`
+      );
+    }
+
+    // The GRANT's reach, checked before anything is quoted or spent.
+    const sellable = new Set((active.limits.sellableAssets ?? []).map((a) => a.toLowerCase()));
+    if (!sellable.has(token.toLowerCase())) {
+      return (
+        `I can't trade ${symbol}: this grant's signature doesn't name it, so the wall would refuse the ` +
+        `trade after paying gas for it. Add ${symbol} in /settings and re-sign at /grant.`
+      );
+    }
+
+    // PAPER MODE IS REFUSED HERE, in words. applyPaperIntent rejects a
+    // curve-trade with the raw string "unsupported paper intent curve-trade",
+    // which surfaces to the owner and reads like a crash rather than a decision.
+    if (paperActive()) {
+      return (
+        `${symbol} trades on a bonding curve, and curve trading is live-only for now — the practice book ` +
+        `can't simulate a curve yet. Nothing was sent.`
+      );
+    }
+
+    const ref = await curveFor(token);
+    if (!ref) return `I don't have a curve on record for ${symbol}, so I can't trade it there.`;
+
+    const client = mainnetClient();
+    const decimalsCache = new Map<string, number>();
+    const quoteDecimals =
+      (await quoteDecimalsOf(client, ref.quoteToken as `0x${string}`, decimalsCache)) ?? null;
+    if (quoteDecimals === null) {
+      return `I can't read the decimals of what ${symbol}'s curve is quoted in, so I can't size a trade safely.`;
+    }
+    const tokenDecimals = watchTokens.find((t) => t.address.toLowerCase() === token.toLowerCase())?.decimals ?? 18;
+
+    const reserves = await readCurveReserves(
+      client,
+      { curve: ref.curve as `0x${string}`, graduationThresholdRaw: ref.graduationThresholdRaw },
+      { quote: quoteDecimals, token: tokenDecimals },
+    );
+    if (!reserves) return `couldn't read ${symbol}'s curve just now — try again in a moment.`;
+    if (curveGraduated(reserves)) {
+      return (
+        `${symbol} has graduated off its bonding curve — its market is a pool now, and the curve adapter ` +
+        `refuses a graduated curve by name. Nothing was sent.`
+      );
+    }
+
+    // IMPACT, on the thinnest-liquidity venue on the chain. cfg.maxImpactBps has
+    // never bounded a curve trade because judgeImpact is only called from
+    // swap-only branches; this is the same ceiling, applied where it matters most.
+    const sizeRaw = usdg(usdgAmount);
+    const isBuy = side === "buy";
+
+    // What actually goes in: for a buy, the quote asset; for a sell, the token.
+    let amountInRaw: bigint;
+    let assetIn: `0x${string}`;
+    let assetOut: `0x${string}`;
+    if (isBuy) {
+      assetIn = ref.quoteToken as `0x${string}`;
+      assetOut = token;
+      // USDG-quoted curves are the one hop the agent's cash reaches directly.
+      if (assetIn.toLowerCase() !== (CASH.USDG as string).toLowerCase()) {
+        return (
+          `${symbol}'s curve is quoted in ${assetIn.slice(0, 10)}…, not USDG, so buying it needs a hop ` +
+          `through that asset first. I don't do that in one step yet — nothing was sent.`
+        );
+      }
+      amountInRaw = sizeRaw;
+    } else {
+      assetIn = token;
+      assetOut = ref.quoteToken as `0x${string}`;
+      // SIZED FROM THE CHAIN, not from the valued positions row. A curve token
+      // the price guard refuses is exactly the one with no positions row, and
+      // reading one would answer "you don't hold any X" about a token the owner
+      // demonstrably holds. Unpriceable is a reason to SELL, not to refuse.
+      let held: bigint;
+      try {
+        held = (await client.readContract({
+          address: token,
+          abi: erc20Abi,
+          functionName: "balanceOf",
+          args: [active.grant.smartAccount as `0x${string}`],
+        })) as bigint;
+      } catch {
+        return `couldn't read your ${symbol} balance just now — try again in a moment.`;
+      }
+      if (held === 0n) return `you don't hold any ${symbol}.`;
+      amountInRaw = held;
+    }
+
+    const impact = isBuy ? curveBuyImpactBps(reserves, amountInRaw) : null;
+    if (impact !== null && impact > cfg.maxImpactBps) {
+      return (
+        `that would move ${symbol}'s curve by ${(impact / 100).toFixed(1)}%, past your ${(
+          cfg.maxImpactBps / 100
+        ).toFixed(1)}% ceiling. Try a smaller size.`
+      );
+    }
+
+    const quoted = isBuy ? curveBuyOut(reserves, amountInRaw) : curveSellOut(reserves, amountInRaw);
+    if (quoted === null) return `couldn't quote ${symbol} on its curve — the reserves don't support a trade this size.`;
+    const minAmountOutRaw = curveMinOut(quoted, cfg.slippageBps);
+    if (minAmountOutRaw === null || minAmountOutRaw <= 0n) {
+      return `couldn't derive a slippage floor for ${symbol} — refusing rather than signing an unbounded trade.`;
+    }
+
+    const intent: TradeIntent = {
+      kind: "curve-trade",
+      target: adapter,
+      curve: ref.curve as `0x${string}`,
+      assetIn,
+      assetOut,
+      amountInRaw,
+      minAmountOutRaw,
+      // For a buy the USDG leg IS the notional. For a sell it is what the quote
+      // says comes back, which is the number the caps should judge.
+      notionalUsdg: isBuy ? sizeRaw : quoted,
+    };
+
+    await ensureDecision(
+      intent,
+      "chat",
+      `owner asked to ${side} ${usdgAmount} USDG of ${symbol} on its bonding curve`,
+    );
+    await processIntent(intent, lastEquityUsdg, lastEquityKnown);
+    return `🏹 submitted ${side} ${symbol} on its curve — watch /trades for the result (it still passes the policy wall).`;
+  }
+
   async function submitChatTrade(side: "buy" | "sell", symbol: string, usdgAmount: number): Promise<string> {
     if (!active) return "no agent armed — sign a grant in the dashboard first.";
     // Before the first tick completes, equity is unknown (0n) and the drawdown
@@ -4207,6 +4405,11 @@ async function main() {
       const known = watchTokens.map((t) => t.symbol).join(", ");
       return `I don't know ${symbol}. I'm watching: ${known || "nothing yet"}. Add it in /settings and re-sign at /grant if you want me trading it.`;
     }
+    // WHERE DOES THIS TOKEN ACTUALLY TRADE? A Pons token has no pool until it
+    // graduates, so routing it to the swap router would build an operation
+    // against a pool that does not exist. Asked before anything is sized.
+    if (await curveFor(token)) return submitChatCurveTrade(side, symbol, token, usdgAmount);
+
     const router = swapRouterFor(cfg);
     let intent: TradeIntent;
     if (side === "buy") {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4323,10 +4323,22 @@ async function main() {
     );
     if (!reserves) return `couldn't read ${symbol}'s curve just now — try again in a moment.`;
     if (curveGraduated(reserves)) {
-      return (
-        `${symbol} has graduated off its bonding curve — its market is a pool now, and the curve adapter ` +
-        `refuses a graduated curve by name. Nothing was sent.`
-      );
+      // GRADUATION IS AN EXIT PROBLEM, not just a refusal.
+      //
+      // The position is real and the venue it was bought on is gone. What must
+      // NOT happen here is a quiet fallback to the swap router: 16 of 17 sampled
+      // graduated tokens had no Uniswap v3 pool at any fee tier (pons-price.ts),
+      // so that builds an operation against a pool that does not exist and burns
+      // gas to find out. A graduated token's market is v4.
+      //
+      // So say which door is open. The v4 adapter is a SEPARATE owner opt-in
+      // (wall.ts) — a grant carrying the Pons adapter need not carry it — and the
+      // difference decides whether this is a re-sign or a sweep.
+      const v4 = grantV4Adapter(active.grant);
+      const base = `${symbol} has graduated off its bonding curve, so the curve adapter refuses it by name and its market has moved to a pool. Nothing was sent.`;
+      return v4
+        ? `${base} Its market is on Uniswap v4 now; routing a graduated position through the v4 adapter isn't wired yet, so for now sweep it with your owner key from /grant.`
+        : `${base} Exiting it needs the Uniswap v4 adapter, which this grant doesn't carry — add it in /settings and re-sign at /grant, or sweep the position with your owner key.`;
     }
 
     // IMPACT, on the thinnest-liquidity venue on the chain. cfg.maxImpactBps has

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -201,7 +201,7 @@ import {
   setTrenchEntry,
   upgradeTrenchEntry,
   setPositions,
-  type TradeRow,
+  type TradeRow,  knownCurves,
 } from "./store";
 
 const BREAKER_ABI = parseAbi(["function isTripped(address account) view returns (bool)"]);
@@ -417,7 +417,7 @@ async function main() {
       watchTokens = watchTokensFor(next.basketSymbols, next.customTokens);
       console.log(`[settings] strategy settings applied — ${strategy.name}, venue ${next.swapVenue}`);
       if (active) {
-        active.limits = limitsFromGrant(active.grant, watchTokens);
+        active.limits = limitsFromGrant(active.grant, watchTokens, (await knownCurves()) ?? undefined);
         await addEvent(active.agentId, "ok", `settings applied — strategy ${strategy.name}, venue ${next.swapVenue}`);
       }
       stratKey = nextStrat;
@@ -2045,7 +2045,10 @@ async function main() {
       // Agentic account exists and tools/list has been read, equity orders can
       // only paper-fill.
       orderExecutor: null,
-      limits: limitsFromGrant(grant, watchTokens),
+      // The provenance set for the curve-trade rule. Read once at arm time,
+      // alongside every other grant-derived bound, so a curve the agent never
+      // saw launch cannot be traded even though the wall cannot pin it.
+      limits: limitsFromGrant(grant, watchTokens, (await knownCurves()) ?? undefined),
       breakerLive,
       v4AdapterLive,
       ponsAdapterLive,
@@ -3431,11 +3434,20 @@ async function main() {
       // funded account), and a suppression outliving its reason is
       // indistinguishable from a strategy that simply stopped working.
       if (revertVerdict && !revertVerdict.retryable) {
-        const key = suppressionKey(
-          intent.kind,
-          intent.kind === "swap" ? intent.sellToken : undefined,
-          intent.kind === "swap" ? intent.buyToken : undefined,
-        );
+        // NAME THE TOKENS FOR EVERY KIND THAT HAS THEM.
+        //
+        // This passed tokens only for swaps, so every curve failure collapsed to
+        // the single key `curve-trade:->` and the first non-retryable one
+        // suppressed ALL curve trading for the rest of the arm — one graduated
+        // token taking the whole venue down with it. suppressionKey's own comment
+        // says the scope is the token PAIR precisely so that cannot happen.
+        const [supSell, supBuy] =
+          intent.kind === "swap"
+            ? [intent.sellToken, intent.buyToken]
+            : intent.kind === "curve-trade"
+              ? [intent.assetIn, intent.assetOut]
+              : [undefined, undefined];
+        const key = suppressionKey(intent.kind, supSell, supBuy);
         suppressedIntents.set(key, revertVerdict.rule);
         await addEvent(
           agentId,

--- a/worker/src/ledger-mirror.test.ts
+++ b/worker/src/ledger-mirror.test.ts
@@ -23,11 +23,11 @@ import { MIRROR_STATE_DDL, mirrorTenant } from "./ledger-mirror";
 
 const SRC = [
   "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT NOT NULL, level TEXT, message TEXT, created_at INTEGER);",
-  "CREATE TABLE trades (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT, kind TEXT, target TEXT, sell_token TEXT, buy_token TEXT, amount_usdg REAL, user_op_hash TEXT, tx_hash TEXT, status TEXT, reject_rule TEXT, created_at INTEGER);",
+  "CREATE TABLE trades (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT, kind TEXT, target TEXT, sell_token TEXT, buy_token TEXT, amount_usdg REAL, user_op_hash TEXT, tx_hash TEXT, status TEXT, reject_rule TEXT, decision_id TEXT, fill_side TEXT, fill_qty_raw TEXT, fill_price_usd REAL, realized_pnl_usdg REAL, basis_source TEXT, gas_wei TEXT, created_at INTEGER);",
   "CREATE TABLE equity (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT, eth_wei TEXT, cash_usdg REAL, vault_usdg REAL, equity_usdg REAL, at INTEGER);",
   "CREATE TABLE decisions (id TEXT PRIMARY KEY, agent_id TEXT, source TEXT, strategy TEXT, provider TEXT, model TEXT, symbol TEXT, action TEXT, size_usdg REAL, reason TEXT, dropped_rule TEXT, signals_json TEXT, at INTEGER);",
   "CREATE TABLE agents (smart_account TEXT PRIMARY KEY, name TEXT, owner_address TEXT, session_key_address TEXT, chain_id INTEGER, caps TEXT, granted_at INTEGER, expires_at INTEGER, status TEXT, created_at INTEGER, mode TEXT, beat_at INTEGER);",
-  "CREATE TABLE positions (agent_id TEXT, symbol TEXT, token TEXT, raw_balance TEXT, ui_multiplier TEXT, price_usd REAL, price_stale INTEGER, value_usdg REAL, updated_at INTEGER, PRIMARY KEY (agent_id, symbol));",
+  "CREATE TABLE positions (agent_id TEXT, symbol TEXT, token TEXT, raw_balance TEXT, ui_multiplier TEXT, price_usd REAL, price_stale INTEGER, price_source TEXT DEFAULT 'chainlink', value_usdg REAL, updated_at INTEGER, PRIMARY KEY (agent_id, symbol));",
 ].join("\n");
 
 /** The destination, with the same shape a Postgres ledger has. */
@@ -51,7 +51,7 @@ const seedChild = () => {
       `INSERT INTO trades (agent_id, kind, target, amount_usdg, status, created_at) VALUES ('0xagent','swap','0xt',${i},'landed',${100 + i})`,
     );
   }
-  raw.exec("INSERT INTO positions VALUES ('0xagent','PEPE','0xp','1','1',2.0,0,10.0,9)");
+  raw.exec("INSERT INTO positions VALUES ('0xagent','PEPE','0xp','1','1',2.0,0,'curve',10.0,9)");
   raw.exec(
     "INSERT INTO decisions VALUES ('d1','0xagent','strategist',null,null,null,'PEPE','buy',5,'looked cheap',null,'{}',9)",
   );
@@ -64,6 +64,20 @@ const count = async (db: ReturnType<typeof mem>, table: string): Promise<number>
 };
 
 describe("the ledger mirror", () => {
+  it("carries price_source across — a curve mark must not arrive as an oracle", async () => {
+    // The positions SELECT omitted price_source, and the destination schema
+    // defaults it to 'chainlink'. So the weakest mark this system produces — a
+    // bonding-curve price — arrived in the shared ledger wearing an oracle's
+    // name and rendered on the dashboard as oracle-grade. The whole point of the
+    // column is that the three sources are NOT equally good evidence.
+    const shared = mem(DEST);
+    await mirrorTenant({ tenant: "0xten", child: seedChild(), shared });
+    const row = (await shared.prepare("SELECT price_source FROM positions").get()) as {
+      price_source: string;
+    };
+    assert.equal(row.price_source, "curve");
+  });
+
   it("copies a child's ledger up", async () => {
     const shared = mem(DEST);
     const r = await mirrorTenant({ tenant: "0xten", child: seedChild(), shared });

--- a/worker/src/ledger-mirror.ts
+++ b/worker/src/ledger-mirror.ts
@@ -57,6 +57,18 @@ const LOG_TABLES = [
       "tx_hash",
       "status",
       "reject_rule",
+      // THE EVIDENCE COLUMNS. This list was 11 columns and carried none of the
+      // fill or basis data, so everything the ledger knows about WHAT a trade
+      // actually filled at existed only in the child's local sqlite and never
+      // reached the shared database behind the dashboard. A proof that holds
+      // only where nobody can see it is not a proof.
+      "decision_id",
+      "fill_side",
+      "fill_qty_raw",
+      "fill_price_usd",
+      "realized_pnl_usdg",
+      "basis_source",
+      "gas_wei",
       "created_at",
     ],
   },
@@ -228,8 +240,14 @@ export async function mirrorTenant(args: {
 
       const positions = (await child
         .prepare(
+          // price_source IS LOAD-BEARING and was omitted. The shared schema
+          // defaults it to 'chainlink' (store.ts), so a pool mark — or a bonding
+          // curve mark, which is the weakest evidence this system produces —
+          // arrived in Postgres wearing an oracle's name and rendered on the
+          // dashboard as oracle-grade. The whole point of the column is that the
+          // three sources are NOT equally good evidence.
           `SELECT agent_id, symbol, token, raw_balance, ui_multiplier, price_usd, price_stale,
-                  value_usdg, updated_at FROM positions`,
+                  price_source, value_usdg, updated_at FROM positions`,
         )
         .all()) as Record<string, unknown>[];
       await shared.tx(async (db) => {
@@ -240,13 +258,13 @@ export async function mirrorTenant(args: {
         }
         const ins = db.prepare(
           `INSERT INTO positions (agent_id, symbol, token, raw_balance, ui_multiplier, price_usd,
-                                  price_stale, value_usdg, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                                  price_stale, price_source, value_usdg, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         );
         for (const p of positions) {
           await ins.run(
             p.agent_id, p.symbol, p.token, p.raw_balance, p.ui_multiplier, p.price_usd,
-            p.price_stale, p.value_usdg, p.updated_at,
+            p.price_stale, p.price_source, p.value_usdg, p.updated_at,
           );
         }
       });

--- a/worker/src/limits.ts
+++ b/worker/src/limits.ts
@@ -8,6 +8,7 @@ import {
   grantHasV4,
   grantV4Adapter,
   grantPonsAdapter,
+  builtinGrantTargets,
   sellableAssets,
   usdgUnits,
   type StockToken,
@@ -19,6 +20,17 @@ import type { AgentLimits } from "./policy";
 export function limitsFromGrant(
   grant: StoredGrant,
   watchTokens: readonly StockToken[] = STOCK_TOKENS,
+  /**
+   * Curves this agent has seen launch, from the FACTORY-FILTERED scan.
+   *
+   * Passed in rather than read here because this module is deliberately pure
+   * and grant-sourced; the caller owns the store. Defaulting to undefined —
+   * not [] — matters: undefined means the rule cannot run, [] would mean every
+   * curve is unknown and would refuse the venue outright. A check that did not
+   * run must never read as one that passed, and it must not silently become a
+   * blanket refusal either.
+   */
+  knownCurves?: readonly string[],
 ): AgentLimits {
   return {
     perTradeUsdg: usdgUnits(grant.caps.perTradeUsdg),
@@ -77,6 +89,10 @@ export function limitsFromGrant(
     ],
     allowedAssets: [CASH.USDG as `0x${string}`, ...watchTokens.map((token) => token.address)],
     sellableAssets: [...sellableAssets(grant)],
+    // The quote side only -- see AgentLimits.quoteAssets. sellableAssets minus
+    // this is the set of tokens a curve trade could be buying INTO.
+    quoteAssets: [...builtinGrantTargets(grant)],
+    knownCurves,
     // THE TRANSFER PERMISSION, MIRRORED. checkPolicy has always known how to
     // judge this — it was simply never told. A grant without the transfer
     // marker has NO USDG transfer permission in its call policy:

--- a/worker/src/policy.test.ts
+++ b/worker/src/policy.test.ts
@@ -598,3 +598,166 @@ describe("checkPolicy — the withdrawal allowlist mirrors the on-chain pin", ()
     assert.equal(!v.ok && v.rule, "per-trade-cap");
   });
 });
+
+
+/**
+ * STAGE 4 — THE MIRROR WAS LOOSER THAN THE CHAIN FOR CURVE TRADES.
+ *
+ * Every asset rule used to sit inside `if (intent.kind === "swap")`, so a curve
+ * trade reached the bundler having passed no asset check at all. The chain would
+ * still refuse it — the wall pins both legs ONE_OF the sealed list — but
+ * limits.ts records that the mirror going LOOSER than the chain is the one
+ * direction that is never safe, and the cost of finding out on chain is a wasted
+ * UserOp and a `gas-unreadable` refusal that names nothing.
+ */
+describe("curve trades are judged off-chain, not discovered on-chain", () => {
+  const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
+  const MEME = "0x1111111111111111111111111111111111111111";
+  const CURVE = "0x2222222222222222222222222222222222222222";
+  const ADAPTER = "0x3333333333333333333333333333333333333333";
+  const STOCK = "0x4444444444444444444444444444444444444444";
+
+  const curveIntent = (over: Record<string, unknown> = {}) =>
+    ({
+      kind: "curve-trade",
+      target: ADAPTER,
+      curve: CURVE,
+      assetIn: USDG,
+      assetOut: MEME,
+      amountInRaw: 10_000_000n,
+      minAmountOutRaw: 1n,
+      notionalUsdg: 10_000_000n,
+      ...over,
+    }) as never;
+
+  const limits = (over: Record<string, unknown> = {}) =>
+    ({
+      allowedTargets: [ADAPTER],
+      allowedAssets: [USDG, MEME],
+      sellableAssets: [USDG, MEME, STOCK],
+      quoteAssets: [USDG, STOCK],
+      knownCurves: [CURVE],
+      cashToken: USDG,
+      maxTradeUsdg: 1_000_000_000n,
+      maxDailyUsdg: 1_000_000_000n,
+      maxOpsPerDay: 100,
+      ...over,
+    }) as never;
+
+  const state = () =>
+    ({ spentTodayUsdg: 0n, opsToday: 0, equityUsdg: 1_000_000_000n, highWaterMarkUsdg: 0n }) as never;
+
+  it("refuses an asset the GRANT does not cover", () => {
+    const v = checkPolicy(
+      curveIntent({ assetOut: "0x9999999999999999999999999999999999999999" }),
+      limits(),
+      state(),
+    );
+    assert.equal(v.ok, false);
+    assert.equal((v as { rule: string }).rule, "asset-allowlist");
+  });
+
+  it("checks the GRANT list, not the settings list — the whole point of the fix", () => {
+    // allowedAssets is [USDG, ...watchTokens] and watchTokens hot-reload from
+    // SETTINGS with no signature. sellableAssets comes from the grant. An owner
+    // who adds a token in /settings and does not re-sign must still be refused
+    // here, or the fix reproduces the bug it is closing.
+    const v = checkPolicy(
+      curveIntent(),
+      limits({ allowedAssets: [USDG, MEME], sellableAssets: [USDG] }),
+      state(),
+    );
+    assert.equal(v.ok, false, "settings-derived reach must not authorise a curve buy");
+    assert.equal((v as { rule: string }).rule, "asset-allowlist");
+  });
+
+  it("refuses a curve nothing vouches for", () => {
+    // The curve is the one argument the wall CANNOT pin, so off-chain is the
+    // only place it can be constrained at all.
+    const v = checkPolicy(curveIntent({ curve: "0x8888888888888888888888888888888888888888" }), limits(), state());
+    assert.equal(v.ok, false);
+    assert.equal((v as { rule: string }).rule, "curve-provenance");
+  });
+
+  it("refuses a non-positive size instead of signing it", () => {
+    for (const over of [{ amountInRaw: 0n }, { notionalUsdg: 0n }, { amountInRaw: -1n }]) {
+      const v = checkPolicy(curveIntent(over), limits(), state());
+      assert.equal(v.ok, false, Object.keys(over).join(",") + "=" + Object.values(over).map(String).join(","));
+      assert.equal((v as { rule: string }).rule, "non-positive");
+    }
+  });
+
+  it("allows a legal curve buy", () => {
+    assert.equal(checkPolicy(curveIntent(), limits(), state()).ok, true);
+  });
+});
+
+/**
+ * THE BREAKER'S EXIT EXEMPTION — and the trap in widening it.
+ *
+ * The wall pins BOTH legs ONE_OF the same sealed list, so "assetOut is sellable"
+ * is true of every curve trade ever built, buys included. Testing that would mark
+ * the whole venue exempt and switch the breaker off exactly where risk is
+ * highest. The real discriminator is that sellableAssets = builtinGrantTargets u
+ * grantTokens: a launched memecoin arrives as an owner-added EXTRA, while USDG
+ * and the stock tokens are BUILT IN.
+ */
+describe("drawdown breaker and curve exits", () => {
+  const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
+  const MEME = "0x1111111111111111111111111111111111111111";
+  const CURVE = "0x2222222222222222222222222222222222222222";
+  const ADAPTER = "0x3333333333333333333333333333333333333333";
+  const STOCK = "0x4444444444444444444444444444444444444444";
+
+  const lim = {
+    allowedTargets: [ADAPTER],
+    allowedAssets: [USDG, MEME, STOCK],
+    sellableAssets: [USDG, MEME, STOCK],
+    quoteAssets: [USDG, STOCK],
+    knownCurves: [CURVE],
+    cashToken: USDG,
+    maxTradeUsdg: 1_000_000_000n,
+    maxDailyUsdg: 1_000_000_000n,
+    maxOpsPerDay: 100,
+    maxDrawdownBps: 500,
+  } as never;
+
+  // Deep in a drawdown: equity is half the high-water mark.
+  const drawdown = {
+    spentTodayUsdg: 0n,
+    opsToday: 0,
+    equityUsdg: 500_000_000n,
+    highWaterMarkUsdg: 1_000_000_000n,
+    equityKnown: true,
+  } as never;
+
+  const trade = (assetIn: string, assetOut: string) =>
+    ({
+      kind: "curve-trade",
+      target: ADAPTER,
+      curve: CURVE,
+      assetIn,
+      assetOut,
+      amountInRaw: 10_000_000n,
+      minAmountOutRaw: 1n,
+      notionalUsdg: 10_000_000n,
+    }) as never;
+
+  it("lets a stock-quoted curve position OUT during a drawdown", () => {
+    // 42.8% of curves are quoted in a stock token. The cashToken-only test
+    // blocked the exit for nearly half the venue at the moment it matters most.
+    assert.equal(checkPolicy(trade(MEME, STOCK), lim, drawdown).ok, true);
+  });
+
+  it("still lets a USDG-quoted position out", () => {
+    assert.equal(checkPolicy(trade(MEME, USDG), lim, drawdown).ok, true);
+  });
+
+  it("does NOT treat a curve BUY as an exit", () => {
+    // The failure mode of a careless widening: every leg is sellable, so a naive
+    // test exempts entries too and the breaker stops existing for this venue.
+    const v = checkPolicy(trade(USDG, MEME), lim, drawdown);
+    assert.equal(v.ok, false, "buying deeper into a drawdown must still be blocked");
+    assert.equal((v as { rule: string }).rule, "drawdown-breaker");
+  });
+});

--- a/worker/src/policy.ts
+++ b/worker/src/policy.ts
@@ -50,6 +50,36 @@ export interface AgentLimits {
    */
   sellableAssets?: readonly string[];
   /**
+   * Curve addresses this agent has SEEN LAUNCH, from a factory-filtered scan.
+   *
+   * The curve is the one argument the wall cannot pin -- a new address per
+   * token, hundreds an hour -- so wall.ts passes `null` for it and says so
+   * outright. That makes this the only place a curve can be constrained at all.
+   *
+   * What made a curve trustworthy before this was INCIDENTAL: the launch scan
+   * happens to filter on PONS_V2_FACTORY (pons.ts) and discovery copies the
+   * value through. Any future producer that sourced a curve from somewhere else
+   * -- an LLM proposal, a chat message, a poisoned tape -- would silently lose
+   * that property, and nothing would have noticed.
+   *
+   * Optional, like sellableAssets, for fixtures. Absent means the rule cannot
+   * run; it must never mean the rule passed.
+   */
+  knownCurves?: readonly string[];
+  /**
+   * The QUOTE side of the book: USDG and the tradeable stock tokens.
+   *
+   * `builtinGrantTargets(grant)` -- deliberately NOT sellableAssets, which also
+   * contains the owner's added extras and therefore the launched memecoins. The
+   * two lists differ by exactly the tokens a curve trade might be ENTERING, so
+   * using the wrong one turns the drawdown breaker's exit exemption into a
+   * blanket exemption for the venue.
+   *
+   * Optional for fixtures. Absent means the exit test falls back to cashToken
+   * alone -- narrower, which is the safe direction for an exemption.
+   */
+  quoteAssets?: readonly string[];
+  /**
    * Tickers the agent may trade on the brokerage rail — the broker analog of
    * allowedAssets, since an equity order has no address for that list to
    * check. Optional for fixtures only (the sellableAssets rule); on a live
@@ -252,6 +282,71 @@ export function checkPolicy(
     }
   }
 
+  // ── curve trades ────────────────────────────────────────────────────────
+  //
+  // THIS BLOCK EXISTS BECAUSE THE MIRROR WAS LOOSER THAN THE CHAIN.
+  //
+  // Every asset rule below used to sit inside `if (intent.kind === "swap")`,
+  // so a curve trade reached the bundler having passed no asset check at all.
+  // The chain would still refuse it -- wall.ts pins both legs ONE_OF the
+  // sealed list -- but limits.ts:27-41 records that the mirror going LOOSER
+  // than the chain is the one direction that is never safe, and the cost of
+  // discovering it on chain is a wasted UserOp and a `gas-unreadable` refusal
+  // that names nothing.
+  //
+  // GATED ON sellableAssets, NOT allowedAssets, and the distinction is the
+  // whole point. allowedAssets is [USDG, ...watchTokens] and watchTokens comes
+  // from SETTINGS (limits.ts:78), which hot-reload with no signature.
+  // sellableAssets comes from the GRANT (grant.ts:344), which is what the wall
+  // actually sealed. Checking the settings-derived list here would reproduce
+  // exactly the bug this block is closing: an owner adds a token in /settings,
+  // does not re-sign, and gets a curve buy that passes every off-chain check
+  // and reverts at the wall.
+  if (intent.kind === "curve-trade") {
+    // Positivity. equity-order has one of these; curve-trade did not, so a zero
+    // or negative size would sail through every cap below (they are all upper
+    // bounds) and be signed.
+    if (intent.amountInRaw <= 0n || intent.notionalUsdg <= 0n) {
+      return {
+        ok: false,
+        rule: "non-positive",
+        detail: `curve trade sized ${intent.amountInRaw} raw / ${intent.notionalUsdg} USDG is not a trade`,
+      };
+    }
+
+    if (limits.sellableAssets) {
+      const sellable = limits.sellableAssets.map(lc);
+      for (const token of [intent.assetIn, intent.assetOut]) {
+        if (!sellable.includes(lc(token))) {
+          return {
+            ok: false,
+            rule: "asset-allowlist",
+            detail:
+              `asset ${token} is not in the signed grant, so the wall will refuse this trade. ` +
+              `Add it at /settings and re-sign the grant at /grant to cover it.`,
+          };
+        }
+      }
+    }
+
+    // CURVE PROVENANCE. `intent.target` is the adapter and is covered by the
+    // target allowlist above; `intent.curve` is covered by nothing, on chain or
+    // off. This turns the incidental factory-filter property into an enforced
+    // one, before any producer exists that could source a curve elsewhere.
+    if (limits.knownCurves) {
+      if (!limits.knownCurves.map(lc).includes(lc(intent.curve))) {
+        return {
+          ok: false,
+          rule: "curve-provenance",
+          detail:
+            `curve ${intent.curve} was not seen in a factory-filtered launch, so nothing vouches ` +
+            `for it being a Pons curve at all. The wall cannot pin this argument, which is exactly ` +
+            `why it is checked here.`,
+        };
+      }
+    }
+  }
+
   if (intent.kind === "swap") {
     for (const token of [intent.sellToken, intent.buyToken]) {
       if (!limits.allowedAssets.map(lc).includes(lc(token))) {
@@ -409,9 +504,28 @@ export function checkPolicy(
     // into cash is. Leaving it out would have the breaker block the one
     // direction it should never block — getting out of a memecoin — while a
     // drawdown is in progress, which is precisely when it matters most.
+    // ANY curve trade out of the token and back into something the grant can
+    // sell is an exit, not just one into cash. 42.8% of curves are quoted in a
+    // stock token, so the cashToken-only test blocked the exit for nearly half
+    // the venue during a drawdown -- the exact lock-in the comment above says
+    // it prevents, for the positions most likely to be causing the drawdown.
+    // ANY curve trade back into the QUOTE side is an exit, not just one into
+    // cash. 42.8% of curves are quoted in a stock token, so a cashToken-only
+    // test blocked the exit for nearly half the venue during a drawdown --
+    // the exact lock-in the comment above says it prevents, for the positions
+    // most likely to be causing the drawdown.
+    //
+    // QUOTE SIDE, NOT sellableAssets. The wall pins BOTH legs ONE_OF the same
+    // sealed list, so `assetOut is sellable` is true of every curve trade ever
+    // built, including buys -- testing it would mark the whole venue exempt and
+    // switch the breaker off exactly where the risk is highest. The real
+    // discriminator is that sellableAssets = builtinGrantTargets u grantTokens
+    // (grant.ts:344): the launched memecoin arrives as an owner-added EXTRA,
+    // while USDG and the tradeable stock tokens are BUILT IN. So trading out
+    // into a builtin is an exit and trading out into an extra is an entry.
     (intent.kind === "curve-trade" &&
-      limits.cashToken !== undefined &&
-      lc(intent.assetOut) === lc(limits.cashToken));
+      ((limits.cashToken !== undefined && lc(intent.assetOut) === lc(limits.cashToken)) ||
+        (limits.quoteAssets !== undefined && limits.quoteAssets.map(lc).includes(lc(intent.assetOut)))));
 
   if (!isExit && state.highWaterMarkUsdg > 0n && state.equityKnown !== false) {
     const drawdownBps = Number(

--- a/worker/src/revert.test.ts
+++ b/worker/src/revert.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
-import { PATTERN_SOURCES, classifyRevert, suppressionKey } from "./revert";
+import test, { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import { toFunctionSelector } from "viem";
+import { PATTERN_SOURCES, PONS_ERROR_SELECTORS, classifyRevert, suppressionKey } from "./revert";
 
 /**
  * The value of this table is entirely in what it REFUSES to claim, so most of
@@ -159,4 +161,105 @@ test("REGRESSION: no stray control characters in the pattern sources", () => {
     // eslint-disable-next-line no-control-regex
     assert.equal(/[\u0000-\u001F]/.test(p), false, `pattern ${JSON.stringify(p)} carries a control character`);
   }
+});
+
+
+/**
+ * PONS REVERTS — permanent conditions that used to look retryable.
+ *
+ * Before this, every curve failure fell to `unclassified`, which this file
+ * deliberately treats as retryable. So a graduated curve would be re-proposed
+ * every tick for the life of the arm: the 1,242-identical-rejections failure the
+ * header warns about, arriving through a venue the table had never heard of.
+ */
+describe("Pons adapter reverts", () => {
+  const revertData = (selector: string, args = "") => `execution reverted: ${selector}${args}`;
+
+  it("a graduated curve is permanent, not something to retry", () => {
+    const v = classifyRevert(revertData("0x025ac17e"));
+    assert.equal(v.rule, "curve-graduated");
+    assert.equal(v.retryable, false);
+    assert.match(v.detail, /graduated/);
+  });
+
+  it("shape refusals are permanent", () => {
+    for (const sel of [
+      "0xf51cd3d9", // NativeQuoteNotSupported
+      "0xe3716feb", // AssetsDoNotMatchCurve
+      "0x09ee12d5", // NotAContract
+      "0x5048bd62", // IdenticalAssets
+      "0x1f2a2005", // ZeroAmount
+      "0xed3ba6a6", // Reentrant
+    ]) {
+      const v = classifyRevert(revertData(sel));
+      assert.equal(v.rule, "curve-unsupported", sel);
+      assert.equal(v.retryable, false, sel);
+    }
+  });
+
+  it("InsufficientOutput is slippage and IS worth retrying", () => {
+    // The one transient member of the set. It is the adapter's floor firing
+    // against the account's own balance delta, which is the market moving.
+    const v = classifyRevert(revertData("0x2c19b8b8", "0000000000000000000000000000000000000000000000000000000000000001"));
+    assert.equal(v.rule, "slippage");
+    assert.equal(v.retryable, true);
+  });
+
+  it("NoOutput is NOT slippage — a curve that pays nothing is not a market", () => {
+    const v = classifyRevert(revertData("0x5a7cfa65"));
+    assert.equal(v.rule, "curve-unsupported");
+    assert.equal(v.retryable, false);
+  });
+
+  it("Expired is a deadline and retryable", () => {
+    const v = classifyRevert(revertData("0x203d82d8"));
+    assert.equal(v.rule, "deadline");
+    assert.equal(v.retryable, true);
+  });
+
+  it("matches whatever case the RPC hex-encodes with", () => {
+    assert.equal(classifyRevert(revertData("0x025AC17E")).rule, "curve-graduated");
+  });
+
+  it("PONS ITSELF still classifies unclassified, and that is deliberate", () => {
+    // A scoping pass reported Pons's SlippageExceeded as 0x71c4efed while
+    // deriving `SlippageExceeded()` gives 0x8199f5f3. The two disagree, so
+    // neither is evidence, and this file's rule is to add nothing from memory.
+    // Retryable-and-visible beats confidently-wrong.
+    assert.equal(classifyRevert(revertData("0x71c4efed")).rule, "unclassified");
+    assert.equal(classifyRevert(revertData("0x71c4efed")).retryable, true);
+  });
+
+  it("the selectors are four bytes and all distinct", () => {
+    // Cheap guard against a paste error turning two errors into one bucket.
+    for (const s of PONS_ERROR_SELECTORS) assert.match(s, /^0x[0-9a-f]{8}$/);
+    assert.equal(new Set(PONS_ERROR_SELECTORS).size, PONS_ERROR_SELECTORS.length);
+  });
+
+  it("EVERY error declared in PonsSelfTrade.sol is classified", () => {
+    // The drift guard that matters. Adding an error to the .sol without adding
+    // it here means a new permanent failure silently becomes retryable — which
+    // is precisely the bug this whole block exists to fix, one release later.
+    const sol = readFileSync(
+      new URL("../../contracts/contracts/PonsSelfTrade.sol", import.meta.url),
+      "utf8",
+    );
+    const declared = [...sol.matchAll(/^\s*error\s+(\w+)\s*\(([^)]*)\)\s*;/gm)].map((m) => {
+      const args = (m[2] ?? "")
+        .split(",")
+        .map((a) => a.trim().split(/\s+/)[0])
+        .filter(Boolean)
+        .join(",");
+      return `${m[1]}(${args})`;
+    });
+    assert.ok(declared.length >= 12, `expected the .sol to declare errors, found ${declared.length}`);
+    for (const sig of declared) {
+      const sel = toFunctionSelector(`function ${sig}`);
+      assert.notEqual(
+        classifyRevert(`execution reverted: ${sel}`).rule,
+        "unclassified",
+        `${sig} (${sel}) is declared in PonsSelfTrade.sol but classifies as unclassified`,
+      );
+    }
+  });
 });

--- a/worker/src/revert.ts
+++ b/worker/src/revert.ts
@@ -48,6 +48,17 @@ export type RevertClass =
   | "no-liquidity"
   /** A deadline passed before inclusion. Transient by construction. */
   | "deadline"
+  /**
+   * The curve graduated. Its market has moved to a pool; this venue is done with
+   * that token forever. The most permanent condition in the taxonomy.
+   */
+  | "curve-graduated"
+  /**
+   * The adapter refused the trade's SHAPE — a native-quoted curve, assets that do
+   * not match the curve, a non-contract asset, identical legs, a zero size. None
+   * of these change by waiting, and all are decided before any money moves.
+   */
+  | "curve-unsupported"
   /** We do not recognise it. Retryable, deliberately — see the header. */
   | "unclassified";
 
@@ -73,7 +84,117 @@ export interface RevertVerdict {
  * Each entry names where its pattern comes from. An entry without a source is
  * an entry to delete.
  */
+/**
+ * PonsSelfTrade's custom-error selectors.
+ *
+ * COMPUTED, NOT REMEMBERED, per this file's own rule. The signatures were read
+ * out of contracts/contracts/PonsSelfTrade.sol:154-165 and the selectors derived
+ * from them with `toFunctionSelector`, so a rename in the .sol that is not
+ * mirrored here surfaces as an unclassified revert rather than as a confident
+ * misclassification.
+ *
+ * Solidity revert data is `selector ++ abi.encode(args)`, so matching the leading
+ * four bytes is exact and the arguments are ignored. Case-insensitive because
+ * different RPCs hex-encode with different case.
+ *
+ * WHAT IS DELIBERATELY ABSENT: the errors PONS ITSELF reverts with. Those come
+ * from a contract this repo does not own, so their signatures cannot be read out
+ * of source. A scoping pass suggested Pons's SlippageExceeded is 0x71c4efed;
+ * deriving `SlippageExceeded()` gives 0x8199f5f3, so the two disagree and neither
+ * is evidence. A selector guessed from a plausible name is exactly the
+ * confident-misclassification the header forbids, so Pons's own reverts classify
+ * `unclassified` — retryable, and visible — until one is observed on chain and
+ * added with the transaction that produced it.
+ */
+const PONS_ERR = {
+  Expired: "0x203d82d8",
+  ZeroAmount: "0x1f2a2005",
+  NotAContract: "0x09ee12d5",
+  Reentrant: "0xed3ba6a6",
+  NativeQuoteNotSupported: "0xf51cd3d9",
+  CurveGraduated: "0x025ac17e",
+  AssetsDoNotMatchCurve: "0xe3716feb",
+  IdenticalAssets: "0x5048bd62",
+  InsufficientOutput: "0x2c19b8b8",
+  NoOutput: "0x5a7cfa65",
+  TransferFailed: "0x90b8ec18",
+  ApprovalFailed: "0x8164f842",
+} as const;
+
+/** The selectors, for the test that asserts they are 4 bytes and all distinct. */
+export const PONS_ERROR_SELECTORS: readonly string[] = Object.values(PONS_ERR);
+
 const PATTERNS: readonly { re: RegExp; rule: RevertClass; retryable: boolean; detail: string }[] = [
+  {
+    // ABOVE the generic entries. These are exact four-byte matches and cannot
+    // collide with a prose revert string, so specificity costs nothing.
+    re: new RegExp(PONS_ERR.CurveGraduated, "i"),
+    rule: "curve-graduated",
+    retryable: false,
+    detail:
+      "this token has graduated off its bonding curve — its market is a pool now, and the adapter " +
+      "refuses by name rather than trading at a price for a market that has moved. Retrying cannot " +
+      "undo a graduation; the position has to be routed through a pool venue instead.",
+  },
+  {
+    re: new RegExp(
+      [
+        PONS_ERR.NativeQuoteNotSupported,
+        PONS_ERR.AssetsDoNotMatchCurve,
+        PONS_ERR.NotAContract,
+        PONS_ERR.IdenticalAssets,
+        PONS_ERR.ZeroAmount,
+        PONS_ERR.Reentrant,
+      ].join("|"),
+      "i",
+    ),
+    rule: "curve-unsupported",
+    retryable: false,
+    detail:
+      "the adapter refused the shape of this trade before any money moved — a native-quoted curve, " +
+      "assets that do not belong to it, a non-contract asset, identical legs, or a zero size. None of " +
+      "these change by waiting, so the intent is suppressed rather than repeated every tick.",
+  },
+  {
+    // The adapter's own floor, measured against the ACCOUNT's balance delta
+    // rather than the curve's claim — so this fires on a real shortfall, not on a
+    // curve lying about what it paid. Genuinely transient: it is the venue moving
+    // between quote and fill, which is what a floor is for.
+    re: new RegExp(PONS_ERR.InsufficientOutput, "i"),
+    rule: "slippage",
+    retryable: true,
+    detail:
+      "the curve delivered less than the floor this operation was signed with, measured against the " +
+      "account's own balance rather than the curve's word for it. Nothing moved. Worth retrying at a " +
+      "fresh quote.",
+  },
+  {
+    // Zero delivered. NOT slippage — a curve that takes the input and pays
+    // nothing is broken or hostile, and retrying pays it again.
+    re: new RegExp(PONS_ERR.NoOutput, "i"),
+    rule: "curve-unsupported",
+    retryable: false,
+    detail:
+      "the curve delivered nothing at all. That is not the market moving; it is a curve that took the " +
+      "input and paid no output, which is what the adapter's balance-delta check exists to catch.",
+  },
+  {
+    re: new RegExp(PONS_ERR.Expired, "i"),
+    rule: "deadline",
+    retryable: true,
+    detail:
+      "the curve trade's deadline passed before it was included. Nothing moved, and the next tick " +
+      "builds a fresh one.",
+  },
+  {
+    re: new RegExp([PONS_ERR.TransferFailed, PONS_ERR.ApprovalFailed].join("|"), "i"),
+    rule: "allowance",
+    retryable: false,
+    detail:
+      "the adapter could not pull the input or approve the curve for it. merrymen batches the approve " +
+      "with the trade, so seeing this means the batch did not carry what it should have — a wiring " +
+      "fault, not a market one.",
+  },
   {
     // STF is TransferHelper.safeTransferFrom's revert string in v3-periphery,
     // and it fires when the INPUT token's transferFrom fails — insufficient

--- a/worker/src/store.ts
+++ b/worker/src/store.ts
@@ -2293,6 +2293,43 @@ export async function clearTrenchEntry(agentId: string, mode: BasisMode, symbol:
 }
 
 /**
+ * Every curve this agent has recorded from a launch scan — the provenance set.
+ *
+ * WHY THIS EXISTS. The curve is the one argument the wall cannot pin: a new
+ * address per token, hundreds an hour, so wall.ts passes `null` for it and says
+ * so outright. Off-chain is therefore the ONLY place a curve can be constrained
+ * at all, and checkPolicy's `curve-provenance` rule is the constraint.
+ *
+ * What makes the set trustworthy is upstream, not here: `recordCandidate`'s only
+ * non-test callers are in the worker tick, and the launch scan that feeds them
+ * filters on PONS_V2_FACTORY (venues/pons.ts). So a row in this column is an
+ * address that appeared as the curve of a token launched by the real factory.
+ * That property was INCIDENTAL until the policy rule started depending on it —
+ * which is exactly why it is written down here.
+ *
+ * NOT age-windowed and NOT LIMIT-bounded, unlike `recentCandidates`. A position
+ * opened last week must still be exitable today, and an exit refused because the
+ * curve aged out of a recency window would be the worst possible time to
+ * discover that this list was the wrong shape.
+ *
+ * Returns null on failure, never []. Empty means "no curves known", which would
+ * refuse the whole venue; null means "could not ask", which leaves the rule
+ * unable to run rather than silently converting a database hiccup into a
+ * blanket refusal.
+ */
+export async function knownCurves(): Promise<string[] | null> {
+  try {
+    const rows = (await getDb()
+      .prepare(`SELECT DISTINCT curve FROM discovered_pools WHERE curve IS NOT NULL`)
+      .all()) as { curve: string | null }[];
+    return rows.map((r) => r.curve).filter((c): c is string => !!c).map((c) => c.toLowerCase());
+  } catch {
+    return null;
+  }
+}
+
+
+/**
  * Where a specific token trades on the launchpad — by address, not by recency.
  *
  * `recentCandidates` cannot serve this: it is age-windowed, LIMIT-bounded, and

--- a/worker/src/strategies/registry.ts
+++ b/worker/src/strategies/registry.ts
@@ -31,6 +31,18 @@ export function isCircleStrategy(name: string): boolean {
 }
 
 export interface StrategyBuildOpts {
+  /**
+   * The bonding-curve legs available right now, re-read per decision.
+   *
+   * Supplied by the host (the worker tick), because a curve leg carries THIS
+   * TICK’S reserves — the input a slippage floor is derived from. Optional, so
+   * a host that does not trade curves is unchanged.
+   */
+  curveLegsNow?: () => {
+    legs: ReadonlyMap<string, import("../strategist/proposals").CurveLeg>;
+    tokens: ReadonlyMap<string, `0x${string}`>;
+    slippageBps: number;
+  } | null;
   swapRouter: `0x${string}`;
   usdg6: (v: number) => bigint;
   basketSymbols: string[];
@@ -173,6 +185,9 @@ export function buildStrategy(name: string, opts: StrategyBuildOpts): Strategy {
         maxPerActionUsdg: opts.usdg6(opts.llm.maxActionUsdg),
         maxActionsPerTick: 4,
       },
+      // The curve venue, re-read per decision. Undefined when the host does
+      // not supply one, which keeps every existing strategy identical.
+      curveLegsNow: opts.curveLegsNow,
       decisionIntervalMs: opts.llm.intervalMin * 60_000,
       onNote: opts.onNote,
       onDecision: opts.llm.onDecision,

--- a/worker/src/strategist/proposals.ts
+++ b/worker/src/strategist/proposals.ts
@@ -11,6 +11,13 @@
 
 import type { TradeIntent } from "../policy";
 import type { Snapshot } from "../strategies/types";
+import {
+  curveBuyOut,
+  curveSellOut,
+  curveMinOut,
+  curveGraduated,
+  type CurveReserves,
+} from "../venues/pons-price";
 
 export interface ProposedAction {
   action: "buy" | "sell" | "hold";
@@ -21,6 +28,31 @@ export interface ProposedAction {
   reason: string;
 }
 
+/**
+ * Where a symbol trades when it trades on a bonding curve.
+ *
+ * WHY THE UNIVERSE CARRIES A QUOTE. This file is pure and synchronous on
+ * purpose — the boundary a model's words cross has no I/O, so nothing it says
+ * can make a network call. But a curve trade needs a `minAmountOutRaw`, and
+ * deriving one needs the curve's reserves. So the RESERVES ride here, read once
+ * per tick by the caller, and the arithmetic (curveBuyOut / curveMinOut) stays
+ * pure and happens below.
+ *
+ * That also fixes the thing the intent type asks for by name: the quote that
+ * sizes the trade and the floor the chain enforces come from ONE reading of a
+ * curve the repo's own prose says can move 1,546 bps at p99 over four minutes.
+ */
+export interface CurveLeg {
+  /** The bonding curve. An argument the wall cannot pin — see wall.ts. */
+  curve: `0x${string}`;
+  /** What the curve is quoted in. `0x000…0` means native ETH, which is unreachable. */
+  quoteToken: `0x${string}`;
+  /** The PonsSelfTrade adapter sealed into THIS grant — never from settings. */
+  adapter: `0x${string}`;
+  /** Reserves as of this tick, for the quote. */
+  reserves: CurveReserves;
+}
+
 export interface StrategistUniverse {
   /** symbol → token for every tradable leg. Anything else is rejected. */
   legs: ReadonlyMap<string, `0x${string}`>;
@@ -29,6 +61,19 @@ export interface StrategistUniverse {
   /** Hard per-proposal ceiling (6dp) — independent of, and beneath, grant caps. */
   maxPerActionUsdg: bigint;
   maxActionsPerTick: number;
+  /**
+   * symbol → its bonding curve, for tokens that trade on one.
+   *
+   * Optional so every existing caller and fixture keeps working unchanged: a
+   * universe without curve legs behaves exactly as it did, which is what makes
+   * this additive rather than a rewrite of the boundary.
+   */
+  curveLegs?: ReadonlyMap<string, CurveLeg>;
+  /** symbol → token address for curve legs. Kept beside `legs`, not merged into
+   *  it, because `legs` means “has a pool” to every other arm in this file. */
+  curveTokens?: ReadonlyMap<string, `0x${string}`>;
+  /** Slippage tolerance for a derived curve floor, bps. Defaults to 100. */
+  slippageBps?: number;
 }
 
 export interface ValidationResult {
@@ -65,6 +110,113 @@ export function proposalsToIntents(
     }
     if (p.action === "hold") continue;
 
+    if (!Number.isFinite(p.sizeUsdg) || p.sizeUsdg <= 0) {
+      rejected.push(`#${i} ${p.symbol}: size ${p.sizeUsdg} is not a positive number`);
+      continue;
+    }
+    const size = usdg6(p.sizeUsdg);
+
+    // ── the curve venue ───────────────────────────────────────────────────
+    //
+    // THE STAGE THAT MAKES THE AGENT ABLE TO PROPOSE ONE AT ALL. Every arm below
+    // constructs `kind: "swap"` against a single `swapRouter`, so no matter what
+    // else shipped, the strategist could never emit a curve trade — while
+    // memecoin-scout already tells the model that coins launch on the Pons
+    // launchpad. The model could name a curve coin and this boundary would
+    // always answer "not in the tradable universe".
+    //
+    // Checked BEFORE the pool legs, because a token that trades on a curve has
+    // no pool: routing it to the swap router builds an operation against a pool
+    // that does not exist.
+    const curveLeg = universe.curveLegs?.get(p.symbol);
+    if (curveLeg) {
+      const token = universe.curveTokens?.get(p.symbol);
+      if (!token) {
+        rejected.push(`#${i} ${p.symbol}: curve leg with no token address`);
+        continue;
+      }
+      if (snap.pausedTokens.has(token.toLowerCase())) {
+        rejected.push(`#${i} ${p.symbol}: token is paused`);
+        continue;
+      }
+      // NATIVE-QUOTED CURVES ARE UNREACHABLE, and saying so beats a revert. The
+      // adapter is non-payable and every wall permission carries valueLimit 0.
+      if (/^0x0{40}$/i.test(curveLeg.quoteToken)) {
+        rejected.push(`#${i} ${p.symbol}: curve is quoted in native ETH, which this adapter cannot trade`);
+        continue;
+      }
+      if (curveGraduated(curveLeg.reserves)) {
+        rejected.push(`#${i} ${p.symbol}: curve has graduated — its market is a pool now`);
+        continue;
+      }
+
+      const isBuy = p.action === "buy";
+      let amountInRaw: bigint;
+      let assetIn: `0x${string}`;
+      let assetOut: `0x${string}`;
+      if (isBuy) {
+        // Only a USDG-quoted curve is one hop from the agent's cash. Anything
+        // else needs a hop through the quote asset first, which is not built.
+        if (curveLeg.quoteToken.toLowerCase() !== universe.usdg.toLowerCase()) {
+          rejected.push(`#${i} ${p.symbol}: curve is not quoted in USDG, so buying it needs a hop I don't do yet`);
+          continue;
+        }
+        if (size > cashLeft) {
+          rejected.push(`#${i} ${p.symbol}: buy ${p.sizeUsdg} USDG exceeds available cash`);
+          continue;
+        }
+        assetIn = universe.usdg;
+        assetOut = token;
+        amountInRaw = size;
+      } else {
+        const held = snap.holdings.get(p.symbol);
+        if (!held || held.rawBalance === 0n) {
+          rejected.push(`#${i} ${p.symbol}: nothing held to sell`);
+          continue;
+        }
+        assetIn = token;
+        assetOut = curveLeg.quoteToken;
+        // Proportional where the holding has a value, whole where it does not.
+        // A curve token the guard refuses to price has valueUsdg 0, and the
+        // right answer there is to sell all of it rather than nothing.
+        amountInRaw =
+          held.valueUsdg > 0n && size < held.valueUsdg
+            ? (held.rawBalance * size) / held.valueUsdg
+            : held.rawBalance;
+      }
+      if (amountInRaw <= 0n) {
+        rejected.push(`#${i} ${p.symbol}: size rounds to zero`);
+        continue;
+      }
+
+      const quoted = isBuy
+        ? curveBuyOut(curveLeg.reserves, amountInRaw)
+        : curveSellOut(curveLeg.reserves, amountInRaw);
+      if (quoted === null) {
+        rejected.push(`#${i} ${p.symbol}: the curve's reserves don't support a trade this size`);
+        continue;
+      }
+      const minAmountOutRaw = curveMinOut(quoted, universe.slippageBps ?? 100);
+      if (minAmountOutRaw === null || minAmountOutRaw <= 0n) {
+        rejected.push(`#${i} ${p.symbol}: no slippage floor could be derived — refusing to size it blind`);
+        continue;
+      }
+
+      if (isBuy) cashLeft -= size;
+      intents.push({
+        kind: "curve-trade",
+        target: curveLeg.adapter,
+        curve: curveLeg.curve,
+        assetIn,
+        assetOut,
+        amountInRaw,
+        minAmountOutRaw,
+        notionalUsdg: isBuy ? size : quoted,
+      });
+      accepted.push(p);
+      continue;
+    }
+
     const token = universe.legs.get(p.symbol);
     if (!token) {
       rejected.push(`#${i} ${p.symbol}: not in the tradable universe`);
@@ -74,11 +226,7 @@ export function proposalsToIntents(
       rejected.push(`#${i} ${p.symbol}: token is paused`);
       continue;
     }
-    if (!Number.isFinite(p.sizeUsdg) || p.sizeUsdg <= 0) {
-      rejected.push(`#${i} ${p.symbol}: size ${p.sizeUsdg} is not a positive number`);
-      continue;
-    }
-    const size = usdg6(p.sizeUsdg);
+
     if (size > universe.maxPerActionUsdg) {
       rejected.push(`#${i} ${p.symbol}: ${p.sizeUsdg} USDG exceeds strategist ceiling`);
       continue;

--- a/worker/src/strategist/strategist.test.ts
+++ b/worker/src/strategist/strategist.test.ts
@@ -322,3 +322,147 @@ describe("makeLlmStrategist — decision windows, not per-tick chatter", () => {
     assert.equal(driver.calls, 0);
   });
 });
+
+
+/**
+ * THE VENUE THE AGENT COULD NEVER PROPOSE.
+ *
+ * Every arm of proposalsToIntents constructed `kind: "swap"` against a single
+ * swapRouter over a symbol→token legs map, so no strategy — deterministic or
+ * LLM — could emit a curve trade no matter what else shipped. Meanwhile
+ * memecoin-scout already tells the model that coins launch on the Pons
+ * launchpad, so the model would name a curve coin and this boundary would
+ * answer "not in the tradable universe", forever.
+ */
+describe("the curve venue at the proposal boundary", () => {
+  const CURVE = "0x7777777777777777777777777777777777777777" as const;
+  const ADAPTER = "0x8888888888888888888888888888888888888888" as const;
+  const MEME = "0x9999999999999999999999999999999999999999" as const;
+
+  // A curve with real reserves: 2 units of quote against 3,000,000 tokens.
+  const reserves = {
+    quoteRaw: 2_000_000_000_000_000_000n,
+    tokenRaw: 3_000_000_000_000_000_000_000_000n,
+    quoteDecimals: 18,
+    tokenDecimals: 18,
+    graduationThresholdRaw: 5_000_000_000_000_000_000n,
+  };
+
+  const curveUniverse = (over: Partial<StrategistUniverse> = {}) =>
+    universe({
+      curveLegs: new Map([["PEPE", { curve: CURVE, quoteToken: USDG, adapter: ADAPTER, reserves }]]),
+      curveTokens: new Map([["PEPE", MEME]]),
+      slippageBps: 100,
+      ...over,
+    });
+
+  it("emits a curve-trade for a token that trades on a curve", () => {
+    const r = proposalsToIntents(
+      [{ action: "buy", symbol: "PEPE", sizeUsdg: 10, reason: "launchpad momentum" }],
+      curveUniverse(),
+      snap(),
+    );
+    assert.equal(r.intents.length, 1, r.rejected.join("; "));
+    const i = r.intents[0]!;
+    assert.equal(i.kind, "curve-trade");
+    if (i.kind !== "curve-trade") return;
+    // The TARGET is the adapter, never the curve — the curve is an argument the
+    // wall cannot pin, which is the whole reason the adapter exists.
+    assert.equal(i.target, ADAPTER);
+    assert.equal(i.curve, CURVE);
+    assert.equal(i.assetIn, USDG);
+    assert.equal(i.assetOut, MEME);
+    // And it carries a real floor, derived from the SAME reserves that sized it.
+    assert.ok(i.minAmountOutRaw > 0n, "a curve trade without a floor is unbounded");
+  });
+
+  it("a curve token is NOT rejected as 'not in the tradable universe'", () => {
+    // The specific failure a user would have hit: the pool-leg lookup rejects
+    // anything missing from `legs`, and a curve token is missing from `legs` by
+    // definition — it has no pool. Ordering is the fix and this pins it.
+    const r = proposalsToIntents(
+      [{ action: "buy", symbol: "PEPE", sizeUsdg: 10, reason: "x" }],
+      curveUniverse(),
+      snap(),
+    );
+    assert.equal(r.rejected.length, 0, r.rejected.join("; "));
+  });
+
+  it("refuses a native-quoted curve by name rather than by revert", () => {
+    // The adapter is non-payable and every wall permission carries valueLimit 0,
+    // so this can never work. ~47% of launches are native-quoted.
+    const r = proposalsToIntents(
+      [{ action: "buy", symbol: "PEPE", sizeUsdg: 10, reason: "x" }],
+      curveUniverse({
+        curveLegs: new Map([
+          [
+            "PEPE",
+            {
+              curve: CURVE,
+              quoteToken: "0x0000000000000000000000000000000000000000" as const,
+              adapter: ADAPTER,
+              reserves,
+            },
+          ],
+        ]),
+      }),
+      snap(),
+    );
+    assert.equal(r.intents.length, 0);
+    assert.match(r.rejected.join(" "), /native ETH/);
+  });
+
+  it("refuses a graduated curve — its market has moved to a pool", () => {
+    // Graduation is the TOKEN side emptying, not the quote side filling —
+    // PonsSelfTrade.sol describes exactly this shape: “quote side back at the
+    // virtual seed, token side empty”.
+    const graduated = { ...reserves, tokenRaw: 0n };
+    const r = proposalsToIntents(
+      [{ action: "buy", symbol: "PEPE", sizeUsdg: 10, reason: "x" }],
+      curveUniverse({
+        curveLegs: new Map([["PEPE", { curve: CURVE, quoteToken: USDG, adapter: ADAPTER, reserves: graduated }]]),
+      }),
+      snap(),
+    );
+    assert.equal(r.intents.length, 0);
+    assert.match(r.rejected.join(" "), /graduated/);
+  });
+
+  it("sells the WHOLE holding when the curve mark is unpriceable", () => {
+    // valueUsdg 0 is the normal state for a curve token the price guard refuses,
+    // and the right answer is to sell all of it rather than nothing. Refusing
+    // would strand the position exactly when it most needs an exit.
+    const r = proposalsToIntents(
+      [{ action: "sell", symbol: "PEPE", sizeUsdg: 10, reason: "x" }],
+      curveUniverse(),
+      snap({
+        // A real holding. 500 raw units against a 3e24 token reserve is dust: the
+        // quote rounds to zero and the trade is correctly refused, which would
+        // have made this test pass for the wrong reason.
+        holdings: new Map([["PEPE", { token: MEME, rawBalance: 500_000_000_000_000_000_000n, valueUsdg: 0n, priceStale: false }]]),
+      }),
+    );
+    assert.equal(r.intents.length, 1, r.rejected.join("; "));
+    const i = r.intents[0]!;
+    if (i.kind !== "curve-trade") throw new Error("expected a curve trade");
+    assert.equal(
+      i.amountInRaw,
+      500_000_000_000_000_000_000n,
+      "an unpriceable holding must still be fully sellable",
+    );
+    assert.equal(i.assetIn, MEME);
+    assert.equal(i.assetOut, USDG);
+  });
+
+  it("a universe with no curve legs behaves exactly as before", () => {
+    // The change must be additive — every existing caller and fixture passes no
+    // curve legs at all.
+    const r = proposalsToIntents(
+      [{ action: "buy", symbol: "AAPL", sizeUsdg: 10, reason: "x" }],
+      universe(),
+      snap(),
+    );
+    assert.equal(r.intents.length, 1);
+    assert.equal(r.intents[0]!.kind, "swap");
+  });
+});

--- a/worker/src/strategist/strategy.ts
+++ b/worker/src/strategist/strategy.ts
@@ -33,6 +33,23 @@ export interface StrategistDecision {
 export interface LlmStrategistConfig {
   driver: ProposalDriver;
   universe: StrategistUniverse;
+  /**
+   * The curve legs available RIGHT NOW, re-read each decision.
+   *
+   * A function rather than a field because `universe` is built once at
+   * strategy construction while a curve leg carries this tick's RESERVES —
+   * the input a slippage floor is derived from. Freezing them at startup
+   * would size every future trade against a curve as it looked when the
+   * worker booted, on a venue whose p99 move over four minutes is 1,546 bps.
+   *
+   * Optional: absent means no curve venue, which is exactly how every
+   * existing caller behaves.
+   */
+  curveLegsNow?: () => {
+    legs: ReadonlyMap<string, import("./proposals").CurveLeg>;
+    tokens: ReadonlyMap<string, `0x${string}`>;
+    slippageBps: number;
+  } | null;
   /** Minimum ms between model calls — decisions are windows, ticks are not. */
   decisionIntervalMs: number;
   /** Injectable clock for tests. */
@@ -119,7 +136,17 @@ export function makeLlmStrategist(cfg: LlmStrategistConfig): Strategy {
       const { actions, malformed } = parseProposals(raw);
       if (malformed > 0) note("warn", `strategist emitted ${malformed} malformed action(s) — dropped`);
 
-      const { intents, accepted, rejected } = proposalsToIntents(actions, cfg.universe, snap);
+      // Merged HERE, not at construction, so the reserves are this tick's.
+      const curve = cfg.curveLegsNow?.() ?? null;
+      const universeNow: StrategistUniverse = curve
+        ? {
+            ...cfg.universe,
+            curveLegs: curve.legs,
+            curveTokens: curve.tokens,
+            slippageBps: curve.slippageBps,
+          }
+        : cfg.universe;
+      const { intents, accepted, rejected } = proposalsToIntents(actions, universeNow, snap);
 
       // Journal the decision BEFORE the intent leaves for the policy wall: every
       // survivor gets a decisionId stamped onto its intent (so the resulting trade

--- a/worker/src/venues/pons-price.test.ts
+++ b/worker/src/venues/pons-price.test.ts
@@ -11,6 +11,10 @@ import {
   curvePrice,
   realQuoteRaw,
   virtualSeedRaw,
+  curveBuyOut,
+  curveSellOut,
+  curveMinOut,
+  CURVE_FEE_BPS,
   type CurveReserves,
 } from "./pons-price";
 
@@ -404,5 +408,95 @@ describe("curvePriceUsable", () => {
     assert.equal((v as { kind: string }).kind, "impact-cap");
     // A null impact is not a refusal: not every caller is sizing a trade.
     assert.equal(curvePriceUsable({ ...ok, impactBps: null }, G).ok, true);
+  });
+});
+
+
+/**
+ * THE QUOTE FUNCTIONS — the thing that stood between a curve buy and an
+ * unbounded loss, and that did not exist until now.
+ *
+ * The arithmetic was lifted OUT of curveBuyImpactBps, which computed tokensOut
+ * and threw it away. So the first duty of these tests is to prove the two have
+ * not drifted: the lift must be a lift, not a rewrite that happens to look
+ * similar.
+ */
+describe("curve quotes", () => {
+  it("agrees with the impact function it was lifted from", () => {
+    // Same reserves, same input, zero fee: the effective price implied by
+    // curveBuyOut must reproduce curveBuyImpactBps. Computed here from the
+    // frictionless output so the fee does not confound the comparison.
+    const inRaw = 1_000_000_000_000_000n;
+    const out = curveBuyOut(LIVE, inRaw);
+    assert.ok(out !== null && out > 0n);
+    // Undo the fee to recover the frictionless output the impact fn assumes.
+    const k = LIVE.quoteRaw * LIVE.tokenRaw;
+    const frictionless = LIVE.tokenRaw - k / (LIVE.quoteRaw + inRaw);
+    const SCALE = 1_000_000_000_000n;
+    const spot = (LIVE.quoteRaw * SCALE) / LIVE.tokenRaw;
+    const paid = (inRaw * SCALE) / frictionless;
+    const expected = Number(((paid - spot) * 10_000n) / spot);
+    assert.equal(curveBuyImpactBps(LIVE, inRaw), expected, "the lift changed the maths");
+  });
+
+  it("is FEE-AWARE, so a derived floor is not systematically too high", () => {
+    // The whole reason the constant exists. A frictionless quote produces a
+    // minAmountOut the honest case cannot meet, and the trade reverts having
+    // paid gas to be told the market did exactly what it was going to do.
+    const inRaw = 1_000_000_000_000_000n;
+    const k = LIVE.quoteRaw * LIVE.tokenRaw;
+    const frictionless = LIVE.tokenRaw - k / (LIVE.quoteRaw + inRaw);
+    const withFee = curveBuyOut(LIVE, inRaw);
+    assert.ok(withFee !== null);
+    assert.ok(withFee < frictionless, "fee-aware quote must be below the frictionless one");
+    // And by roughly the fee, not by some other amount.
+    const shortfallBps = Number(((frictionless - withFee) * 10_000n) / frictionless);
+    assert.ok(
+      Math.abs(shortfallBps - Number(CURVE_FEE_BPS)) <= 2,
+      `shortfall ${shortfallBps} bps should track the ${CURVE_FEE_BPS} bps fee`,
+    );
+  });
+
+  it("a round trip loses about two fees — the number a strategy has to beat", () => {
+    // ~199 bps round trip. Stated as a test because it is the economics of the
+    // whole venue: against merrymen's ~47 bps pool floor, a curve strategy has
+    // to clear roughly 2% before gas to be worth running at all.
+    const inRaw = 100_000_000_000_000n;
+    const tokens = curveBuyOut(LIVE, inRaw);
+    assert.ok(tokens !== null);
+    const back = curveSellOut(LIVE, tokens);
+    assert.ok(back !== null);
+    const lossBps = Number(((inRaw - back) * 10_000n) / inRaw);
+    assert.ok(lossBps > 150 && lossBps < 320, `round trip lost ${lossBps} bps`);
+  });
+
+  it("returns null, never 0, when it cannot evaluate", () => {
+    // The codebase's central rule. A 0 here is a quote of 'you get nothing',
+    // which a caller would happily sign a minAmountOut of 0 against.
+    assert.equal(curveBuyOut({ ...LIVE, quoteRaw: 0n }, 1n), null);
+    assert.equal(curveBuyOut({ ...LIVE, tokenRaw: 0n }, 1n), null);
+    assert.equal(curveBuyOut(LIVE, 0n), null);
+    assert.equal(curveBuyOut(LIVE, -1n), null);
+    assert.equal(curveSellOut(LIVE, 0n), null);
+    // A dust input whose fee rounds it to nothing is 'cannot evaluate', not 0.
+    assert.equal(curveBuyOut(LIVE, 1n), null);
+  });
+
+  it("curveMinOut refuses a tolerance that would authorise a total loss", () => {
+    assert.equal(curveMinOut(1_000n, 0), 1_000n);
+    assert.equal(curveMinOut(1_000n, 100), 990n);
+    // 100% tolerance is a floor of zero, i.e. no floor. Refused rather than
+    // computed, because a caller that passes it wants a number it should not get.
+    assert.equal(curveMinOut(1_000n, 10_000), null);
+    assert.equal(curveMinOut(1_000n, -1), null);
+    assert.equal(curveMinOut(0n, 100), null);
+  });
+
+  it("the fee constant is HARDCODED, not derived from the unauthenticated tape", () => {
+    // pons-activity.ts filters on topic0 with no address filter, so any contract
+    // on this chain can emit those topics with arbitrary data. If this constant
+    // ever becomes tape-derived, an attacker moves every future slippage floor
+    // for the cost of one contract. Asserting the value pins that decision.
+    assert.equal(CURVE_FEE_BPS, 99n);
   });
 });

--- a/worker/src/venues/pons-price.ts
+++ b/worker/src/venues/pons-price.ts
@@ -189,6 +189,97 @@ export function curvePrice(r: CurveReserves, quoteUsd8: bigint): CurvePrice | nu
  * and "no impact" must not be the same value to a caller deciding whether to
  * spend money.
  */
+/**
+ * THE CURVE'S OWN FEE, IN BASIS POINTS PER SIDE.
+ *
+ * A quote that ignores it is systematically optimistic, and a minAmountOut
+ * derived from an optimistic quote is a floor the honest case trips over: the
+ * trade reverts, the account pays gas, and nothing says why. Measured at ~99 bps
+ * by replaying the compiled adapter against a live USDG-quoted curve through
+ * eth_simulateV1 (10 USDG in, 3,050,001.54 tokens out) versus the frictionless
+ * constant product below.
+ *
+ * HARDCODED ON PURPOSE, and the activity tape VALIDATES it rather than sets it.
+ * pons-activity.ts:24-26 says outright that its eth_getLogs carries no address
+ * filter -- topic0 only -- so any contract on this chain can emit those topics
+ * with arbitrary data words. Deriving this constant from that tape would let an
+ * attacker move the number that sets every future slippage floor, for the cost of
+ * one contract, on a chain already producing hundreds of launches an hour. Any
+ * re-derivation must restrict itself to emitters that appear as curves in the
+ * FACTORY-FILTERED launch set (pons.ts:194).
+ */
+export const CURVE_FEE_BPS = 99n;
+
+/**
+ * How many tokens a quote-in buy actually returns, fee included. Raw units.
+ *
+ * WHY THIS EXISTS SEPARATELY FROM curveBuyImpactBps. That function computes
+ * `tokensOut` on its way to a bps figure and then throws the number away, and it
+ * was the only place in the repo the constant product was written down. So there
+ * was no function anywhere answering “given (curve, amountIn), how many tokens
+ * come back” -- which is the one input a minAmountOut needs, which is the one
+ * field standing between a curve buy and an unbounded loss.
+ *
+ * WHAT THIS IS NOT: an independent check on the curve. `r` is read from the
+ * curve's OWN getReserves(), so a hostile curve reports whatever reserves make
+ * its price look fair and this function faithfully agrees. The floor derived
+ * here bounds HONEST-WORKER SLIPPAGE -- the market moving between quote and
+ * fill -- and is never an answer to the hostile-curve risk. That risk is bounded
+ * elsewhere and only elsewhere: the wall's pinned asset legs, the amountIn-capped
+ * pull, the per-trade approve, and PonsSelfTrade's own measurement of the
+ * CALLER's balance delta. Nobody should later cite minAmountOut as the reason a
+ * strange curve is safe.
+ *
+ * Uses the FULL reserve including the virtual seed, for the reason spelled out
+ * on curveBuyImpactBps: the seed is what the curve itself prices against.
+ *
+ * Returns null, never 0, when it cannot be evaluated.
+ */
+export function curveBuyOut(r: CurveReserves, quoteInRaw: bigint): bigint | null {
+  if (r.quoteRaw <= 0n || r.tokenRaw <= 0n || quoteInRaw <= 0n) return null;
+  // The fee is taken on the way IN, which is why it is applied to the input
+  // rather than the output: a curve that skimmed the output would leave the
+  // invariant holding at a different k, and that is not what was measured.
+  const inAfterFee = (quoteInRaw * (10_000n - CURVE_FEE_BPS)) / 10_000n;
+  if (inAfterFee <= 0n) return null;
+  const k = r.quoteRaw * r.tokenRaw;
+  const newQuote = r.quoteRaw + inAfterFee;
+  const tokensOut = r.tokenRaw - k / newQuote;
+  return tokensOut > 0n ? tokensOut : null;
+}
+
+/**
+ * The sell twin: how much quote asset comes back for `tokenInRaw` tokens.
+ *
+ * Needed as early as the buy, because an entry whose exit cannot be quoted is an
+ * entry nobody can size. Same fee, same seed treatment, same null discipline,
+ * and the same warning as above about whose arithmetic this is.
+ */
+export function curveSellOut(r: CurveReserves, tokenInRaw: bigint): bigint | null {
+  if (r.quoteRaw <= 0n || r.tokenRaw <= 0n || tokenInRaw <= 0n) return null;
+  const inAfterFee = (tokenInRaw * (10_000n - CURVE_FEE_BPS)) / 10_000n;
+  if (inAfterFee <= 0n) return null;
+  const k = r.quoteRaw * r.tokenRaw;
+  const newToken = r.tokenRaw + inAfterFee;
+  const quoteOut = r.quoteRaw - k / newToken;
+  return quoteOut > 0n ? quoteOut : null;
+}
+
+/**
+ * A slippage floor for a curve trade: the quote, less `toleranceBps`.
+ *
+ * Kept beside the quote so the two can never be computed from different readings
+ * of a curve the repo's own prose says can move 1,546 bps at p99 over four
+ * minutes. The intent type already requires this (policy.ts) -- “carried on the
+ * intent rather than recomputed at execution time so the number the trade is
+ * judged against and the number the chain enforces cannot come from two
+ * different readings”.
+ */
+export function curveMinOut(quotedOutRaw: bigint, toleranceBps: number): bigint | null {
+  if (quotedOutRaw <= 0n || toleranceBps < 0 || toleranceBps >= 10_000) return null;
+  return (quotedOutRaw * BigInt(10_000 - toleranceBps)) / 10_000n;
+}
+
 export function curveBuyImpactBps(r: CurveReserves, quoteInRaw: bigint): number | null {
   if (r.quoteRaw <= 0n || r.tokenRaw <= 0n || quoteInRaw <= 0n) return null;
   // Constant product: tokensOut = tokenRaw - k/(quoteRaw + in)


### PR DESCRIPTION
Everything toward buying Pons bonding-curve tokens that needs **nothing from the owner**. Scoped by a 14-agent sweep; this is stages 1-10 of 12.

**Nothing here has executed.** The adapter is not deployed, so this is proven by tests, typechecks and one mainnet *simulation* — not by a landed trade. That deploy is the serialisation point and it belongs to the owner.

## What already existed

`PonsSelfTrade.sol` is a finished adapter handling **both directions** in one function, with slippage measured as the *caller's* own balance delta rather than the curve's claim, a transient reentrancy guard, and no owner/pause/upgrade/rescue. The wall permission is sealed, the call builder and executor arm exist. A scoping agent injected the compiled bytecode into `eth_simulateV1` against a **live mainnet curve**: 10 USDG to 3,050,001.54 tokens, adapter left holding zero, ~99 bps.

An earlier claim that "there is no code path that buys a curve token" was true of the *producer* and wrong about the mechanism.

## Stage 1 — a quote, so a floor can exist

The constant product lived in one place, `curveBuyImpactBps`, which computed `tokensOut` on its way to a bps figure and **threw it away**. So nothing could compute a `minAmountOut` — the one field between a curve buy and an unbounded loss. Lifted out as `curveBuyOut` / `curveSellOut` / `curveMinOut`; a test proves the lift reproduces the original arithmetic exactly.

Fee-aware at 99 bps/side, **hardcoded deliberately**: `pons-activity.ts` states its log scan carries no address filter, so deriving the fee from that tape would let anyone move every future slippage floor for the cost of one contract.

Documented in the function itself: a curve-derived quote is **not** an independent check on that curve — reserves come from its own `getReserves()`, so the floor bounds honest-worker slippage and is never the answer to the hostile-curve risk.

## Stage 4 — stop the mirror running looser than the chain

Sequenced *before* any producer exists.

- **Asset check**: rules sat inside the swap-only branch, so a curve trade reached the bundler having passed none. Now gated on `sellableAssets` (**grant**-sourced), never `allowedAssets` (**settings**-sourced, hot-reloads with no signature) — a test asserts that case, because using the wrong list reproduces the bug.
- **`curve-provenance`, a new rule**: the curve is the one argument the wall *cannot* pin, so off-chain is the only place it can be constrained. Trustworthiness was incidental — the launch scan happens to filter on `PONS_V2_FACTORY`. `store.knownCurves()` makes it enforced, returning `null` not `[]` on failure, since empty would refuse the whole venue.
- **Breaker exit, widened carefully**: it exempted only exits into `cashToken`, but 42.8% of curves are stock-quoted, so nearly half the venue could not exit during a drawdown. The obvious widening is a trap and a test pins it — the wall pins *both* legs to the same list, so "assetOut is sellable" is true of every curve trade **including buys**.
- **Revert classification**: every Pons failure fell to `unclassified` and therefore retryable, so a graduated curve would be re-proposed every tick forever. Selectors are **computed** from `PonsSelfTrade.sol`; a test reads the `.sol` and fails if any declared error goes unclassified. Pons's *own* errors are deliberately absent — a scoping pass reported `SlippageExceeded` as `0x71c4efed`, deriving it gives `0x8199f5f3`, they disagree, so neither is evidence.
- **Suppression scope**: the key passed tokens only for swaps, so one graduated token would suppress the entire venue for the arm.

## Stage 3 — config wiring, verified before sealing

`ponsAdapterAddress` appeared **zero times** in the settings page, settings API and grant page, while the deploy script and runbook both told the owner to paste it into a field that did not exist.

**`verifiedAdapter()` is the load-bearing half.** Sealing an adapter also makes it an approve spender on *every* token in the grant, and the non-USDG approves pass a null amount condition — what `wall.ts` calls "a standing licence to move every share the agent holds". The worker's `getCode` gate runs at **arm** time, after signing. This runs in the browser before the prompt, with two checks because they fail differently: code exists on this chain, and the code answers `tradeExactIn` (which catches a live *wrong* contract). Threaded **by name** at all three mint sites — positionally, this is the edit that already shipped a two-fault bug.

Unknown settings keys are **named, not rejected** — a 400 would break any client round-tripping a blob with a field this build does not know.

## Stage 2 (engineer half) — record the address

The script only printed it, which is why "is it deployed?" could not be answered from the repo, git history, or a running worker. Now `contracts/deployments.json`, keyed by chain id.

## Stages 5-6 — the first producer, and books that can account for it

`submitChatCurveTrade` is the **first `curve-trade` producer in this repo**. `submitChatTrade` now asks where a token actually trades before routing. Every refusal is a sentence instead of gas: no adapter, adapter with no code, token not in the **signature**, paper mode, graduated curve, non-USDG quote, impact past the ceiling. The sell leg sizes from an on-chain `balanceOf` — a curve token the guard refuses to price is exactly the one with no positions row, so the old path would say "you do not hold any X" about a token the owner demonstrably holds.

`describeIntent` returned the literal kind as the action with no symbol, written straight into the decisions table — so every attribution surface showed a nameless action for the trades most needing explanation.

Seven copies of the same ternary decided the ledger's token columns and all seven were wrong for a curve trade; `audit.ts` then passed such a row vacuously. Replaced with one `tokenLegs` helper.

**Two live bugs unrelated to curves:** the hosted mirror copied `trades` with 11 hardcoded columns carrying **no fill, basis, decision or gas data**, so everything the ledger knows about what a trade filled at never left the child's sqlite. And `price_source` was missing from the positions SELECT while the destination defaults to `chainlink` — every non-oracle mark on app.merrymen.dev has been rendering as oracle-grade. A test now asserts a curve mark survives the trip as a curve mark.

## Stage 8 (live half) — a paper memecoin no longer freezes the tick

`readPositions` splits "price temporarily absent" (holds the tick, by design) from "no feed at all" (structural, never resolves). The paper path had no such split, so one simulated memecoin froze equity, the breaker, **and the strategy that would have sold it**. Practice mode is where someone finds out how this behaves, which makes it the worst place to hang.

## Stage 10 — give the agent the venue

Every arm of `proposalsToIntents` constructed a swap against a single router, so **no strategy could emit a curve trade** regardless of what else shipped — while `memecoin-scout` already briefs the model about Pons.

The curve arm is checked **before** the pool-leg lookup, and the ordering is the fix: a curve token is absent from `legs` by definition, so the pool rejection would kill every curve symbol first. A test pins that rejection not firing.

**The universe carries the reserves.** This file is pure and synchronous on purpose. So reserves ride on the leg, read once per tick, and the arithmetic stays pure — which also satisfies what the intent type asks for by name: the quote that *sizes* the trade and the floor the *chain* enforces come from one reading of a curve whose p99 move over four minutes is 1,546 bps. `curveLegsNow` is a function, not a field, because freezing reserves at construction would size every future trade against a curve as it looked at boot.

An unpriceable holding **sells whole** rather than being refused. Additive throughout: a universe with no curve legs behaves identically, and a test asserts it.

## Stage 9 — partial, deliberately

Graduation is an **exit** problem. The thing that must not happen is a quiet fallback to the swap router — 16 of 17 sampled graduated tokens had no v3 pool at any tier. The refusal now names which door is open, which depends on whether the grant carries the *separate* v4 adapter opt-in.

**Not done:** routing a graduated position *through* v4 — that needs PoolKey discovery and the v4 quote path, a second venue's worth of work.

---

**Still the owner's:** deploying the adapter, re-signing, and the Stage 11 pre-authorisation decision. **Stages 11-12 remain.**

Tests 1540/1540, web build clean, contracts compile.
