### PR TITLE
The deploy script had a parse error, and nothing was checking it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,13 @@ jobs:
         working-directory: contracts
         run: npm install --no-audit --no-fund
 
+      # DEPLOY SCRIPTS ARE CHECKED TOO. The root tsconfig covers only the config
+      # and ./test, so scripts/ was never compiled by anything — and one shipped
+      # with a parse error, in a file whose job is to spend real gas on mainnet.
+      - name: Typecheck deploy scripts
+        working-directory: contracts
+        run: npm run typecheck:scripts
+
       - name: Test
         working-directory: contracts
         run: npm test

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -5,7 +5,8 @@
   "description": "On-chain drawdown breaker: BreakerRegistry + Kernel v3 policy adapter.",
   "scripts": {
     "build": "hardhat compile",
-    "test": "hardhat test"
+    "test": "hardhat test",
+    "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-viem": "^2.0.0",

--- a/contracts/scripts/deploy-ponsselftrade.ts
+++ b/contracts/scripts/deploy-ponsselftrade.ts
@@ -132,8 +132,7 @@ async function main() {
       codeBytes: (code.length - 2) / 2,
     },
   };
-  writeFileSync(file, JSON.stringify(book, null, 2) + "
-");
+  writeFileSync(file, JSON.stringify(book, null, 2) + "\n");
 
   console.log("");
   console.log(`✓ PonsSelfTrade deployed at ${adapter.address}`);

--- a/contracts/tsconfig.scripts.json
+++ b/contracts/tsconfig.scripts.json
@@ -1,0 +1,23 @@
+{
+  // DEPLOY SCRIPTS ARE TYPECHECKED, and until now they were not.
+  //
+  // The root tsconfig includes only `hardhat.config.ts` and `./test`, so nothing
+  // under `scripts/` was ever checked by anything — not locally, not in CI. A
+  // deploy script shipped with a literal newline inside a string, which is a
+  // parse error, and it was found by someone reading the file rather than by a
+  // tool. That script's job is to spend real gas on mainnet.
+  //
+  // A SEPARATE CONFIG rather than widening the root one: these run under
+  // Hardhat's ESM loader and use `import.meta.url`, which the root's
+  // `module: commonjs` rejects. Changing the root would alter how the tests and
+  // the Hardhat config compile to fix a problem that belongs to one directory.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  // hardhat.config.ts is what registers the hardhat-viem type augmentation,
+  // so `hre.viem` only exists to the compiler when it is in the program.
+  "include": ["./hardhat.config.ts", "./scripts"]
+}


### PR DESCRIPTION
`scripts/deploy-ponsselftrade.ts` line 135 read:

```ts
writeFileSync(file, JSON.stringify(book, null, 2) + "
");
```

A literal newline inside a string literal — a parse error. I put it there in the commit that made the script record its own deployed address. **That script's entire job is to spend real gas deploying a contract to mainnet, and the owner was about to run it.**

## Why nothing caught it

`contracts/tsconfig.json` includes only `./hardhat.config.ts` and `./test`. Nothing under `scripts/` has ever been compiled — not locally, not in CI.

I ran `tsc --noEmit -p tsconfig.json` after writing it, grepped the output for the filename, saw zero lines, and reported the file clean. **The file was never in the program.** Zero errors in a file nobody compiled is not evidence of anything, and I offered it as though it were.

It was found by an architecture-mapping pass *reading* the file, not by a tool.

## The fix, and the hole

- The parse error is fixed.
- `tsconfig.scripts.json` now compiles `scripts/`, and a CI step runs it.
- Separate from the root config rather than widening it: these run under Hardhat's ESM loader and use `import.meta.url`, which `module: commonjs` rejects. Changing the root would alter how the tests and the Hardhat config compile, to fix a problem that belongs to one directory. It includes `hardhat.config.ts` because that registers the hardhat-viem type augmentation — without it every `hre.viem` reads as an error.
- `deploy-v4selfswap.ts` was equally unchecked and is now covered too.

---

Same escape-collapse failure as three others today (`/s+/g` eating every letter "s", `\b` becoming U+0008, `/$15/` matching nothing). Every one was a backslash written through a generator. The difference here is that the others failed loudly in tests, and this one sat in the only directory with no tests at all.