### PR TITLE
Put the account address on the dashboard, copyable

### DIFF
--- a/web/src/app/app/Console.tsx
+++ b/web/src/app/app/Console.tsx
@@ -420,6 +420,12 @@ function Loaded({ feed, status }: { feed: FeedResponse | null; status: AgentStat
                   true. Any further down and the person who doubts it never
                   scrolls that far. */}
               <SelftestButton />
+              {/* Under the status line and the prove-it button: the three things
+                  someone opens this page to find are what it is doing, whether it
+                  works, and where their money is. */}
+              {status.grant?.smartAccount && (
+                <AccountAddress address={status.grant.smartAccount} />
+              )}
               <section className="hero">
                 <div className="equity">
                   <div className="kick">Total equity</div>
@@ -824,6 +830,55 @@ function SelftestButton() {
         </p>
       )}
     </div>
+  );
+}
+
+/**
+ * YOUR ACCOUNT ADDRESS, ALWAYS ON SCREEN AND ALWAYS ONE TAP FROM THE CLIPBOARD.
+ *
+ * It used to appear only in the onboarding FUND step and then vanish for good.
+ * So an owner who finished setup and later wanted to check where their money
+ * was had nowhere on the dashboard to look — and the place they went instead
+ * was MetaMask, which shows a DIFFERENT address and an empty balance.
+ *
+ * That is not hypothetical. A user imported his owner key, saw nothing, and
+ * said: “I don't see my money… which is not the wallet I've sent tokens to.”
+ * Every fact in that sentence was right. He was holding two addresses and
+ * nothing on any screen put them side by side and said which was which.
+ *
+ * The explanation already existed on /grant, in the recovery panel and in the
+ * README. It did not help, because by the time somebody is frightened about
+ * their money they are not reading a paragraph about ERC-4337 — they are trying
+ * to compare two strings. So this shows the string, labels what it is, and says
+ * in one line what MetaMask will show instead.
+ */
+function AccountAddress({ address }: { address: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <section className="acct">
+      <div className="acct-lab">Your agent&rsquo;s account &mdash; send funds here</div>
+      <button
+        type="button"
+        className="acct-copy"
+        onClick={async () => {
+          try {
+            await navigator.clipboard.writeText(address);
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1400);
+          } catch {
+            /* clipboard blocked — the address is still selectable */
+          }
+        }}
+      >
+        <span className="acct-v">{address}</span>
+        <span className="acct-i">{copied ? "copied ✓" : "copy"}</span>
+      </button>
+      <p className="acct-note">
+        This is a smart account, not a MetaMask wallet. Importing your owner key into
+        MetaMask shows a <b>different</b> address with nothing in it &mdash; that is normal, and
+        your money is here. To move funds out, use <b>recover</b> rather than MetaMask.
+      </p>
+    </section>
   );
 }
 

--- a/web/src/app/app/console.css
+++ b/web/src/app/app/console.css
@@ -476,6 +476,48 @@
   font-family: var(--sans); font-size: 13px; line-height: 1.5;
   color: var(--text-dim); margin: 4px 0 0;
 }
+/* The account address — permanent, and one tap from the clipboard. */
+.acct { margin-bottom: 16px; }
+.acct-lab {
+  font-family: var(--sans);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  color: var(--text-dim);
+  margin-bottom: 6px;
+}
+.acct-copy {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+.acct-v {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+.acct-i {
+  font-family: var(--sans);
+  font-size: 12px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+.acct-note {
+  font-family: var(--sans);
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-dim);
+  margin: 8px 2px 0;
+}
+
 /* The prove-it button, sitting between the status line and the numbers. */
 .selftest { margin-bottom: 16px; }
 .st-btn {

--- a/worker/src/telegram/executor.ts
+++ b/worker/src/telegram/executor.ts
@@ -48,6 +48,9 @@ export interface CommandDeps {
   grantHasTransfer: boolean;
   reads: {
     status(): string;
+    /** `/wallet` — leads with the account address. Optional so existing hosts and
+     *  fixtures that predate it keep the old static signpost. */
+    wallet?(): string;
     positions(): string;
     /** Liquidity depth for one ticker — a chain read, so always async. */
     depth(symbol: string): Promise<string>;
@@ -137,7 +140,11 @@ export async function executeCommand(cmd: Command, deps: CommandDeps): Promise<s
     // Static signpost — no state, no gating: it only tells you where the
     // dashboard is. Safe to answer even unlinked/read-only.
     case "wallet":
-      return WALLET_TEXT;
+      // Was the static signpost. It now leads with the account ADDRESS, because
+      // the question people actually arrive with is "where is my money", and the
+      // answer to that is a string they can compare against what MetaMask showed
+      // them — not a paragraph about smart accounts.
+      return deps.reads.wallet ? deps.reads.wallet() : WALLET_TEXT;
     case "status":
       return deps.reads.status();
     case "positions":

--- a/worker/src/telegram/reads.ts
+++ b/worker/src/telegram/reads.ts
@@ -703,7 +703,7 @@ export function readLlmState(ctx: StatusContext): string {
  * key must never touch a chat app), so this is a signpost to the local dashboard
  * rather than a dead end.
  */
-export const WALLET_TEXT = [
+const WALLET_TEXT_LINES = [
   "🏹 <b>your wallet lives in the dashboard</b> — not in chat.",
   "",
   "Open <b>http://localhost:3100/grant</b> on the machine running merrymen:",
@@ -716,7 +716,57 @@ export const WALLET_TEXT = [
   "Heads-up: the address you funded is a <b>smart account</b>, not a MetaMask wallet — importing your owner key into MetaMask shows a different, empty address. That’s normal; your funds are safe at the account address.",
   "",
   "Why not here? Your owner key never touches chat — wallet actions stay on your machine.",
-].join("\n");
+];
+
+/** The signpost alone, for callers with no ledger to read. */
+export const WALLET_TEXT = WALLET_TEXT_LINES.join("\n");
+
+/**
+ * `/wallet`, leading with the ONE fact that resolves the confusion: the address.
+ *
+ * A user imported his owner key into MetaMask, saw an empty wallet, and told us
+ * “I don't see my money… which is not the wallet I've sent tokens to.” Every
+ * observable fact in that message is correct; only the conclusion is wrong.
+ *
+ * The explanation already existed — in the grant page, the recovery panel, the
+ * README, and the last line of the signpost below. He hit it anyway, and his own
+ * message shows why: he was holding two addresses and nothing put them side by
+ * side and said which was which. A paragraph about smart accounts does not
+ * answer “is MY money gone”. His own address, printed, does.
+ *
+ * So the address leads and the concept follows it, rather than the other way
+ * round. This is also why it became a function — the static export could not
+ * reach the ledger to know the address.
+ */
+export function readWallet(agentId?: string | null, dashboardUrl?: string): string {
+  const base = dashboardUrl ?? "http://localhost:3100";
+  const signpost = WALLET_TEXT_LINES.map((l) =>
+    l.split("http://localhost:3100").join(base),
+  );
+  const db = openRO();
+  if (!db) return signpost.join("\n");
+  let who: string | null = null;
+  try {
+    who = resolveAgent(db, agentId);
+  } catch {
+    /* pre-migration ledger — the signpost still stands on its own */
+  } finally {
+    db.close();
+  }
+  if (!who) return signpost.join("\n");
+  return [
+    "🏹 <b>your agent's account</b> — this is where your money is:",
+    `<code>${esc(who)}</code>`,
+    "",
+    "That address is a <b>smart account</b>. Your owner key CONTROLS it but is not",
+    "it — import the key into MetaMask and MetaMask shows the KEY's own address,",
+    "which is empty and always will be. Nothing is lost; there are two addresses",
+    "and that is the other one. Compare what MetaMask shows against the address",
+    "above.",
+    "",
+    ...signpost,
+  ].join("\n");
+}
 
 export const HELP_TEXT = [
   "🏹 <b>merryman — commands</b>",


### PR DESCRIPTION
> "I imported my wallet into MetaMask. But I don't see my money."
> `0x8168E2Fb723C2a60982AFbFdFafD84f9fb22f7EE` — "Imported wallet."
> "Which is not the wallet I've sent tokens to."

**Every observable fact in that message is correct.** I checked the address on chain: an EOA, 0 ETH, 0 USDG. It is his **owner key's own address**, which in this design never holds anything. His money is in the smart account that key controls — a different address, exactly as he suspected.

## Why the existing warnings did not help

The explanation already existed in four places: the grant page, the recovery panel, the README, and the last line of `/wallet`. He hit it anyway, and his own message shows why — he was holding two addresses and nothing put them side by side and said which was which.

By the time somebody is frightened about their money they are not reading a paragraph about ERC-4337. They are trying to compare two strings.

**And the string was not there to compare against.** The account address appeared only in the onboarding *fund* step and then vanished for good. An owner who had finished setup and later wanted to check where their money was had nowhere on the dashboard to look. Where they went instead was MetaMask.

## The fix

The address is now permanent on `/app`, directly under the status line and the prove-it button — the three things someone opens that page to find are what it is doing, whether it works, and where their money is. One tap copies it, and one line says what MetaMask will show instead, and that **recover**, not MetaMask, is how funds come out.

`/wallet` in Telegram now leads with the same address rather than closing with a paragraph. It reads the ledger so it can know the address at all; the static signpost survives as the fallback for callers with no ledger.

---

Fourth address/funding confusion in two days — wrong asset, wrong chain, silent trencher, now owner-key vs smart-account. This one is the most dangerous, because the natural conclusion is "I have been scammed."

Tests 1548/1548, web build clean.