### PR TITLE
Sponsored gas: fund one asset instead of two

### DIFF
--- a/packages/core/src/chain.ts
+++ b/packages/core/src/chain.ts
@@ -65,6 +65,24 @@ export function pimlicoBundlerUrl(chainId: number, apiKey: string): string {
   return `https://api.pimlico.io/v2/${chainId}/rpc?apikey=${encodeURIComponent(apiKey)}`;
 }
 
+/**
+ * The Pimlico PAYMASTER RPC — the same endpoint as the bundler.
+ *
+ * Verified by probe, not by documentation: `pm_getPaymasterStubData` against
+ * chain 4663 on this URL returns a real paymaster address and signed
+ * paymasterData. That mattered enough to check, because the alternative to
+ * Pimlico serving one here is deploying our own paymaster contract.
+ *
+ * A separate function despite being the same string today, for the reason the
+ * bundler helper exists: the chain id is stamped from the grant, so a testnet
+ * grant can never reach a mainnet sponsor. Deliberately NOT an operator-supplied
+ * override — an override would reintroduce the wrong-chain class this shape makes
+ * impossible, and bundlerChainMismatch only inspects the bundler URL.
+ */
+export function pimlicoPaymasterUrl(chainId: number, apiKey: string): string {
+  return `https://api.pimlico.io/v2/${chainId}/rpc?apikey=${encodeURIComponent(apiKey)}`;
+}
+
 /** ERC-4337 EntryPoints — all deployed on both mainnet and testnet (probed 2026-07-09). */
 export const ENTRYPOINT = {
   v06: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -234,6 +234,16 @@ export interface MerrymenSettings {
    * the per-trade cap and the wall.
    */
   trencherLiveEnabled?: boolean;
+  /**
+   * Pay this agent's gas from a sponsor, so the owner funds USDG only.
+   *
+   * HOUSE-OWNED (see HOUSE_KEY_FIELDS) because hosted it spends OUR money, not
+   * the tenant's — a third category from the key/URL split that file draws.
+   * A tenant who could set this would be writing a cheque on the house.
+   */
+  sponsorGasEnabled?: boolean;
+  /** Pimlico sponsorship policy id (`sp_…`), which is where the real spend limits live. */
+  sponsorshipPolicyId?: string;
   scoutEnabled?: boolean;
   /** Max USDG of COST that may sit in unpriceable positions at once. 0 = off. */
   scoutBudgetUsdg?: number;
@@ -348,6 +358,14 @@ export const HOUSE_KEY_FIELDS = [
   // a key is a credential the tenant pays with, a base URL is an address OUR
   // egress would connect to. One is their money, the other is our SSRF.
   "llmBaseUrl",
+  // SPONSORSHIP IS THE HOUSE'S MONEY — a third category.
+  //
+  // The distinction above is a tenant's credential versus our egress. This is
+  // neither: it decides whether WE pay for a tenant's gas. Leaving it out would
+  // let a hosted tenant enable it in their own settings, which is a cheque
+  // written on the house account, stored and honoured.
+  "sponsorGasEnabled",
+  "sponsorshipPolicyId",
   "rialtoApiKey",
   "rialtoApiKeyHeader",
   "bitqueryApiKey",
@@ -449,6 +467,8 @@ export const SETTINGS_DEFAULTS = {
   discoveryEnabled: true,
   discoveryIntervalMin: 10,
   trencherLiveEnabled: false,
+  // Off by default like every other switch that spends money.
+  sponsorGasEnabled: false,
   scoutEnabled: false,
   scoutBudgetUsdg: 0,
   scoutPerTokenUsdg: 25,

--- a/web/src/app/app/status-line.ts
+++ b/web/src/app/app/status-line.ts
@@ -33,6 +33,15 @@ export interface AgentSnapshot {
   mode: "live" | "paper" | "idle";
   /** Practice chain — nothing here is real, whatever else is true. */
   testnet: boolean;
+  /**
+   * Is somebody else paying this agent's gas?
+   *
+   * When true, `hasGas` stops gating trading — which matters because the
+   * no-gas branch is evaluated ABOVE testnet, paper and live, so it wins over
+   * every other sentence. A sponsored agent whose owner sent only USDG would
+   * otherwise read 'no ETH to pay the fees' forever while trading normally.
+   */
+  gasSponsored?: boolean;
   /** Does the smart account hold any gas? Without it nothing can be signed. */
   hasGas: boolean;
   /** Trading capital, in USDG. */
@@ -138,6 +147,28 @@ export function statusLine(a: AgentSnapshot): StatusLine {
   // So when there IS cash, say so first and name the two-asset thing
   // outright. Rule 2 still holds: this claims nothing it did not check —
   // `cashUsdg` and `hasGas` are both read from the same snapshot.
+  // SPONSORED AND UNFUNDED IS A WORKING AGENT, not a broken one.
+  //
+  // Note what this does NOT say: 'you never need ETH'. Withdrawal is a
+  // different path — recover.ts pays for the sweep out of the same balance it
+  // is sweeping — so an owner told they need no ETH at all could trade happily
+  // and then find they cannot get their money out. Sponsorship covers TRADING,
+  // and the sentence says exactly that much.
+  if (!a.hasGas && a.gasSponsored) {
+    return a.cashUsdg > 0
+      ? {
+          headline: `${name} is live and its trading fees are covered — you only fund ${money(a.cashUsdg)}.`,
+          next:
+            "We pay the network fee on every trade, so you never have to top up gas to keep it running. " +
+            "Moving money back OUT to your own wallet is the one thing that still needs a little ETH in the account.",
+          tone: "good",
+        }
+      : {
+          headline: `${name} is ready and its fees are covered — it just needs something to trade with.`,
+          next: `Send USDG to the account address, on ${net}. You do not need ETH for it to trade.`,
+          tone: "waiting",
+        };
+  }
   if (!a.hasGas) {
     return a.cashUsdg > 0
       ? {

--- a/worker/src/executor.ts
+++ b/worker/src/executor.ts
@@ -15,6 +15,7 @@
 
 import { http, createPublicClient, type Chain, type Hex } from "viem";
 import { createKernelAccountClient } from "@zerodev/sdk";
+import { SponsorRefused, assertBoundsHeld, type Sponsor } from "./paymaster";
 import { KERNEL_V3_3, getEntryPoint } from "@zerodev/sdk/constants";
 import { deserializeFlaggedPermissionAccount } from "./session-account";
 import { WALL_POLICY_FLAG } from "../../packages/core/src/index";
@@ -132,6 +133,12 @@ export async function createAgentExecutor(opts: {
   bundlerUrl: string;
   /** RPC override (settings rpcMainnet/rpcTestnet) — falls back to the chain default. */
   rpcUrl?: string;
+  /**
+   * Who pays the gas. Absent means the account self-pays from its own ETH,
+   * which is what every agent did before sponsorship existed and what a
+   * self-hosted owner still does unless they wire their own.
+   */
+  sponsor?: Sponsor;
 }): Promise<AgentExecutor> {
   const publicClient = createPublicClient({ chain: opts.chain, transport: http(opts.rpcUrl) });
   const entryPoint = getEntryPoint("0.7");
@@ -148,10 +155,17 @@ export async function createAgentExecutor(opts: {
     WALL_POLICY_FLAG,
   );
 
+  // WHO PAYS, and nothing else. A paymaster settles with the EntryPoint
+  // directly, so the account never handles ETH and every `valueLimit: 0n` in
+  // the wall is untouched. A sponsored operation faces exactly the policies an
+  // unsponsored one does; only the payer changes.
   const client = createKernelAccountClient({
     account,
     chain: opts.chain,
     bundlerTransport: http(opts.bundlerUrl),
+    ...(opts.sponsor
+      ? { paymaster: opts.sponsor.paymaster, paymasterContext: opts.sponsor.paymasterContext }
+      : {}),
     // Without this the SDK calls the ZeroDev-only `zd_getUserOperationGasPrice`,
     // which Pimlico/Alchemy/self-hosted bundlers reject — see worker/src/gas.ts.
     userOperation: userOpGasConfig(publicClient, opts.bundlerUrl),
@@ -178,7 +192,14 @@ export async function createAgentExecutor(opts: {
       let estimateError = "";
       const estimate = async (): Promise<UserOpGas | null> => {
         try {
-          const g = (await client.estimateUserOperationGas({ callData })) as Partial<UserOpGas>;
+          const g = (await client.estimateUserOperationGas({
+            callData,
+            // Estimate the operation we will actually SEND. An unsponsored probe
+            // of a sponsored op omits the paymaster's own verification and postOp
+            // gas, so the three limits we bound would be measured against a
+            // different operation than the one that gets signed.
+            ...(opts.sponsor ? { paymaster: opts.sponsor.estimateOnly } : {}),
+          })) as Partial<UserOpGas>;
           if (
             typeof g.callGasLimit !== "bigint" ||
             typeof g.verificationGasLimit !== "bigint" ||
@@ -203,6 +224,12 @@ export async function createAgentExecutor(opts: {
           // underfunded), AA23 (the wall refused the call), a simulation
           // revert, a 429 and a bundler outage into one sentence that names
           // none of them — on the single most likely outcome of a first op.
+          // A SPONSOR REFUSAL IS NOT AN UNREADABLE ESTIMATE. This catch exists to
+          // keep a bundler's diagnosis, and it would otherwise swallow
+          // SponsorRefused into `estimateError` — so a drained or declining
+          // sponsor would book as `gas-unreadable` and the typed vocabulary this
+          // whole class exists for would never fire on its most likely path.
+          if (e instanceof SponsorRefused) throw e;
           estimateError = e instanceof Error ? e.message : String(e);
           return null;
         }
@@ -221,6 +248,20 @@ export async function createAgentExecutor(opts: {
           // diagnosis; ours is the policy.
           estimateError ? `${estimateError} — ${bounded.detail}` : bounded.detail,
         );
+      }
+
+      // THE LIMITS WE SIGNED MUST BE THE LIMITS WE BOUNDED. viem spreads the
+      // paymaster's reply OVER the prepared request, so a sponsor that returned
+      // callGasLimit would replace boundGas's number with no error and no log —
+      // and under sponsorship the payer of an out-of-gas is the house. The
+      // allowlist in paymaster.ts stops our wrappers propagating that; this
+      // proves it stayed stopped, against the operation about to be signed.
+      if (opts.sponsor) {
+        const prepared = (await client.prepareUserOperation({
+          callData,
+          ...bounded.gas,
+        } as never)) as Record<string, unknown>;
+        assertBoundsHeld(bounded.gas, prepared);
       }
 
       const userOpHash = await client.sendUserOperation({

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -43,6 +43,7 @@ import {
   chainForId,
   effectivePerfFeeBps,
   pimlicoBundlerUrl,
+  pimlicoPaymasterUrl,
   robinhoodTestnet,
   grantHasMultihop,
   // Aliased: `grantHasTransfer` is also the name of the dep this file passes
@@ -70,6 +71,7 @@ import {
   type ExecuteHooks,
   type ExecutionResult,
 } from "./executor";
+import { createSponsor, type Sponsor } from "./paymaster";
 import { fillFromDeltas, netTokenDeltas, slippageBpsAgainst, type ReceiptLog } from "./fills";
 import { belowFloorBps, checkDelivery, describeDelivery } from "./delivery";
 import { classifyRevert, suppressionKey } from "./revert";
@@ -340,6 +342,14 @@ async function main() {
   /** Could this agent put a real order on-chain right now? */
   const canTradeForReal = () => !!active && !!active.executor && chainCanTrade() && !readAsBroke();
   const paperActive = () => !!active && !canTradeForReal() && cfg.paperTradingEnabled;
+  /**
+   * Is somebody else paying the gas?
+   *
+   * Read from the CONFIG rather than from the executor, because the question is
+   * asked in places that run before an executor exists — including the refusal
+   * below that used to make sponsorship unreachable.
+   */
+  const gasSponsored = () => cfg.sponsorGasEnabled && !!cfg.bundlerApiKey;
   function paperPriceOf(
     token: `0x${string}`,
   ): { priceUsd: number; stale: boolean; source: PriceQuote["source"] } | null {
@@ -1826,6 +1836,18 @@ async function main() {
     // id, so it is always pointed at the right chain.
     const bundlerUrl =
       cfg.bundlerUrl || (cfg.bundlerApiKey ? pimlicoBundlerUrl(grant.chainId, cfg.bundlerApiKey) : undefined);
+    // GAS SPONSORSHIP, from the SAME key and the SAME chain id as the bundler.
+    // Derived rather than configurable for the reason the bundler URL is: the
+    // chain id is stamped from the grant, so a testnet grant can never reach a
+    // mainnet sponsor. Absent unless the house turned it on AND there is a key
+    // to build it from.
+    const sponsor: Sponsor | undefined =
+      cfg.sponsorGasEnabled && cfg.bundlerApiKey
+        ? createSponsor({
+            url: pimlicoPaymasterUrl(grant.chainId, cfg.bundlerApiKey),
+            policyId: cfg.sponsorshipPolicyId,
+          })
+        : undefined;
     const agentId = await ensureAgent(grant);
     // The soul's name is the source of truth — mirror it onto the roster. The
     // configured name was reconciled into the soul above the short-circuit, so
@@ -1869,8 +1891,12 @@ async function main() {
           serializedGrant: grant.serialized,
           bundlerUrl,
           rpcUrl: rpc,
+          sponsor,
         });
-        console.log(`[worker] executor live — smart account ${executor.address} on chain ${chain.id}`);
+        console.log(
+          `[worker] executor live — smart account ${executor.address} on chain ${chain.id}` +
+            (sponsor ? " · gas sponsored" : " · self-paying gas"),
+        );
         lastArmFailure = null;
       } catch (e) {
         const why = e instanceof Error ? e.message : String(e);
@@ -2699,7 +2725,14 @@ async function main() {
     // refuses a trade the chain would have accepted is a worse failure than the
     // one being fixed: it would look identical to the agent being broken. Below
     // the floor we warn and let the chain decide.
-    if (lastGasWei === 0n) {
+    // SPONSORSHIP LIFTS THIS, and until it does nothing above matters: this
+    // returns BEFORE the executor is reached, so a sponsored client is never
+    // even constructed and all 73 gasless agents behave exactly as they did.
+    //
+    // `lastGasWei` is the account's ETH BALANCE, not a gas cost — the name
+    // misleads at every use site. When a sponsor pays, that balance gates
+    // nothing, which is the entire point of having one.
+    if (lastGasWei === 0n && !gasSponsored()) {
       await addEvent(
         agentId,
         "err",
@@ -3317,11 +3350,21 @@ async function main() {
         amount_usdg: usdgNum(notional),
         tx_hash: txHash,
         user_op_hash: exec.userOpHash,
-        gas_wei: exec.gasWei.toString(),
-        // Gas priced at the moment it was burned, not at today's rate: the cost
-        // was incurred then, and re-valuing it later would make a past trade's
-        // P&L drift with the ETH price.
-        ...(gasCost.usdg === null ? {} : { gas_usdg: usdgNum(gasCost.usdg) }),
+        // WHOSE COST WAS THIS? The EntryPoint reports actualGasCost either way,
+        // but under sponsorship it was debited from the sponsor's deposit and
+        // never left this account. gas_wei feeds pnlUsdg, which SUBTRACTS it from
+        // the owner's return — on the public scoreboard among other places — so
+        // writing a sponsored cost there understates every sponsored user's
+        // performance by money they did not spend.
+        ...(gasSponsored()
+          ? { sponsored_gas_wei: exec.gasWei.toString() }
+          : {
+              gas_wei: exec.gasWei.toString(),
+              // Gas priced at the moment it was burned, not at today's rate: the
+              // cost was incurred then, and re-valuing it later would make a past
+              // trade's P&L drift with the ETH price.
+              ...(gasCost.usdg === null ? {} : { gas_usdg: usdgNum(gasCost.usdg) }),
+            }),
         ...(slippageBps === null ? {} : { fill_slippage_bps: slippageBps }),
         status: "landed",
         ...sim,

--- a/worker/src/ledger-mirror.test.ts
+++ b/worker/src/ledger-mirror.test.ts
@@ -23,7 +23,7 @@ import { MIRROR_STATE_DDL, mirrorTenant } from "./ledger-mirror";
 
 const SRC = [
   "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT NOT NULL, level TEXT, message TEXT, created_at INTEGER);",
-  "CREATE TABLE trades (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT, kind TEXT, target TEXT, sell_token TEXT, buy_token TEXT, amount_usdg REAL, user_op_hash TEXT, tx_hash TEXT, status TEXT, reject_rule TEXT, decision_id TEXT, fill_side TEXT, fill_qty_raw TEXT, fill_price_usd REAL, realized_pnl_usdg REAL, basis_source TEXT, gas_wei TEXT, created_at INTEGER);",
+  "CREATE TABLE trades (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT, kind TEXT, target TEXT, sell_token TEXT, buy_token TEXT, amount_usdg REAL, user_op_hash TEXT, tx_hash TEXT, status TEXT, reject_rule TEXT, decision_id TEXT, fill_side TEXT, fill_qty_raw TEXT, fill_price_usd REAL, realized_pnl_usdg REAL, basis_source TEXT, gas_wei TEXT, sponsored_gas_wei TEXT, created_at INTEGER);",
   "CREATE TABLE equity (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT, eth_wei TEXT, cash_usdg REAL, vault_usdg REAL, equity_usdg REAL, at INTEGER);",
   "CREATE TABLE decisions (id TEXT PRIMARY KEY, agent_id TEXT, source TEXT, strategy TEXT, provider TEXT, model TEXT, symbol TEXT, action TEXT, size_usdg REAL, reason TEXT, dropped_rule TEXT, signals_json TEXT, at INTEGER);",
   "CREATE TABLE agents (smart_account TEXT PRIMARY KEY, name TEXT, owner_address TEXT, session_key_address TEXT, chain_id INTEGER, caps TEXT, granted_at INTEGER, expires_at INTEGER, status TEXT, created_at INTEGER, mode TEXT, beat_at INTEGER);",

--- a/worker/src/ledger-mirror.ts
+++ b/worker/src/ledger-mirror.ts
@@ -69,6 +69,9 @@ const LOG_TABLES = [
       "realized_pnl_usdg",
       "basis_source",
       "gas_wei",
+      // Otherwise 'what did sponsorship cost the house this week' is a question
+      // that can only be answered by sshing into 18 separate child databases.
+      "sponsored_gas_wei",
       "created_at",
     ],
   },

--- a/worker/src/paymaster.test.ts
+++ b/worker/src/paymaster.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  PAYMASTER_GAS_MAX,
+  PAYMASTER_POSTOP_GAS,
+  PAYMASTER_VERIFICATION_GAS,
+  SponsorRefused,
+  assertBoundsHeld,
+} from "./paymaster";
+
+/**
+ * The sponsor is an untrusted party that picks numbers WE pay for — or rather,
+ * that the house pays for, which is worse, because the account that would feel
+ * an out-of-gas is not the account being charged.
+ *
+ * These tests are about the two things that make sponsorship safe to attach: the
+ * limits we bounded survive it, and a refusal is a typed pre-broadcast event
+ * rather than a free-form string in a column with a small vocabulary.
+ */
+
+describe("the bounds we signed must survive the sponsor", () => {
+  const bounded = {
+    callGasLimit: 200_000n,
+    verificationGasLimit: 150_000n,
+    preVerificationGas: 60_000n,
+  };
+
+  it("passes when the prepared operation reports our numbers back", () => {
+    assert.doesNotThrow(() =>
+      assertBoundsHeld(bounded, {
+        callGasLimit: 200_000n,
+        verificationGasLimit: 150_000n,
+        preVerificationGas: 60_000n,
+      }),
+    );
+  });
+
+  it("passes when the fields are not reported at all", () => {
+    // Absence is not contradiction. A check that treated a missing field as a
+    // failure would refuse every operation on a bundler that simply echoes less.
+    assert.doesNotThrow(() => assertBoundsHeld(bounded, {}));
+  });
+
+  it("REFUSES when the sponsor lowered a limit — the out-of-gas case", () => {
+    // The dangerous direction. An under-provisioned operation does not bounce:
+    // the EntryPoint runs it, the inner call runs out of gas, and it is charged
+    // in full. Under sponsorship the payer of that is the house.
+    assert.throws(
+      () => assertBoundsHeld(bounded, { callGasLimit: 21_000n }),
+      (e: unknown) => e instanceof SponsorRefused && e.rule === "sponsor-absurd",
+    );
+  });
+
+  it("REFUSES when the sponsor raised a limit", () => {
+    // Also refused, and not out of symmetry: gas-limits.ts exists so that no
+    // number nobody checked is ever signed. A sponsor that raises one has
+    // replaced our arithmetic with its own.
+    assert.throws(
+      () => assertBoundsHeld(bounded, { verificationGasLimit: 900_000n }),
+      (e: unknown) => e instanceof SponsorRefused,
+    );
+  });
+
+  it("reads hex, because that is what an RPC actually returns", () => {
+    assert.doesNotThrow(() => assertBoundsHeld(bounded, { callGasLimit: "0x30d40" }));
+    assert.throws(
+      () => assertBoundsHeld(bounded, { callGasLimit: "0x5208" }),
+      (e: unknown) => e instanceof SponsorRefused,
+    );
+  });
+
+  it("ignores junk rather than treating it as a mismatch", () => {
+    // A field we cannot parse is a field we cannot contradict. Refusing here
+    // would turn an unfamiliar reply shape into a trading outage.
+    assert.doesNotThrow(() => assertBoundsHeld(bounded, { callGasLimit: null }));
+    assert.doesNotThrow(() => assertBoundsHeld(bounded, { callGasLimit: "not a number" }));
+  });
+});
+
+describe("SponsorRefused carries a rule from a fixed vocabulary", () => {
+  it("names the three ways a sponsor says no", () => {
+    // The whole point of the type: without it these land in the generic submit
+    // catch as `status: "reverted"` with a free-form reject_rule — a ledger row
+    // asserting the chain refused a trade the chain never saw.
+    for (const rule of ["sponsor-refused", "sponsor-unreachable", "sponsor-absurd"] as const) {
+      const e = new SponsorRefused(rule, "because");
+      assert.equal(e.rule, rule);
+      assert.equal(e.name, "SponsorRefused");
+      assert.ok(e instanceof Error);
+    }
+  });
+});
+
+describe("the paymaster gas ceiling", () => {
+  it("leaves room for a real approve+swap and refuses well below absurd", () => {
+    // Sized against gas-limits.ts's 3,000,000 total ceiling: the two paymaster
+    // fields together must not be able to eat it.
+    assert.ok(PAYMASTER_VERIFICATION_GAS < PAYMASTER_GAS_MAX);
+    assert.ok(PAYMASTER_POSTOP_GAS < PAYMASTER_GAS_MAX);
+    assert.ok(PAYMASTER_GAS_MAX * 2n < 3_000_000n, "two paymaster fields must not exhaust the op ceiling");
+  });
+});

--- a/worker/src/paymaster.ts
+++ b/worker/src/paymaster.ts
@@ -1,0 +1,227 @@
+/**
+ * SPONSORED GAS — so an owner funds ONE asset instead of two.
+ *
+ * WHY THIS EXISTS. Two users reported the same thing on the same day: "It says
+ * it can't trade. Because no ETH. But there is 15 bucks in it", and "I've topped
+ * up a wallet but nothing's showing". Neither was confused. On this chain the
+ * money you TRADE with (USDG) and the money you pay FEES with (ETH) are
+ * different assets, and 73 of the fleet's sampled account lines read
+ * `eth 0 · cash 1000 USDG` — agents holding money they cannot spend.
+ *
+ * A paymaster pays the EntryPoint directly. The account never touches ETH, so
+ * this changes WHO PAYS and nothing else: every permission in the wall keeps its
+ * `valueLimit: 0n`, the session key gains no new reach, and a sponsored
+ * operation faces exactly the same policies as an unsponsored one. That
+ * separation is the whole reason this is a safe thing to add and a WRAPPED
+ * ETH auto-swap — the other suggestion for the same problem — is not.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * MEASURED, NOT ASSUMED. `pm_getPaymasterStubData` was probed against chain 4663
+ * with the live key before a line of this was written, because the alternative
+ * to Pimlico having a paymaster there is deploying our own contract. It answers,
+ * and the exact response shape drove two decisions below:
+ *
+ *   stub → { paymaster, paymasterData, paymasterPostOpGasLimit }
+ *   data → { paymaster, paymasterData }
+ *
+ * Note what is ABSENT from the stub: `paymasterVerificationGasLimit`. viem
+ * re-enters `estimateUserOperationGas` when EITHER paymaster gas field is
+ * undefined after the stub (prepareUserOperation.js), so leaving it absent hands
+ * both numbers back to the bundler — outside every bound `gas-limits.ts` exists
+ * to impose. Filling it here is what keeps them ours.
+ *
+ * ALLOWLIST, NOT SPREAD. Neither observed response carries callGasLimit,
+ * verificationGasLimit or preVerificationGas — but viem's paymaster actions are
+ * unfiltered passthroughs (`const {a, b, ...rest} = await request(); return
+ * {...rest}`), and prepareUserOperation spreads the result OVER the request. So
+ * a sponsor that started returning those three fields would silently replace the
+ * limits `boundGas` computed, with no error and no log, and under sponsorship
+ * the payer of an out-of-gas is the house. The response shape is the sponsor's
+ * to change and ours to constrain, so these wrappers return a fixed set of keys
+ * and drop everything else. A TypeScript return type is not a filter.
+ */
+
+import { http } from "viem";
+import {
+  createPaymasterClient,
+  type GetPaymasterDataParameters,
+  type GetPaymasterDataReturnType,
+  type GetPaymasterStubDataParameters,
+  type GetPaymasterStubDataReturnType,
+} from "viem/account-abstraction";
+
+/**
+ * The sponsor said no, BEFORE anything was broadcast.
+ *
+ * A sibling of `GasRefused` and deliberately not an on-chain revert: nothing
+ * reached a bundler, nothing was signed, and no gas was spent. Without its own
+ * type this lands in the generic submit-failure branch and books a ledger row
+ * saying `status: "reverted"` with a free-form `reject_rule` — a row asserting
+ * the chain refused a trade the chain never saw, in a column every other
+ * producer fills from a small vocabulary.
+ */
+export class SponsorRefused extends Error {
+  constructor(
+    readonly rule: "sponsor-refused" | "sponsor-unreachable" | "sponsor-absurd",
+    detail: string,
+  ) {
+    super(detail);
+    this.name = "SponsorRefused";
+  }
+}
+
+/**
+ * Limits WE choose when the sponsor does not state one, and a ceiling that
+ * applies even when it does.
+ *
+ * Same thesis as gas-limits.ts: never sign a limit nobody checked. The ceiling
+ * matters more here than there, because the account is not the one paying — an
+ * absurd paymaster gas limit costs the house, and the account would never feel
+ * it.
+ */
+export const PAYMASTER_VERIFICATION_GAS = 200_000n;
+export const PAYMASTER_POSTOP_GAS = 100_000n;
+/** Refuse outright above this, per field, whatever the sponsor says. */
+export const PAYMASTER_GAS_MAX = 500_000n;
+
+export interface Sponsor {
+  /** For `createKernelAccountClient` — viem's own paymaster shape. */
+  paymaster: {
+    getPaymasterStubData: (
+      p: GetPaymasterStubDataParameters,
+    ) => Promise<GetPaymasterStubDataReturnType>;
+    getPaymasterData: (p: GetPaymasterDataParameters) => Promise<GetPaymasterDataReturnType>;
+  };
+  paymasterContext: unknown;
+  /**
+   * For the executor's two gas PROBES, which only need the operation to be
+   * shaped like a sponsored one.
+   *
+   * Only `getPaymasterData` is set, and that is not a typo: viem resolves BOTH
+   * hooks to undefined — silently disabling the paymaster — when
+   * `getPaymasterStubData` is supplied without `getPaymasterData`. Supplying
+   * only the latter makes viem use it for the stub slot and skip the second
+   * call, which is one sponsor round trip per probe instead of two.
+   */
+  estimateOnly: {
+    getPaymasterData: (
+      p: GetPaymasterStubDataParameters,
+    ) => Promise<GetPaymasterStubDataReturnType>;
+  };
+}
+
+/** Build the sponsor. `url` is Pimlico's — the same endpoint as the bundler. */
+export function createSponsor(opts: { url: string; policyId?: string }): Sponsor {
+  const pm = createPaymasterClient({ transport: http(opts.url) });
+
+  const clamp = (label: string, v: bigint): bigint => {
+    if (v > PAYMASTER_GAS_MAX) {
+      throw new SponsorRefused(
+        "sponsor-absurd",
+        `the sponsor asked for ${v} ${label}, past our ${PAYMASTER_GAS_MAX} ceiling. An approve plus a ` +
+          `swap does not need that, so the operation is not the one it is meant to be. Refused before signing.`,
+      );
+    }
+    return v;
+  };
+
+  const stub = async (
+    p: GetPaymasterStubDataParameters,
+  ): Promise<GetPaymasterStubDataReturnType> => {
+    let r: Record<string, unknown>;
+    try {
+      r = (await pm.getPaymasterStubData(p)) as unknown as Record<string, unknown>;
+    } catch (e) {
+      throw new SponsorRefused(
+        "sponsor-unreachable",
+        `the gas sponsor did not answer (pm_getPaymasterStubData): ${
+          e instanceof Error ? e.message : String(e)
+        }. That is a refusal to quote, not a quote of zero.`,
+      );
+    }
+    const verification = asBigint(r.paymasterVerificationGasLimit) ?? PAYMASTER_VERIFICATION_GAS;
+    const postOp = asBigint(r.paymasterPostOpGasLimit) ?? PAYMASTER_POSTOP_GAS;
+    // BOTH fields, ALWAYS present. Either one missing sends viem back to the
+    // bundler for a fresh estimate of both, and the numbers stop being ours.
+    return {
+      paymaster: r.paymaster,
+      paymasterData: r.paymasterData,
+      paymasterVerificationGasLimit: clamp("paymasterVerificationGasLimit", verification),
+      paymasterPostOpGasLimit: clamp("paymasterPostOpGasLimit", postOp),
+      ...(r.isFinal === true ? { isFinal: true as const } : {}),
+    } as unknown as GetPaymasterStubDataReturnType;
+  };
+
+  const data = async (p: GetPaymasterDataParameters): Promise<GetPaymasterDataReturnType> => {
+    let r: Record<string, unknown>;
+    try {
+      r = (await pm.getPaymasterData(p)) as unknown as Record<string, unknown>;
+    } catch (e) {
+      // The likeliest real-world refusal: a drained deposit, an exhausted
+      // policy, a rate limit. All of them are "no" rather than "not now".
+      throw new SponsorRefused(
+        "sponsor-refused",
+        `the gas sponsor declined this operation (pm_getPaymasterData): ${
+          e instanceof Error ? e.message : String(e)
+        }. Nothing was signed and nothing was sent.`,
+      );
+    }
+    const verification = asBigint(r.paymasterVerificationGasLimit);
+    const postOp = asBigint(r.paymasterPostOpGasLimit);
+    return {
+      paymaster: r.paymaster,
+      paymasterData: r.paymasterData,
+      ...(verification === undefined
+        ? {}
+        : { paymasterVerificationGasLimit: clamp("paymasterVerificationGasLimit", verification) }),
+      ...(postOp === undefined
+        ? {}
+        : { paymasterPostOpGasLimit: clamp("paymasterPostOpGasLimit", postOp) }),
+    } as unknown as GetPaymasterDataReturnType;
+  };
+
+  return {
+    paymaster: { getPaymasterStubData: stub, getPaymasterData: data },
+    paymasterContext: opts.policyId ? { sponsorshipPolicyId: opts.policyId } : undefined,
+    estimateOnly: { getPaymasterData: stub },
+  };
+}
+
+/** `0x…` or a bigint or a number → bigint. Anything else → undefined, never 0n. */
+function asBigint(v: unknown): bigint | undefined {
+  if (typeof v === "bigint") return v;
+  if (typeof v === "number" && Number.isFinite(v)) return BigInt(v);
+  if (typeof v === "string" && /^0x[0-9a-fA-F]+$/.test(v)) return BigInt(v);
+  return undefined;
+}
+
+/**
+ * Did the limits we bounded survive the sponsor?
+ *
+ * THE POST-CONDITION, and the reason the allowlist above is not the only guard.
+ * viem spreads the paymaster's reply over the prepared request, so a sponsor
+ * returning `callGasLimit` would overwrite the number `boundGas` signed off on —
+ * silently, because the shape is valid. The allowlist stops OUR wrappers from
+ * propagating that; this proves it stayed stopped, against the operation that is
+ * actually about to be signed.
+ *
+ * Pure and exported so the check is testable without a sponsor, a bundler or a
+ * chain — the same discipline gas-limits.ts is built on.
+ */
+export function assertBoundsHeld(
+  bounded: { callGasLimit: bigint; verificationGasLimit: bigint; preVerificationGas: bigint },
+  prepared: Partial<Record<string, unknown>>,
+): void {
+  for (const field of ["callGasLimit", "verificationGasLimit", "preVerificationGas"] as const) {
+    const got = asBigint(prepared[field]);
+    if (got === undefined) continue; // not reported back; nothing to contradict
+    if (got !== bounded[field]) {
+      throw new SponsorRefused(
+        "sponsor-absurd",
+        `the sponsor changed ${field} from ${bounded[field]} to ${got}. Gas limits are bounded before ` +
+          `signing precisely so nobody else picks them, and under sponsorship an under-provisioned ` +
+          `operation is paid for by the house. Refused.`,
+      );
+    }
+  }
+}

--- a/worker/src/settings.ts
+++ b/worker/src/settings.ts
@@ -73,6 +73,8 @@ export interface ResolvedConfig {
   discoveryIntervalMin: number;
   /** Scout mode: may the agent buy tokens it cannot price? Off by default. */
   trencherLiveEnabled: boolean;
+  sponsorGasEnabled: boolean;
+  sponsorshipPolicyId?: string;
   browserUrl: string | undefined;
   browserToken: string | undefined;
   scoutEnabled: boolean;
@@ -286,6 +288,8 @@ export function mergeSettings(
     discoveryEnabled: bool(file.discoveryEnabled, env.MERRYMEN_DISCOVERY_ENABLED, d.discoveryEnabled),
     discoveryIntervalMin: num(file.discoveryIntervalMin, env.MERRYMEN_DISCOVERY_INTERVAL_MIN, d.discoveryIntervalMin, 1, 1440),
     trencherLiveEnabled: bool(file.trencherLiveEnabled, env.MERRYMEN_TRENCHER_LIVE, d.trencherLiveEnabled),
+    sponsorGasEnabled: bool(file.sponsorGasEnabled, env.MERRYMEN_SPONSOR_GAS, d.sponsorGasEnabled),
+    sponsorshipPolicyId: str(file.sponsorshipPolicyId, env.MERRYMEN_SPONSORSHIP_POLICY_ID),
     browserUrl: str(file.browserUrl, env.MERRYMEN_BROWSER_URL),
     browserToken: str(file.browserToken, env.MERRYMEN_BROWSER_TOKEN),
     scoutEnabled: bool(file.scoutEnabled, env.MERRYMEN_SCOUT_ENABLED, d.scoutEnabled),
@@ -376,7 +380,17 @@ export function patchSettingsFile(patch: Partial<MerrymenSettings>): MerrymenSet
 
 /** Fingerprint of fields that require re-arming the executor when changed. */
 export function connectionKey(cfg: ResolvedConfig): string {
-  return [cfg.bundlerApiKey, cfg.bundlerUrl, cfg.rpcMainnet, cfg.rpcTestnet].join("|");
+  // SPONSORSHIP BELONGS IN THE FINGERPRINT. The paymaster attaches inside
+  // createAgentExecutor, which is rebuilt only when this changes — so without
+  // these two the toggle saves, reports ok, and does nothing until a restart.
+  return [
+    cfg.bundlerApiKey,
+    cfg.bundlerUrl,
+    cfg.rpcMainnet,
+    cfg.rpcTestnet,
+    String(cfg.sponsorGasEnabled),
+    cfg.sponsorshipPolicyId ?? "",
+  ].join("|");
 }
 
 /**

--- a/worker/src/store.ts
+++ b/worker/src/store.ts
@@ -296,6 +296,12 @@ const SQLITE_ALTERS: string[] = [
     // sim_gas holds QuoterV2's estimate for the SWAP CALL only, unmultiplied by
     // any gas price, so realized P&L was gross of gas forever.
     "ALTER TABLE trades ADD COLUMN gas_wei TEXT",
+    // What the SPONSOR paid, when somebody else paid. Kept separate from
+    // gas_wei rather than sharing it, because gas_wei means 'what this owner
+    // spent' and is subtracted from their P&L at five call sites. The
+    // EntryPoint still reports actualGasCost for a sponsored op, so the number
+    // survives sponsorship — only its owner changes.
+    "ALTER TABLE trades ADD COLUMN sponsored_gas_wei TEXT",
     // EPOCH. Everything written before the accounting was fixed stays epoch 1
     // and is excluded from performance reporting — kept for forensics, never
     // presented as measured. The first tick after the fix opens epoch 2. This


### PR DESCRIPTION
Two users, same day:

> "It says it can't trade" / "Because no ETH" / "But there is 15 bucks in it"

> "Hey, I've topped up a wallet but nothings showing"

A third suggested the fix: *"Maybe only ETH to wallet xy and the agent converts it to USDG while leaving ETH for gas."*

**He identified the right problem, and that fix cannot work.** All 14 wall permissions carry `valueLimit: 0n`, so the account can never move native ETH — and there is no WETH approve and no wrap path. Building his version means granting the session key the one thing this wall has never allowed.

A paymaster inverts it and lands somewhere better: **send USDG only, never need ETH** — while changing nothing about custody. The sponsor settles with the EntryPoint directly, so the account still never touches ETH, every `valueLimit: 0n` stands, and a sponsored operation faces exactly the policies an unsponsored one does. Only the payer changes.

73 of the fleet's sampled account lines read `eth 0 · cash 1000 USDG`.

## Measured before it was written

`pm_getPaymasterStubData` was probed against chain 4663 with the live key, because the alternative to Pimlico serving a paymaster there is deploying our own contract. It answers, on the same endpoint as the bundler. Two details from the real response shaped the code:

- the stub returns `paymasterPostOpGasLimit` but **not** `paymasterVerificationGasLimit`
- neither reply carries the three limits `boundGas` signs

That absent field matters: viem re-enters `estimateUserOperationGas` when *either* paymaster gas field is undefined after the stub, handing both numbers back to the bundler — outside every bound `gas-limits.ts` exists to impose. Filling it in the wrapper is what keeps them ours.

## Allowlist, not spread

viem's paymaster actions are unfiltered passthroughs, and `prepareUserOperation` spreads their result **over** the request. So a sponsor that began returning `callGasLimit` would silently replace a bounded limit — and under sponsorship the payer of an out-of-gas is the house. Today's Pimlico returns no such field; the shape is theirs to change and ours to constrain.

So the wrappers return a fixed key set, and `assertBoundsHeld` re-checks the prepared operation before signing. A TypeScript return type is not a filter.

## The rethrow

`executor.ts`'s estimate closure swallows every error into `estimateError`. A `SponsorRefused` thrown from the probe would have booked as `gas-unreadable`, so the typed vocabulary would never fire on its most likely path — a drained or declining sponsor.

## The line that makes it real

`if (lastGasWei === 0n)` returned **before the executor was constructed**. Ship the SDK wiring alone and all 73 gasless agents behave identically. It now yields to sponsorship.

## Accounting

The EntryPoint still reports `actualGasCost` when a sponsor paid, and `gas_wei` is **subtracted from owner P&L** — including on the public scoreboard. A sponsored cost written there understates every sponsored user's return by money they never spent. It now goes to its own column, mirrored to the hosted ledger.

## What this deliberately does NOT claim

**"You never need ETH."** Withdrawal is a different path — `recover.ts` pays for the sweep out of the same balance it is sweeping — so an owner told they need none at all could trade happily and then find they cannot get their money out. The copy says fees are covered for **trading**, and that moving money out still needs a little ETH.

Sponsoring recovery is a separate decision and a worse one: it signs with the owner sudo validator, which has no session-key policies attached and can move the whole balance in one op, and hosted recovery runs in the browser where the paymaster URL embeds the house key.

## Gating

Off by default, house-owned (a tenant who could enable it would be writing a cheque on the house account), and in `connectionKey` so the toggle re-arms the executor instead of waiting for a restart.

---

**Before enabling:** create a Pimlico sponsorship policy with per-user and per-operation limits and set `sponsorshipPolicyId`. The probe sponsored with **no policy configured**, so the primary spend bound is Pimlico's and it is currently unset.

Known gap, unchanged by this PR: `getOpsToday` counts only landed/submitted ops, so a reverting agent burns sponsor gas without advancing its own cap.

Tests 1548/1548, web build clean.
