### PR TITLE
Both ways out, on the page people actually live on

### DIFF
--- a/web/src/app/app/Console.tsx
+++ b/web/src/app/app/Console.tsx
@@ -20,6 +20,8 @@ import type { AgentStatus } from "@/app/api/grants/route";
 import Onboarding, { type OnboardStep } from "./Onboarding";
 import { LogoMark } from "@/components/Logo";
 import { mascotMood } from "@/lib/mascot";
+import { RecoverPanel } from "@/components/RecoverPanel";
+import { listSavedWallets } from "@/lib/session";
 
 const usd = (n: number) =>
   n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
@@ -425,6 +427,9 @@ function Loaded({ feed, status }: { feed: FeedResponse | null; status: AgentStat
                   works, and where their money is. */}
               {status.grant?.smartAccount && (
                 <AccountAddress address={status.grant.smartAccount} />
+              )}
+              {status.grant?.smartAccount && (
+                <WaysOut smartAccount={status.grant.smartAccount} />
               )}
               <section className="hero">
                 <div className="equity">
@@ -878,6 +883,88 @@ function AccountAddress({ address }: { address: string }) {
         MetaMask shows a <b>different</b> address with nothing in it &mdash; that is normal, and
         your money is here. To move funds out, use <b>recover</b> rather than MetaMask.
       </p>
+    </section>
+  );
+}
+
+/**
+ * THE TWO WAYS OUT, on the page people actually live on.
+ *
+ * Both of these already existed and neither was reachable from here. Sweeping
+ * lived on /home behind a field asking you to paste a key this browser already
+ * holds; the key itself lived on /grant behind a saved-wallets list. So the
+ * dashboard could tell you your money was safe and offer you no way to touch it.
+ *
+ * What that produced: an owner who wanted his funds out imported his owner key
+ * into MetaMask, saw the key's own empty address, and concluded the money was
+ * gone. Every step of that was reasonable. The exit was three pages away.
+ *
+ * Read entirely from localStorage (listSavedWallets) — no server, no session —
+ * so it works even when the hosted side is having a bad day, which is exactly
+ * when somebody wants their money out.
+ */
+function WaysOut({ smartAccount }: { smartAccount: string }) {
+  const [wallet, setWallet] = useState<{ ownerKey?: string } | null>(null);
+  const [showKey, setShowKey] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    try {
+      const saved = listSavedWallets();
+      setWallet(
+        saved.find((w) => w.smartAccount.toLowerCase() === smartAccount.toLowerCase()) ?? null,
+      );
+    } catch {
+      // A browser that never held this wallet is the normal case on a second
+      // device, not an error. The sweep panel below still works from a paste.
+      setWallet(null);
+    }
+  }, [smartAccount]);
+
+  const key = wallet?.ownerKey;
+  return (
+    <section className="ways">
+      {/* Prefilled when this browser has the key, so nobody is asked to paste
+          something the page can already read. */}
+      <RecoverPanel initialOwnerKey={key ?? ""} />
+
+      {key && (
+        <div className="ways-key">
+          <button
+            type="button"
+            className="st-btn"
+            onClick={() => setShowKey((v) => !v)}
+          >
+            {showKey ? "hide my recovery key" : "show my recovery key"}
+          </button>
+          {showKey && (
+            <>
+              <div className="ways-k mono">{key}</div>
+              <button
+                type="button"
+                className="st-btn"
+                onClick={async () => {
+                  try {
+                    await navigator.clipboard.writeText(key);
+                    setCopied(true);
+                    window.setTimeout(() => setCopied(false), 1400);
+                  } catch {
+                    /* clipboard blocked — the key is still selectable */
+                  }
+                }}
+              >
+                {copied ? "copied ✓" : "copy key"}
+              </button>
+              <p className="st-note st-bad">
+                This key controls the account and everything in it. Anyone who reads it can
+                take the funds. Save it somewhere private, and never paste it into a site
+                that asks for it. Importing it into MetaMask shows a different, empty
+                address &mdash; that is the key&rsquo;s own address, not your account.
+              </p>
+            </>
+          )}
+        </div>
+      )}
     </section>
   );
 }

--- a/web/src/app/app/console.css
+++ b/web/src/app/app/console.css
@@ -518,6 +518,20 @@
   margin: 8px 2px 0;
 }
 
+/* Getting your money out, and taking your key with you. */
+.ways { margin-bottom: 16px; display: flex; flex-direction: column; gap: 10px; }
+.ways-key { display: flex; flex-direction: column; gap: 8px; }
+.ways-k {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text);
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  overflow-wrap: anywhere;
+}
+
 /* The prove-it button, sitting between the status line and the numbers. */
 .selftest { margin-bottom: 16px; }
 .st-btn {

--- a/web/src/components/RecoverPanel.tsx
+++ b/web/src/components/RecoverPanel.tsx
@@ -58,12 +58,24 @@ const isKey = (v: string) => /^0x[0-9a-fA-F]{64}$/.test(v.trim());
 const MAINNET = 4663;
 const TESTNET = 46630;
 
-export function RecoverPanel() {
+/**
+ * @param initialOwnerKey The key this browser ALREADY holds, when it holds one.
+ *
+ * Asking a person to paste a key the page can read from its own localStorage is
+ * not security, it is friction — and friction on the exit is the worst place to
+ * put it. A user who could not find this flow imported his key into MetaMask
+ * instead, saw an empty address, and concluded his money was gone.
+ *
+ * Left optional and defaulting to empty so /home keeps working exactly as it
+ * did: that page is reachable while signed out and on a machine that never had
+ * the wallet, which is the case the paste field exists for.
+ */
+export function RecoverPanel({ initialOwnerKey = "" }: { initialOwnerKey?: string } = {}) {
   const [open, setOpen] = useState(false);
   const [ctx, setCtx] = useState<Ctx | null>(null);
   const [loadingCtx, setLoadingCtx] = useState(false);
 
-  const [ownerKey, setOwnerKey] = useState("");
+  const [ownerKey, setOwnerKey] = useState(initialOwnerKey);
   const [chainId, setChainId] = useState<number>(MAINNET);
   const [plan, setPlan] = useState<PlanRes | null>(null);
 


### PR DESCRIPTION
Sweeping your funds and exporting your key **already existed**. Neither was reachable from the dashboard.

- The sweep lived on `/home`, behind a field asking you to paste an owner key **this browser already holds** in localStorage.
- The key itself lived on `/grant`, behind a saved-wallets list.

So the dashboard could tell you your money was safe and offer you no way to touch it.

What that produced: an owner who wanted his funds out imported his key into MetaMask, saw the key's own empty address, and concluded the money was gone. Every step of that was reasonable. The exit was three pages away — and the one path he found was the one that shows the wrong address.

## Both now sit directly under the account address

**Recover, prefilled.** Asking someone to paste a key the page can read from its own storage is not security, it is friction — and friction on the exit is the worst place to put it. `RecoverPanel` takes an optional `initialOwnerKey`; `/home` passes nothing and keeps its paste field, which is the case that field exists for (a second device, signed out, a browser that never held the wallet).

**Export the key**, behind a show/hide, with a copy button and the warning it deserves — including the sentence that would have saved this user: importing it into MetaMask shows a *different, empty* address, which is the key's own, not the account.

Read entirely from localStorage — no server, no session — so it works even when the hosted side is having a bad day, which is exactly when somebody wants their money out.

---

Tests 1548/1548, web build clean.