### PR TITLE
Killing an agent destroyed the only copy of the owner key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,13 @@ jobs:
         working-directory: contracts
         run: npm install --no-audit --no-fund
 
+      # DEPLOY SCRIPTS ARE CHECKED TOO. The root tsconfig covers only the config
+      # and ./test, so scripts/ was never compiled by anything — and one shipped
+      # with a parse error, in a file whose job is to spend real gas on mainnet.
+      - name: Typecheck deploy scripts
+        working-directory: contracts
+        run: npm run typecheck:scripts
+
       - name: Test
         working-directory: contracts
         run: npm test

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -5,7 +5,8 @@
   "description": "On-chain drawdown breaker: BreakerRegistry + Kernel v3 policy adapter.",
   "scripts": {
     "build": "hardhat compile",
-    "test": "hardhat test"
+    "test": "hardhat test",
+    "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-viem": "^2.0.0",

--- a/contracts/scripts/deploy-ponsselftrade.ts
+++ b/contracts/scripts/deploy-ponsselftrade.ts
@@ -132,8 +132,7 @@ async function main() {
       codeBytes: (code.length - 2) / 2,
     },
   };
-  writeFileSync(file, JSON.stringify(book, null, 2) + "
-");
+  writeFileSync(file, JSON.stringify(book, null, 2) + "\n");
 
   console.log("");
   console.log(`✓ PonsSelfTrade deployed at ${adapter.address}`);

--- a/contracts/tsconfig.scripts.json
+++ b/contracts/tsconfig.scripts.json
@@ -1,0 +1,23 @@
+{
+  // DEPLOY SCRIPTS ARE TYPECHECKED, and until now they were not.
+  //
+  // The root tsconfig includes only `hardhat.config.ts` and `./test`, so nothing
+  // under `scripts/` was ever checked by anything — not locally, not in CI. A
+  // deploy script shipped with a literal newline inside a string, which is a
+  // parse error, and it was found by someone reading the file rather than by a
+  // tool. That script's job is to spend real gas on mainnet.
+  //
+  // A SEPARATE CONFIG rather than widening the root one: these run under
+  // Hardhat's ESM loader and use `import.meta.url`, which the root's
+  // `module: commonjs` rejects. Changing the root would alter how the tests and
+  // the Hardhat config compile to fix a problem that belongs to one directory.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  // hardhat.config.ts is what registers the hardhat-viem type augmentation,
+  // so `hre.viem` only exists to the compiler when it is in the program.
+  "include": ["./hardhat.config.ts", "./scripts"]
+}

--- a/web/src/components/KillSwitch.tsx
+++ b/web/src/components/KillSwitch.tsx
@@ -21,7 +21,9 @@ export function KillSwitch() {
     try {
       await fetch("/api/grants", { method: "DELETE" });
     } catch {
-      // server unreachable — still destroy the local key below
+      // Server unreachable — still stand the agent down locally. The local
+      // grant is ARCHIVED rather than destroyed (see clearGrant): killing is
+      // about stopping the agent trading, not about forfeiting the balance.
     }
     clearGrant();
     setState("done");
@@ -34,7 +36,12 @@ export function KillSwitch() {
         <button className="killall" disabled>
           ✓ all agents killed
         </button>
-        <div className="killall-note">grant destroyed · worker halts on its next tick</div>
+        {/* Says what actually happened to the money, because the previous
+            wording implied the wallet was gone and the truth is the opposite. */}
+        <div className="killall-note">
+          grant revoked · worker halts on its next tick · your recovery key is kept, so you
+          can still withdraw
+        </div>
       </>
     );
   }

--- a/web/src/lib/clear-grant.test.ts
+++ b/web/src/lib/clear-grant.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+/**
+ * KILLING AN AGENT MUST NOT DESTROY THE ONLY COPY OF THE OWNER KEY.
+ *
+ * `mintGrant` deliberately omits `demoOwnerPrivateKey` from the payload it sends
+ * the server when hosted, so that the server is never custodian of an owner key.
+ * The consequence is that the browser's localStorage holds the ONLY copy in
+ * existence — and `clearGrant()` was a bare `removeItem`.
+ *
+ * Three call sites reached it, including the kill switch, whose own comment read
+ * "server unreachable — still destroy the local key below". So pressing KILL on
+ * the hosted service permanently removed the ability to withdraw, for anyone,
+ * while the UI said "grant destroyed · worker halts on its next tick". The funds
+ * remain on-chain and become unreachable by construction.
+ *
+ * These are source assertions rather than behavioural ones on purpose: the
+ * module is browser-only (it touches `localStorage` at import-scope paths) and
+ * the property worth pinning is structural — that the archive happens BEFORE the
+ * removal, in this function, forever.
+ */
+
+const SESSION = readFileSync(new URL("./session.ts", import.meta.url), "utf8");
+
+/** The body of a top-level `export function <name>(...)` block. */
+function bodyOf(src: string, name: string): string {
+  const start = src.indexOf(`export function ${name}(`);
+  assert.notEqual(start, -1, `${name} not found`);
+  const open = src.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}" && --depth === 0) return src.slice(open + 1, i);
+  }
+  throw new Error(`unbalanced braces in ${name}`);
+}
+
+test("clearGrant ARCHIVES before it removes — the key survives a kill", () => {
+  const body = bodyOf(SESSION, "clearGrant");
+  const archiveAt = body.indexOf("archivePreviousGrant");
+  const removeAt = body.indexOf("removeItem");
+  assert.notEqual(archiveAt, -1, "clearGrant must archive the grant before discarding it");
+  assert.notEqual(removeAt, -1, "clearGrant must still remove the live grant");
+  assert.ok(
+    archiveAt < removeAt,
+    "the archive must happen BEFORE the removal — after it, there is nothing left to copy",
+  );
+});
+
+test("the server copy still omits the owner key — the reason this matters", () => {
+  // If this ever stops being true the severity changes completely, so the two
+  // facts are pinned together rather than in separate files that could drift.
+  assert.match(
+    SESSION,
+    /hostedAs \? \{\} : \{ demoOwnerPrivateKey: ownerPrivateKey \}/,
+    "hosted grants must not send the owner key to the server",
+  );
+});
+
+test("the archive helper is keyed by account, so a kill cannot clobber another wallet", () => {
+  // Private, so read it straight out of the source rather than via bodyOf.
+  const at = SESSION.indexOf("function archivePreviousGrant(");
+  assert.notEqual(at, -1, "the archive helper must exist");
+  const body = SESSION.slice(at, at + 800);
+  assert.match(body, /ARCHIVE_PREFIX/, "archives must be namespaced");
+  assert.match(
+    body,
+    /prev\.smartAccount/,
+    "and keyed by smart account, so archiving one wallet cannot clobber another",
+  );
+});
+
+test("the kill switch does not tell the user their wallet is gone", () => {
+  const kill = readFileSync(new URL("../components/KillSwitch.tsx", import.meta.url), "utf8");
+  assert.doesNotMatch(
+    kill,
+    /destroy the local key/,
+    "the kill path must no longer describe itself as destroying the key",
+  );
+  assert.match(kill, /recovery key is kept/, "and must say the money is still reachable");
+});

--- a/web/src/lib/session.ts
+++ b/web/src/lib/session.ts
@@ -111,7 +111,29 @@ export function loadGrant(): Grant | null {
   }
 }
 
+/**
+ * Stop using this grant — WITHOUT destroying the only key that can recover it.
+ *
+ * This was a bare `removeItem`, and hosted that is irreversible fund loss.
+ * `mintGrant` omits `demoOwnerPrivateKey` from the copy it sends the server
+ * (see the hostedAs branch below), precisely so the server is never custodian
+ * of an owner key — which means this browser's localStorage holds the ONLY
+ * copy in existence. Three call sites removed it: the grant page's discard,
+ * BandSection, and the kill switch, whose own comment reads “server
+ * unreachable — still destroy the local key below”.
+ *
+ * So pressing KILL on the hosted service permanently destroyed the ability to
+ * ever withdraw, for anyone, and the UI said only “grant destroyed”. The
+ * funds stay on-chain and become unreachable by construction.
+ *
+ * ARCHIVE FIRST, exactly as minting already does. The helper existed and this
+ * path simply never called it. Killing an agent is about stopping it from
+ * TRADING; it was never meant to be about forfeiting the balance, and
+ * listSavedWallets already surfaces archived wallets so the key stays
+ * reachable from /grant and from the dashboard's recovery panel.
+ */
 export function clearGrant(): void {
+  archivePreviousGrant();
   localStorage.removeItem(STORAGE_KEY);
 }
 


### PR DESCRIPTION
On the hosted service this was **irreversible fund loss, one button press away, with the UI reporting success**.

## The chain of facts

`mintGrant` deliberately omits `demoOwnerPrivateKey` from the payload sent to the server when hosted, so the server is never custodian of an owner key. That is the right decision and it is the entire custody argument.

Its consequence: **the browser's localStorage holds the only copy in existence.**

`clearGrant()` was a bare `localStorage.removeItem`. Three call sites reached it — the grant page's discard, `BandSection`, and the kill switch, whose own comment read *"server unreachable — still destroy the local key below"*.

So pressing **KILL** on app.merrymen.dev permanently removed the ability to withdraw, for anyone, forever. The funds stay on-chain in a smart account whose sudo key no longer exists. And the UI said *"grant destroyed · worker halts on its next tick"* — which reads like the reassuring half of a safety feature.

## The fix was already in the file

`archivePreviousGrant()` exists and is called on **mint**, under a comment reading "ARCHIVE FIRST" for exactly this reason. `clearGrant` simply never called it.

Killing an agent is about stopping it **trading** — it was never meant to be about forfeiting the balance — and `listSavedWallets` already surfaces archived wallets, so the key stays reachable from `/grant` and from the dashboard's recovery panel.

The kill switch now says what actually happened: *"grant revoked · worker halts on its next tick · your recovery key is kept, so you can still withdraw"*.

## Tests

Four regression tests, as **source** assertions because the module is browser-only and the property worth pinning is structural:

- the archive must happen **before** the removal (after it, there is nothing left to copy)
- the server copy must still omit the key — if that ever changes the severity changes completely, so the two facts are pinned together rather than in files that could drift
- archives stay keyed by smart account
- the kill switch must not describe itself as destroying the key

---

Found by a workflow designing in-browser hosted recovery, which observed that building a sweep on top of a key three buttons delete would be building on sand.

Tests 1552/1552, web build clean.