### PR TITLE
Trencher was silently dead when live, with no way to fix it

### DIFF
--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -66,6 +66,7 @@ export default function SettingsPage() {
   // Scout mode is a boolean, so it can't ride the string `draft`.
   const [scoutEnabled, setScoutEnabled] = useState<boolean | null>(null);
   const [discoveryEnabled, setDiscoveryEnabled] = useState<boolean | null>(null);
+  const [trencherLive, setTrencherLive] = useState<boolean | null>(null);
   const [allowlist, setAllowlist] = useState<number[] | null>(null);
   const [tgTest, setTgTest] = useState<string | null>(null);
   // PC control: master + capability set + string allowlists (also can't ride `draft`).
@@ -220,6 +221,7 @@ export default function SettingsPage() {
     if (virtualsEnabled !== null) body.virtualsEnabled = virtualsEnabled;
     if (scoutEnabled !== null) body.scoutEnabled = scoutEnabled;
     if (discoveryEnabled !== null) body.discoveryEnabled = discoveryEnabled;
+    if (trencherLive !== null) body.trencherLiveEnabled = trencherLive;
     if (allowlist !== null) body.telegramAllowlist = allowlist;
     if (pcEnabled !== null) body.telegramPcControlEnabled = pcEnabled;
     if (caps !== null) body.telegramCapabilities = caps;
@@ -317,6 +319,7 @@ export default function SettingsPage() {
   const virtualsEnabledVal = virtualsEnabled ?? view.values.virtualsEnabled ?? d.virtualsEnabled;
   const scoutEnabledVal = scoutEnabled ?? view.values.scoutEnabled ?? d.scoutEnabled;
   const discoveryEnabledVal = discoveryEnabled ?? view.values.discoveryEnabled ?? d.discoveryEnabled;
+  const trencherLiveVal = trencherLive ?? view.values.trencherLiveEnabled ?? d.trencherLiveEnabled;
   const allowlistVal = allowlist ?? view.values.telegramAllowlist ?? [];
   const pcEnabledVal = pcEnabled ?? view.values.telegramPcControlEnabled ?? d.telegramPcControlEnabled;
   const agentEnabledVal = agentEnabled ?? view.values.telegramAgentEnabled ?? d.telegramAgentEnabled;
@@ -682,6 +685,32 @@ export default function SettingsPage() {
               <span className="field-hint">
                 Needs a Bitquery key above (or the Merry Circle brain, whose token works for both).
                 Without one this does nothing and says nothing.
+              </span>
+            </label>
+            {/* THE FLAG THAT MADE TRENCHER LOOK BROKEN.
+                It has had an API branch and no control, so an owner who picked
+                trencher and went live got a candidate feed that returned nothing,
+                forever, with nothing said. index.ts says the surprise out loud
+                -- “the strategy stopped seeing anything at the exact moment it
+                became able to act” -- and then left the only remedy unreachable. */}
+            <label className="field settings-field">
+              <span className="field-label">let trencher trade for real</span>
+              <span className="field-input">
+                <input
+                  type="checkbox"
+                  checked={trencherLiveVal}
+                  onChange={(e) => setTrencherLive(e.target.checked)}
+                  style={{ width: "auto" }}
+                />
+                <span className="field-unit">
+                  {trencherLiveVal ? "trencher can open real positions" : "practice only"}
+                </span>
+              </span>
+              <span className="field-hint">
+                Off by default, and until you turn it on the trencher strategy sees no
+                candidates at all once your agent can actually trade &mdash; so it looks like
+                it simply never finds anything. It still cannot touch a token your grant
+                does not name: turning this on removes a rail, not the wall.
               </span>
             </label>
             <Field

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1128,6 +1128,8 @@ async function main() {
    * Live trenching is reachable, it just costs the owner the same two deliberate
    * steps as any other token. That is the feature, not a limitation.
    */
+  // Once per arm — a warning repeated every 60 seconds is a log nobody reads.
+  let trencherRailAnnounced = false;
   async function trenchCandidates(): Promise<Candidate[]> {
     // THE RAIL, MADE EXPLICIT rather than removed.
     //
@@ -1140,7 +1142,30 @@ async function main() {
     // replaces every other bound — the scout budget still gates a buy into a
     // token nobody can independently value, the per-trade cap still holds, and
     // the wall still refuses any asset the signature does not name.
-    if (!paperActive() && !cfg.trencherLiveEnabled) return [];
+    if (!paperActive() && !cfg.trencherLiveEnabled) {
+      // SAY IT. The rail was made explicit in the config and stayed invisible in
+      // operation: an owner who picked trencher and armed a real key got an empty
+      // feed every tick, forever, and the only evidence was the absence of
+      // trades. A user reported it as “it didn't take any trades yet” and then
+      // as “I think I'm stuck in paper mode”, which is the shape of a system
+      // that refuses without saying so. Logged once per arm, not per tick.
+      if (!trencherRailAnnounced) {
+        trencherRailAnnounced = true;
+        console.log(
+          "[trencher] live trenching is off, so the candidate feed is empty. " +
+            "Turn on 'let trencher trade for real' in settings to enable it.",
+        );
+        if (active) {
+          void addEvent(
+            active.agentId,
+            "warn",
+            "trencher is running but live trenching is off, so it sees no candidates and will never " +
+              "open a position. Turn on 'let trencher trade for real' in settings.",
+          );
+        }
+      }
+      return [];
+    }
     const nowSec = Math.floor(Date.now() / 1000);
     const out: Candidate[] = [];
     for (const c of await recentCandidates(TRENCHER_DEFAULTS.maxAgeSec, 25, { poolsOnly: true })) {

--- a/worker/src/v4-wiring.test.ts
+++ b/worker/src/v4-wiring.test.ts
@@ -97,7 +97,30 @@ describe("a v4 mark is a weaker kind of evidence, and stays one", () => {
  */
 describe("trencher goes live only when the owner says so", () => {
   it("still returns nothing when neither paper nor live is on", () => {
-    assert.match(INDEX, /if \(!paperActive\(\) && !cfg\.trencherLiveEnabled\) return \[\];/);
+    // Tests the GUARD, not its formatting. This pinned the exact one-line source
+    // and broke the moment the branch grew a body — a fine trade if the body were
+    // cosmetic, but the body IS the fix (next test).
+    assert.match(INDEX, /if \(!paperActive\(\) && !cfg\.trencherLiveEnabled\) \{/);
+    const guard = INDEX.slice(INDEX.indexOf("if (!paperActive() && !cfg.trencherLiveEnabled)")).slice(0, 1400);
+    assert.match(guard, /return \[\];/, "the guard must still return no candidates");
+  });
+
+  it("SAYS SO instead of returning an empty feed in silence", () => {
+    // A user picked trencher, armed a real key, and got an empty candidate feed
+    // every tick forever. He reported it as “it didn't take any trades yet” and
+    // then “I think I'm stuck in paper mode” — the shape of a system refusing
+    // without saying so. index.ts's own comment calls the surprise out, and then
+    // left it silent.
+    const guard = INDEX.slice(INDEX.indexOf("if (!paperActive() && !cfg.trencherLiveEnabled)")).slice(0, 1400);
+    assert.match(guard, /trencherRailAnnounced/, "the refusal must be announced");
+    assert.match(guard, /addEvent/, "and recorded where the owner can see it");
+  });
+
+  it("the remedy is reachable from the settings page", () => {
+    // The flag had an API branch and no input, so the one action that would fix
+    // it could not be taken. Same class as ponsAdapterAddress.
+    const page = readFileSync(new URL("../../web/src/app/settings/page.tsx", import.meta.url), "utf8");
+    assert.match(page, /trencherLiveEnabled/, "no control means no remedy");
   });
 
   it("is OFF by default — spending real money is opt-in", async () => {


### PR DESCRIPTION
Two users, same day:

> "It didn't take any trades yet" / "Why not?"
> "I chose trencher" / "I want it to trade very actively"
> "But think I'm stuck in paper mode"

**Neither was confused.** `trenchCandidates()` opens with:

```
if (!paperActive() && !cfg.trencherLiveEnabled) return [];
```

So the moment an owner's agent becomes able to trade for real, the trencher candidate feed returns **nothing** — every tick, forever, with nothing logged and nothing on any screen. The strategy stops seeing anything at the exact moment it becomes able to act.

`index.ts` already says this out loud in a comment — *"Safe, and a strange thing to discover"* — and then returns `[]` in silence.

## The remedy was unreachable

`trencherLiveEnabled` has a settings type, a default, a worker read, and an API branch — and **zero occurrences** in `web/src/app/settings/page.tsx`.

That is the same class of bug as `ponsAdapterAddress`: wired everywhere except where a person could touch it. Two in one codebase suggests it is worth a lint, not just a fix.

## What changed

- A toggle in settings: **"let trencher trade for real"**, with a hint that says plainly what happens while it is off.
- The refusal is **announced once per arm** — to the log and to the agent's own event feed, where the owner reads it. Once per arm, not per tick: a warning repeated every 60 seconds is a log nobody reads.

## Tests

The existing guard test pinned the exact one-line source and broke when the branch grew a body. Rewritten to test the **guard** rather than its formatting, plus two new ones:

- the refusal must be announced (`trencherRailAnnounced`, `addEvent`)
- **the remedy must exist in the settings page** — this is the test that would have caught the original bug

Turning the flag on removes a rail, not the wall: the scout budget still gates a buy into anything nobody can independently value, the per-trade cap still holds, and the signature still refuses any asset it does not name.

---

Tests 1533/1533, web build clean.