### PR TITLE
Hosted owners can actually withdraw

### DIFF
--- a/web/src/app/api/bundler/[chainId]/route.ts
+++ b/web/src/app/api/bundler/[chainId]/route.ts
@@ -1,0 +1,172 @@
+/**
+ * THE RECOVERY RELAY — a withdrawal submit path, not a bundler proxy.
+ *
+ * Hosted, the browser can SIGN a withdrawal but cannot SUBMIT one: the Pimlico
+ * key is a house secret, and `pimlicoBundlerUrl` and `pimlicoPaymasterUrl` are
+ * the byte-identical string, so handing it to a browser would hand out
+ * house-sponsored gas along with it. This route closes that gap by adding the
+ * key server-side and forwarding only what a withdrawal needs.
+ *
+ * The engine needs no changes: `recoverFunds` takes `bundlerUrl` as an opaque
+ * string, so the browser passes `${origin}/api/bundler/4663` and everything else
+ * is the code the CLI already runs.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * FOUR GATES, and the third is the one that matters
+ *
+ * 1. METHOD ALLOWLIST, deny by default. Seven methods, listed below.
+ * 2. THE TICKET names WHOSE account may be relayed; `userOp.sender` must equal
+ *    it. See recovery-ticket.ts for what that does and does not prove.
+ * 3. THE OPERATION MUST BE A WITHDRAWAL. Validating method, sender, entryPoint
+ *    and paymaster fields never looks at what the operation DOES — without
+ *    isRecoveryShape, any ticket holder could push swaps, approvals or arbitrary
+ *    contract calls through app.merrymen.dev as a free transaction service on
+ *    the house's bundler account. This is the gate that makes the file's first
+ *    sentence true.
+ * 4. NO PAYMASTER, structurally. Recovery never uses one, so any op carrying
+ *    paymaster fields is refused outright — which makes house sponsorship
+ *    impossible on this path by construction rather than by policy.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHAT IS DELIBERATELY *NOT* DONE HERE
+ *
+ * carriesOwnerKey is NOT run on this body, and that is not an oversight. Its
+ * RAW_KEY pattern matches any bare 32-byte hex value anywhere in the payload,
+ * and a userOpHash is exactly 0x + 64 hex — so every receipt poll would 4xx, the
+ * sweep would succeed on chain, and the panel would report a failure on a
+ * withdrawal that already moved the money. The stronger guard is the typed
+ * schema below: the only accepted fields are a method string, a userOp with a
+ * known key set, an entryPoint address and a 32-byte hash. There is no field an
+ * owner key could ride in. carriesOwnerKey stays where it belongs, on grant
+ * intake.
+ *
+ * THE UPSTREAM URL IS NEVER ECHOED. viem embeds the full request URL — query
+ * string included — in its error metaMessages, which is precisely how a Pimlico
+ * key leaks into an error toast. Failures are mapped to {code, message} and
+ * scrubbed.
+ */
+
+import { NextResponse } from "next/server";
+import { pimlicoBundlerUrl, robinhoodChain, robinhoodTestnet, ENTRYPOINT } from "@merrymen/core";
+import { readTicket } from "@/lib/recovery-ticket";
+import { isRecoveryShape } from "@/lib/recovery-shape";
+
+export const runtime = "nodejs";
+
+/** Everything a withdrawal needs, and nothing else. */
+const ALLOWED = new Set([
+  "eth_chainId",
+  "eth_supportedEntryPoints",
+  "eth_estimateUserOperationGas",
+  "eth_sendUserOperation",
+  "eth_getUserOperationReceipt",
+  "eth_getUserOperationByHash",
+  // Not optional: the fee oracle exists so the bundler accepts the fees it
+  // quoted itself. Without it the send is rejected for underpriced gas.
+  "pimlico_getUserOperationGasPrice",
+]);
+
+/** The two methods that carry an operation, and therefore need it inspected. */
+const OP_METHODS = new Set(["eth_estimateUserOperationGas", "eth_sendUserOperation"]);
+
+const KNOWN_CHAINS = new Set<number>([robinhoodChain.id, robinhoodTestnet.id]);
+const MAX_BODY = 32 * 1024;
+
+/** Any hint of a paymaster is a refusal — see gate 4. */
+const PAYMASTER_FIELDS = [
+  "paymaster",
+  "paymasterData",
+  "paymasterAndData",
+  "paymasterVerificationGasLimit",
+  "paymasterPostOpGasLimit",
+] as const;
+
+function scrub(s: string): string {
+  return s.replace(/apikey=[^&\s"']+/gi, "apikey=<redacted>").replace(/api\.pimlico\.io\S*/gi, "<bundler>");
+}
+
+const bad = (status: number, message: string) => NextResponse.json({ error: message }, { status });
+
+export async function POST(req: Request, ctx: { params: Promise<{ chainId: string }> }) {
+  const chainId = Number((await ctx.params).chainId);
+  if (!KNOWN_CHAINS.has(chainId)) return bad(400, "unknown chain");
+
+  // From the cookie the ticket route set. A header would need the browser to
+  // reach inside viem's transport to add one, which means patching global
+  // fetch — not something to do around a money path.
+  const ticket = readTicket(
+    req.headers.get("cookie")?.match(/(?:^|;\s*)merrymen_recovery=([^;]+)/)?.[1],
+  );
+  if (!ticket) return bad(401, "no valid recovery ticket — sign the challenge first");
+  if (ticket.chainId !== chainId) return bad(401, "this ticket is for a different chain");
+
+  const raw = await req.text();
+  if (raw.length > MAX_BODY) return bad(413, "request too large");
+
+  let rpc: { method?: unknown; params?: unknown; id?: unknown };
+  try {
+    rpc = JSON.parse(raw) as typeof rpc;
+  } catch {
+    return bad(400, "malformed request");
+  }
+  // A batch would let one allowed request fan out into N upstream calls.
+  if (Array.isArray(rpc)) return bad(400, "batched requests are not relayed");
+
+  const method = typeof rpc.method === "string" ? rpc.method : "";
+  if (!ALLOWED.has(method)) return bad(403, `this relay does not forward ${method || "that method"}`);
+
+  const params = Array.isArray(rpc.params) ? rpc.params : [];
+
+  if (OP_METHODS.has(method)) {
+    const op = params[0] as Record<string, unknown> | undefined;
+    if (!op || typeof op !== "object") return bad(400, "missing user operation");
+
+    const sender = typeof op.sender === "string" ? op.sender.toLowerCase() : "";
+    if (sender !== ticket.smartAccount.toLowerCase()) {
+      return bad(403, "this ticket does not cover that account");
+    }
+
+    const entryPoint = typeof params[1] === "string" ? params[1].toLowerCase() : "";
+    if (entryPoint !== ENTRYPOINT.v07.toLowerCase()) {
+      return bad(400, "only EntryPoint v0.7 is relayed");
+    }
+
+    for (const f of PAYMASTER_FIELDS) {
+      const v = op[f];
+      if (v !== undefined && v !== null && v !== "0x" && v !== "") {
+        return bad(403, "sponsored operations are not relayed on this path");
+      }
+    }
+
+    const callData = typeof op.callData === "string" ? (op.callData as `0x${string}`) : "0x";
+    const shape = isRecoveryShape(callData);
+    if (!shape.ok) {
+      return bad(403, `this relay only carries withdrawals — ${shape.why}`);
+    }
+  }
+
+  const key = process.env.MERRYMEN_BUNDLER_API_KEY;
+  if (!key) return bad(503, "this deployment has no bundler configured");
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(pimlicoBundlerUrl(chainId, key), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      // Rebuilt from validated fields — never the caller's raw bytes, so
+      // nothing unexamined is forwarded.
+      body: JSON.stringify({ jsonrpc: "2.0", id: rpc.id ?? 1, method, params }),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (e) {
+    return bad(502, scrub(`the bundler did not answer: ${e instanceof Error ? e.message : String(e)}`));
+  }
+
+  const text = await upstream.text();
+  // Pass the JSON-RPC envelope through so viem can read a result or an error
+  // normally — but scrubbed, because an upstream error can quote the URL.
+  return new NextResponse(scrub(text), {
+    status: upstream.status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/web/src/app/api/recover/ticket/route.ts
+++ b/web/src/app/api/recover/ticket/route.ts
@@ -1,0 +1,115 @@
+/**
+ * MINT A RECOVERY TICKET — the anti-abuse token the bundler relay demands.
+ *
+ * GET  issues an origin-bound, single-use nonce.
+ * POST takes a signature over the recovery challenge, recovers the owner
+ *      ADDRESS, derives the Kernel account that owner controls, and returns a
+ *      short-lived ticket bound to {smartAccount, chainId}.
+ *
+ * NO OWNER KEY CROSSES THE WIRE, and none can: the request body's only accepted
+ * fields are a nonce, a 65-byte signature and a chain id. The signature is over
+ * a message that says in words that it moves no funds, and the server can do
+ * nothing with it except recover an address.
+ *
+ * WHY NOT REQUIRE A SESSION. Because the recoveries that matter most have none.
+ * The kill switch DELETEs the tenant's grants row, so after a kill the server no
+ * longer knows the account at all — and "I killed my agent, now I want my money"
+ * is the likeliest reason anyone opens recovery. A session requirement would
+ * refuse exactly those people. It also has to work for superseded wallets and
+ * from a browser that was never signed in.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT PROVE: that the account has ever existed on
+ * this deployment. A stranger can generate keypairs in a loop and mint tickets
+ * for accounts nobody has funded. That is why the relay tiers its quota on
+ * whether we have actually SEEN the account rather than trusting the ticket
+ * alone — the ticket bounds WHOSE operation may be relayed, not how much of the
+ * house's bundler allowance a stranger may spend.
+ */
+
+import { NextResponse } from "next/server";
+import { recoverMessageAddress } from "viem";
+import { consumeChallengeNonce, issueChallengeNonce, requestOrigin } from "@/lib/auth";
+import { deriveKernelAccountAddress } from "@/lib/derive-account";
+import { mintTicket, recoveryChallengeMessage, TICKET_TTL_MS } from "@/lib/recovery-ticket";
+import { robinhoodChain, robinhoodTestnet } from "@merrymen/core";
+
+export const runtime = "nodejs";
+
+const KNOWN_CHAINS = new Set<number>([robinhoodChain.id, robinhoodTestnet.id]);
+
+export async function GET(req: Request) {
+  const origin = requestOrigin(req);
+  const nonce = issueChallengeNonce(origin);
+  return NextResponse.json({ nonce, message: recoveryChallengeMessage(origin, nonce) });
+}
+
+export async function POST(req: Request) {
+  const origin = requestOrigin(req);
+
+  let body: { nonce?: unknown; signature?: unknown; chainId?: unknown };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: "malformed request" }, { status: 400 });
+  }
+
+  const nonce = typeof body.nonce === "string" ? body.nonce : "";
+  const signature = typeof body.signature === "string" ? body.signature : "";
+  const chainId = Number(body.chainId);
+
+  if (!nonce) return NextResponse.json({ error: "missing nonce" }, { status: 400 });
+  if (!/^0x[0-9a-fA-F]{130}$/.test(signature)) {
+    return NextResponse.json({ error: "missing or malformed signature" }, { status: 400 });
+  }
+  if (!KNOWN_CHAINS.has(chainId)) {
+    return NextResponse.json({ error: "unknown chain" }, { status: 400 });
+  }
+
+  // BURN THE NONCE FIRST. The signature alone binds origin (it is in the text)
+  // but nothing else — without a single-use, expiring nonce, anyone who ever saw
+  // that signature could mint tickets for the account forever.
+  const gate = consumeChallengeNonce(nonce, origin);
+  if (!gate.ok) return NextResponse.json({ error: gate.why }, { status: 401 });
+
+  // Reconstruct the exact text that was signed. Nothing the caller sends is
+  // trusted as an identity — the address falls out of the signature or the
+  // request fails.
+  const message = recoveryChallengeMessage(origin, nonce);
+  let owner: `0x${string}`;
+  try {
+    owner = await recoverMessageAddress({ message, signature: signature as `0x${string}` });
+  } catch {
+    return NextResponse.json({ error: "signature did not recover" }, { status: 401 });
+  }
+
+  // Owner ADDRESS only. deriveKernelAccountAddress builds a view-only signer
+  // whose signing methods throw, so this path cannot handle key material even
+  // by accident.
+  let smartAccount: `0x${string}`;
+  try {
+    smartAccount = (await deriveKernelAccountAddress(owner, chainId)) as `0x${string}`;
+  } catch {
+    return NextResponse.json({ error: "could not derive the account for that owner" }, { status: 502 });
+  }
+
+  // SET AS A COOKIE, not returned for the client to attach.
+  //
+  // The relay is reached through viem's own http transport inside
+  // recoverFunds, which the browser does not get to add headers to without
+  // monkey-patching global fetch — a racy thing to do around a money path. A
+  // cookie is attached automatically by the browser, and is scoped to
+  // /api/bundler so it is not sent anywhere else on the origin.
+  //
+  // httpOnly, so a script on the page cannot read it back out; sameSite strict,
+  // so no other site can cause it to be sent; and short-lived by the ticket's
+  // own expiry, which is what actually bounds it.
+  const res = NextResponse.json({ smartAccount, expiresInMs: TICKET_TTL_MS });
+  res.cookies.set("merrymen_recovery", mintTicket({ smartAccount, chainId }), {
+    httpOnly: true,
+    secure: true,
+    sameSite: "strict",
+    path: "/api/bundler",
+    maxAge: Math.floor(TICKET_TTL_MS / 1000),
+  });
+  return res;
+}

--- a/web/src/components/RecoverPanel.tsx
+++ b/web/src/components/RecoverPanel.tsx
@@ -149,7 +149,10 @@ export function RecoverPanel({ initialOwnerKey = "" }: { initialOwnerKey?: strin
       setPlan({
         smartAccount: b.smartAccount,
         chainId: w.chainId,
-        balances: b.balances.map((x) => ({ symbol: x.symbol, amount: x.ui })),
+        // TokenBalance already carries the display string as `amount`, and the
+        // panel renders exactly that shape — so pass it through rather than
+        // rebuilding it and losing `note` along the way.
+        balances: b.balances,
       } as unknown as PlanRes);
       // The one thing that stops a sweep dead, said BEFORE they press it.
       if (b.needsGas) {

--- a/web/src/components/RecoverPanel.tsx
+++ b/web/src/components/RecoverPanel.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { listSavedWallets } from "@/lib/session";
+import { planFromBrowser, sweepFromBrowser, redact, type BrowserWallet } from "@/lib/recover-client";
 
 /**
  * "Get my money out" — the one-click counterpart to `merrymen recover`.
@@ -27,6 +29,10 @@ interface Ctx {
   /** Labels whose balance could not be READ. Never conflate with "not held". */
   unreadable?: string[];
   error?: string;
+  /** The server's explanation. Was returned, parsed, and never rendered. */
+  detail?: string;
+  /** Hosted: the server cannot sweep, the browser must. */
+  clientSide?: boolean;
 }
 interface PlanRes {
   smartAccount: string;
@@ -97,6 +103,95 @@ export function RecoverPanel({ initialOwnerKey = "" }: { initialOwnerKey?: strin
     setLoadingCtx(false);
   }
 
+  /**
+   * HOSTED: the server holds no owner key and says so. Do the work here.
+   *
+   * The panel used to fetch that refusal, drop it on the floor, and fall
+   * through to a paste-a-key form whose button POSTed to a route that 403s
+   * before it even parses the body. A user with money in the account saw an
+   * empty form and one red line.
+   */
+  function browserWallet(): BrowserWallet | null {
+    const key = ownerKey.trim();
+    if (!isKey(key)) return null;
+    // Prefer the stored wallet, so grantTokens (and therefore the sweep list)
+    // comes from what the wall actually covers rather than the builtin floor.
+    const saved = (() => {
+      try {
+        return listSavedWallets().find(
+          (w) => (w.ownerKey ?? "").toLowerCase() === key.toLowerCase(),
+        );
+      } catch {
+        return undefined;
+      }
+    })();
+    if (!saved) return null;
+    return {
+      smartAccount: saved.smartAccount,
+      ownerKey: key as `0x${string}`,
+      chainId: saved.chainId ?? chainId,
+      grantTokens: (saved as { grantTokens?: string[] }).grantTokens,
+    };
+  }
+
+  async function checkInBrowser() {
+    setError(null);
+    const w = browserWallet();
+    if (!w) {
+      setError(
+        "this browser doesn't hold that wallet, so it can't withdraw here. Use `merrymen recover` on the machine with your key.",
+      );
+      return;
+    }
+    setBusy("checking");
+    try {
+      const b = await planFromBrowser(w);
+      setPlan({
+        smartAccount: b.smartAccount,
+        chainId: w.chainId,
+        balances: b.balances.map((x) => ({ symbol: x.symbol, amount: x.ui })),
+      } as unknown as PlanRes);
+      // The one thing that stops a sweep dead, said BEFORE they press it.
+      if (b.needsGas) {
+        setError(
+          `this account has no ETH, and a withdrawal is an on-chain operation it has to pay for. Send a little ETH to ${b.smartAccount} and try again — a few dollars is plenty.`,
+        );
+      }
+    } catch (e) {
+      setError(redact(e, w.ownerKey));
+    }
+    setBusy(null);
+  }
+
+  async function sweepInBrowser() {
+    setError(null);
+    if (!isAddr(to)) {
+      setError("enter a valid destination address (0x + 40 hex).");
+      return;
+    }
+    const w = browserWallet();
+    if (!w) {
+      setError("this browser doesn't hold that wallet.");
+      return;
+    }
+    const list = balances.map((b) => `${b.amount} ${b.symbol}`).join(", ") || "the balance";
+    if (
+      !window.confirm(
+        `Sweep ${list} to ${to.trim()}?\n\nThis is real and irreversible. The account keeps a little ETH to pay for gas.`,
+      )
+    ) {
+      return;
+    }
+    setBusy("sweeping");
+    try {
+      const r = await sweepFromBrowser(w, to.trim() as `0x${string}`);
+      setResult(r as unknown as SweepRes);
+    } catch (e) {
+      setError(redact(e, w.ownerKey));
+    }
+    setBusy(null);
+  }
+
   async function checkPasted() {
     setError(null);
     if (!isKey(ownerKey)) {
@@ -118,6 +213,10 @@ export function RecoverPanel({ initialOwnerKey = "" }: { initialOwnerKey?: strin
     }
     setBusy(null);
   }
+
+  // HOSTED: the server told us it cannot sweep. Do it here instead of showing
+  // its refusal as though the user had done something wrong.
+  const clientSide = ctx?.clientSide === true;
 
   // Balances/addresses come from the pasted-key plan if present, else the GET ctx.
   const balances = plan?.balances ?? ctx?.balances ?? [];
@@ -228,8 +327,9 @@ export function RecoverPanel({ initialOwnerKey = "" }: { initialOwnerKey?: strin
           {ctx && !ctx.hasStoredKey && !plan && (
             <>
               <p className="recover-sub">
-                No active agent on this machine, so paste the <b>owner key</b> you backed up when you
-                created the wallet. It stays on your machine — it&apos;s used once to sign the sweep.
+                {clientSide
+                  ? "Withdrawing happens right here in your browser — your owner key never leaves this device. It signs the withdrawal locally; this site only relays it to the network."
+                  : "No active agent on this machine, so paste the owner key you backed up when you created the wallet. It stays on your machine — it is used once to sign the sweep."}
               </p>
               <input
                 className="recover-input mono"
@@ -247,7 +347,7 @@ export function RecoverPanel({ initialOwnerKey = "" }: { initialOwnerKey?: strin
                   <input type="radio" checked={chainId === TESTNET} onChange={() => setChainId(TESTNET)} /> testnet · 46630
                 </label>
               </div>
-              <button className="recover-btn" onClick={() => void checkPasted()} disabled={busy !== null}>
+              <button className="recover-btn" onClick={() => void (clientSide ? checkInBrowser() : checkPasted())} disabled={busy !== null}>
                 {busy === "checking" ? "reading the wallet…" : "check what's in it"}
               </button>
             </>
@@ -307,7 +407,7 @@ export function RecoverPanel({ initialOwnerKey = "" }: { initialOwnerKey?: strin
                   />
                   <button
                     className="recover-btn go"
-                    onClick={() => void sweep()}
+                    onClick={() => void (clientSide ? sweepInBrowser() : sweep())}
                     disabled={busy !== null || !hasBundler || !isAddr(to)}
                   >
                     {busy === "sweeping" ? "signing & sending (up to a minute)…" : "recover funds →"}

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -109,6 +109,27 @@ function checkNonce(nonce: string, origin: string, now: number): { ok: true } | 
   return { ok: true };
 }
 
+/**
+ * Validate a challenge nonce and BURN it, for a caller that signs its own
+ * message text rather than the sign-in one.
+ *
+ * Recovery needs this: its challenge says something different (it is about
+ * withdrawing, not signing in) but the nonce discipline must be identical, or a
+ * captured signature becomes a permanent bearer credential. Exported rather than
+ * duplicated so there is exactly ONE definition of what makes a nonce valid —
+ * the origin binding, the HMAC, the expiry and the single-use set.
+ */
+export function consumeChallengeNonce(
+  nonce: string,
+  origin: string,
+  now = Date.now(),
+): { ok: true } | { ok: false; why: string } {
+  const gate = checkNonce(nonce, origin, now);
+  if (!gate.ok) return gate;
+  usedNonces.add(nonce);
+  return { ok: true };
+}
+
 // ── verify a signed challenge → tenant address ───────────────────────────────
 
 export type VerifyResult =

--- a/web/src/lib/recover-client.ts
+++ b/web/src/lib/recover-client.ts
@@ -34,7 +34,7 @@
 
 import { privateKeyToAccount } from "viem/accounts";
 import { robinhoodChain, robinhoodTestnet } from "@merrymen/core";
-import { planRecovery, recoverFunds } from "@merrymen/recover";
+import { planRecovery, recoverFunds, type RecoverPlan } from "@merrymen/recover";
 
 export interface BrowserWallet {
   smartAccount: `0x${string}`;
@@ -98,10 +98,16 @@ export async function getRecoveryTicket(w: BrowserWallet): Promise<void> {
   }
 }
 
-export interface BrowserPlan {
-  smartAccount: `0x${string}`;
-  gasWei: bigint;
-  balances: { symbol: string; address: `0x${string}`; raw: bigint; ui: string }[];
+/**
+ * The engine’s own plan, plus one derived flag.
+ *
+ * EXTENDS rather than redeclares, and the typecheck is what forced that: my
+ * first version listed the fields I happened to use and silently dropped
+ * `unreadable` — the field recover.ts keeps precisely so a blinking RPC cannot
+ * be reported as an empty account. Restating a type is how you lose the parts of
+ * it you were not thinking about.
+ */
+export interface BrowserPlan extends RecoverPlan {
   /** True when the account cannot pay for its own withdrawal. */
   needsGas: boolean;
 }
@@ -116,7 +122,7 @@ export async function planFromBrowser(w: BrowserWallet): Promise<BrowserPlan> {
     // fails loudly instead of sweeping a stranger's empty account.
     expectedSmartAccount: w.smartAccount,
     extraTokens: (w.grantTokens ?? []).map((address) => ({ address, symbol: "", decimals: 18 })),
-  })) as BrowserPlan;
+  })) as RecoverPlan;
   return { ...plan, needsGas: plan.gasWei === 0n };
 }
 

--- a/web/src/lib/recover-client.ts
+++ b/web/src/lib/recover-client.ts
@@ -1,0 +1,143 @@
+"use client";
+
+/**
+ * WITHDRAWING FROM THE BROWSER, because hosted there is nowhere else to do it.
+ *
+ * The server refuses `/api/recover` when hosted, correctly: it holds no owner
+ * key, so it has nothing to sign with. Its comment said recovery "runs entirely
+ * in the browser ... which the client already knows how to do" — and no such
+ * client existed. This is it.
+ *
+ * NO NEW ENGINE. `planRecovery` and `recoverFunds` from the worker are the same
+ * functions the CLI runs; they import only viem, @zerodev/* and packages/core,
+ * with no node builtins, and the `@merrymen/recover` alias already existed. The
+ * phone app has run this same module unmodified for months, so its portability
+ * is demonstrated rather than hoped for.
+ *
+ * TWO THINGS ARE DIFFERENT IN A BROWSER, and both are handled here.
+ *
+ * THE BUNDLER. Hosted, the Pimlico key is a house secret. `recoverFunds` takes
+ * `bundlerUrl` as an opaque string, so it is pointed at this origin's relay,
+ * which adds the key server-side and forwards only withdrawal-shaped traffic.
+ * Reads need no relay at all: the chain's RPC answers browsers directly
+ * (`access-control-allow-origin: *`, probed against 4663), so `rpcUrl` is left
+ * undefined and viem uses the chain default.
+ *
+ * THE TOKEN LIST. `extraTokens` must NOT come from `/api/settings`: hosted, that
+ * route returns `{}` to a caller with no session cookie, and the entire point of
+ * this path is that it works signed out and after a kill. An empty list silently
+ * falls back to the builtin set and leaves every owner-added token behind —
+ * which is the exact failure `sweepList` was written to prevent. So it comes
+ * from the grant in localStorage, which carries `grantTokens`: the addresses the
+ * wall actually covers. `sweepList` re-validates every entry anyway.
+ */
+
+import { privateKeyToAccount } from "viem/accounts";
+import { robinhoodChain, robinhoodTestnet } from "@merrymen/core";
+import { planRecovery, recoverFunds } from "@merrymen/recover";
+
+export interface BrowserWallet {
+  smartAccount: `0x${string}`;
+  ownerKey: `0x${string}`;
+  chainId: number;
+  /** Addresses the grant covers, used as the sweep list. */
+  grantTokens?: readonly string[];
+}
+
+const chainOf = (id: number) => (id === robinhoodTestnet.id ? robinhoodTestnet : robinhoodChain);
+
+/** This origin's relay, which holds the house bundler key so the browser cannot. */
+export const relayUrl = (chainId: number) =>
+  `${typeof window === "undefined" ? "" : window.location.origin}/api/bundler/${chainId}`;
+
+/**
+ * Strip anything that could carry a key or an upstream URL out of an error.
+ *
+ * viem embeds the full request URL — query string included — in its
+ * `metaMessages`, which is how a Pimlico key ends up in a toast. The relay
+ * scrubs its own responses; this covers everything viem adds locally, and the
+ * owner key itself, which is in scope in this module.
+ */
+export function redact(e: unknown, ownerKey?: string): string {
+  let msg = e instanceof Error ? e.message : String(e);
+  if (ownerKey) msg = msg.split(ownerKey).join("<owner key>");
+  return msg
+    .replace(/apikey=[^&\s"']+/gi, "apikey=<redacted>")
+    .replace(/0x[0-9a-fA-F]{64}/g, "<32-byte value>")
+    .slice(0, 400);
+}
+
+/**
+ * Sign the recovery challenge with the OWNER KEY, locally, and arm the relay.
+ *
+ * The ticket comes back as an httpOnly, path-scoped cookie rather than a value
+ * this code holds — so nothing here has to thread it through viem's transport,
+ * and no script on the page can read it back out.
+ */
+export async function getRecoveryTicket(w: BrowserWallet): Promise<void> {
+  const chal = await fetch("/api/recover/ticket", { cache: "no-store" });
+  if (!chal.ok) throw new Error("could not start recovery — the site did not issue a challenge");
+  const { nonce, message } = (await chal.json()) as { nonce: string; message: string };
+
+  // Signed HERE. The key never leaves this function's scope, let alone the tab.
+  const signature = await privateKeyToAccount(w.ownerKey).signMessage({ message });
+
+  const res = await fetch("/api/recover/ticket", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ nonce, signature, chainId: w.chainId }),
+  });
+  const body = (await res.json()) as { smartAccount?: string; error?: string };
+  if (!res.ok) throw new Error(body.error ?? "the site would not issue a recovery ticket");
+
+  // The server derived an account from the signature alone. If it disagrees with
+  // the wallet this browser holds, something is wrong on one side and sweeping
+  // would be guessing.
+  if (body.smartAccount && body.smartAccount.toLowerCase() !== w.smartAccount.toLowerCase()) {
+    throw new Error("this key does not control the account shown — refusing to sweep");
+  }
+}
+
+export interface BrowserPlan {
+  smartAccount: `0x${string}`;
+  gasWei: bigint;
+  balances: { symbol: string; address: `0x${string}`; raw: bigint; ui: string }[];
+  /** True when the account cannot pay for its own withdrawal. */
+  needsGas: boolean;
+}
+
+/** What is in the account, read straight from the chain. No relay, no session. */
+export async function planFromBrowser(w: BrowserWallet): Promise<BrowserPlan> {
+  const plan = (await planRecovery({
+    chain: chainOf(w.chainId),
+    ownerPrivateKey: w.ownerKey,
+    // ALWAYS passed: the server route cannot check this for a pasted key, but
+    // the browser knows which account this wallet is meant to be, so a wrong key
+    // fails loudly instead of sweeping a stranger's empty account.
+    expectedSmartAccount: w.smartAccount,
+    extraTokens: (w.grantTokens ?? []).map((address) => ({ address, symbol: "", decimals: 18 })),
+  })) as BrowserPlan;
+  return { ...plan, needsGas: plan.gasWei === 0n };
+}
+
+/**
+ * Sweep everything to an address the owner names.
+ *
+ * The relay ticket is attached per request. `recoverFunds` builds and signs the
+ * operation locally and submits it through the relay, which will refuse anything
+ * that is not withdrawal-shaped.
+ */
+export async function sweepFromBrowser(w: BrowserWallet, to: `0x${string}`) {
+  // Arms the relay by setting the ticket cookie. Same-origin requests carry it
+  // automatically from here, including the ones viem makes inside recoverFunds.
+  await getRecoveryTicket(w);
+
+  return recoverFunds({
+    chain: chainOf(w.chainId),
+    ownerPrivateKey: w.ownerKey,
+    bundlerUrl: relayUrl(w.chainId),
+    to,
+    expectedSmartAccount: w.smartAccount,
+    extraTokens: (w.grantTokens ?? []).map((address) => ({ address, symbol: "", decimals: 18 })),
+  });
+}

--- a/web/src/lib/recovery-shape.test.ts
+++ b/web/src/lib/recovery-shape.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { encodeFunctionData, erc20Abi } from "viem";
+import { isRecoveryShape } from "./recovery-shape";
+
+/**
+ * THE DECODER IS PINNED AGAINST KERNEL'S OWN ENCODER, not against my idea of it.
+ *
+ * This validator decides whether the house relays an operation. Too strict and it
+ * strands somebody's withdrawal; too loose and app.merrymen.dev becomes a free
+ * transaction-submission service on the house's bundler account. Both failure
+ * modes are silent, so the fixtures come from `@zerodev/sdk`'s own
+ * `encodeExecuteBatchCall` / `encodeExecuteSingleCall` — the exact functions
+ * `account.encodeCalls()` reaches. If Kernel changes its encoding, these fail
+ * loudly rather than the gate quietly swinging open or shut.
+ */
+
+// Loaded lazily: the runner transpiles to CJS, where top-level await is not
+// available. Memoised so the fixtures still come from ONE copy of the SDK.
+let sdk: { batch: Function; single: Function } | null = null;
+async function enc() {
+  if (sdk) return sdk;
+  // BY FILE URL, deliberately past the package exports map. These encoders are
+  // internal to @zerodev/sdk and not exported — but they are exactly what
+  // account.encodeCalls() reaches, and pinning the decoder against a
+  // reimplementation would only prove the decoder agrees with itself.
+  const base = new URL(
+    "../../../node_modules/@zerodev/sdk/_esm/accounts/kernel/utils/ep0_7/",
+    import.meta.url,
+  );
+  const [b, s] = await Promise.all([
+    import(new URL("encodeExecuteBatchCall.js", base).href),
+    import(new URL("encodeExecuteSingleCall.js", base).href),
+  ]);
+  sdk = { batch: (b as any).encodeExecuteBatchCall, single: (s as any).encodeExecuteSingleCall };
+  return sdk;
+}
+
+const DEST = "0x1111111111111111111111111111111111111111" as const;
+const OTHER = "0x2222222222222222222222222222222222222222" as const;
+const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168" as const;
+const NVDA = "0x3333333333333333333333333333333333333333" as const;
+const ROUTER = "0x4444444444444444444444444444444444444444" as const;
+
+const xfer = (to: `0x${string}`, amount: bigint) =>
+  encodeFunctionData({ abi: erc20Abi, functionName: "transfer", args: [to, amount] });
+
+const batch = async (calls: { to: `0x${string}`; value?: bigint; data?: `0x${string}` }[]) =>
+  (await enc()).batch(calls, { execType: "0x00" }, false) as `0x${string}`;
+const single = async (c: { to: `0x${string}`; value?: bigint; data?: `0x${string}` }) =>
+  (await enc()).single(c, { execType: "0x00" }, false) as `0x${string}`;
+
+describe("what the relay will carry", () => {
+  it("accepts the exact shape recover.ts builds — tokens then the ETH leg", async () => {
+    const cd = await batch([
+      { to: USDG, value: 0n, data: xfer(DEST, 318_000000n) },
+      { to: NVDA, value: 0n, data: xfer(DEST, 5n) },
+      { to: DEST, value: 4_000_000_000_000_000n, data: "0x" },
+    ]);
+    const v = isRecoveryShape(cd);
+    assert.equal(v.ok, true, v.ok ? "" : v.why);
+    if (!v.ok) return;
+    assert.equal(v.to.toLowerCase(), DEST.toLowerCase());
+    assert.equal(v.tokenLegs, 2);
+    assert.equal(v.nativeLeg, true);
+  });
+
+  it("accepts a SINGLE-call sweep — which is not a batch at all", async () => {
+    // encodeCallData switches on `calls.length > 1`, so sweeping one token takes
+    // the packed single-call path. A decoder that only understood batches would
+    // strand the simplest possible recovery.
+    const v = isRecoveryShape(await single({ to: USDG, value: 0n, data: xfer(DEST, 318_000000n) }));
+    assert.equal(v.ok, true, v.ok ? "" : v.why);
+    if (!v.ok) return;
+    assert.equal(v.to.toLowerCase(), DEST.toLowerCase());
+    assert.equal(v.tokenLegs, 1);
+    assert.equal(v.nativeLeg, false);
+  });
+
+  it("accepts an ETH-only sweep", async () => {
+    const v = isRecoveryShape(await single({ to: DEST, value: 10n ** 15n, data: "0x" }));
+    assert.equal(v.ok, true, v.ok ? "" : v.why);
+    if (!v.ok) return;
+    assert.equal(v.nativeLeg, true);
+    assert.equal(v.tokenLegs, 0);
+  });
+});
+
+describe("what it refuses — the reason this file exists", () => {
+  it("REFUSES an approve, which is how a relay becomes a drain", async () => {
+    const cd = await batch([
+      {
+        to: USDG,
+        value: 0n,
+        data: encodeFunctionData({ abi: erc20Abi, functionName: "approve", args: [ROUTER, 2n ** 255n] }),
+      },
+    ]);
+    const v = isRecoveryShape(cd);
+    assert.equal(v.ok, false);
+    if (v.ok) return;
+    assert.match(v.why, /only transfer/);
+  });
+
+  it("REFUSES an arbitrary contract call — a swap, or anything else", async () => {
+    const v = isRecoveryShape(await single({ to: ROUTER, value: 0n, data: "0x414bf389deadbeef" }));
+    assert.equal(v.ok, false, "arbitrary calldata must not be relayable");
+  });
+
+  it("REFUSES legs paying DIFFERENT destinations", async () => {
+    // This is what separates a withdrawal from a payment run. Without it, a
+    // caller could move money to anywhere as long as every leg was a transfer.
+    const cd = await batch([
+      { to: USDG, value: 0n, data: xfer(DEST, 1n) },
+      { to: NVDA, value: 0n, data: xfer(OTHER, 1n) },
+    ]);
+    const v = isRecoveryShape(cd);
+    assert.equal(v.ok, false);
+    if (v.ok) return;
+    assert.match(v.why, /one destination/);
+  });
+
+  it("REFUSES a native leg that disagrees with the token legs", async () => {
+    const cd = await batch([
+      { to: USDG, value: 0n, data: xfer(DEST, 1n) },
+      { to: OTHER, value: 10n ** 15n, data: "0x" },
+    ]);
+    assert.equal(isRecoveryShape(cd).ok, false);
+  });
+
+  it("REFUSES two native legs", async () => {
+    const cd = await batch([
+      { to: DEST, value: 1n, data: "0x" },
+      { to: DEST, value: 2n, data: "0x" },
+    ]);
+    const v = isRecoveryShape(cd);
+    assert.equal(v.ok, false);
+    if (v.ok) return;
+    assert.match(v.why, /more than one native/);
+  });
+
+  it("REFUSES a token call carrying native value", async () => {
+    const cd = await batch([{ to: USDG, value: 5n, data: xfer(DEST, 1n) }]);
+    assert.equal(isRecoveryShape(cd).ok, false);
+  });
+
+  it("REFUSES a delegatecall outright", async () => {
+    // execMode's first byte 0xFF. Built by hand because the SDK's delegate
+    // encoder takes a different argument shape, and the point is the mode byte.
+    const cd = encodeFunctionData({
+      abi: [
+        {
+          type: "function",
+          name: "execute",
+          inputs: [
+            { name: "execMode", type: "bytes32" },
+            { name: "executionCalldata", type: "bytes" },
+          ],
+          outputs: [],
+          stateMutability: "payable",
+        },
+      ] as const,
+      functionName: "execute",
+      args: [`0xff${"00".repeat(31)}`, "0xdeadbeef"],
+    });
+    const v = isRecoveryShape(cd);
+    assert.equal(v.ok, false);
+    if (v.ok) return;
+    assert.match(v.why, /delegatecall/);
+  });
+
+  it("REFUSES calldata that is not a Kernel execute at all", async () => {
+    assert.equal(isRecoveryShape("0xdeadbeef").ok, false);
+    assert.equal(isRecoveryShape("0x").ok, false);
+  });
+});

--- a/web/src/lib/recovery-shape.ts
+++ b/web/src/lib/recovery-shape.ts
@@ -142,7 +142,7 @@ export function isRecoveryShape(callData: Hex): ShapeVerdict {
 
   for (const leg of legs) {
     // The bare value transfer — at most one.
-    if (leg.data === "0x" || leg.data === "") {
+    if (leg.data === "0x") {
       if (nativeLeg) return { ok: false, why: "more than one native transfer in one operation" };
       if (leg.value === 0n) return { ok: false, why: "a value leg that moves nothing" };
       nativeLeg = true;

--- a/web/src/lib/recovery-shape.ts
+++ b/web/src/lib/recovery-shape.ts
@@ -1,0 +1,171 @@
+/**
+ * IS THIS CALLDATA A WITHDRAWAL, OR JUST SOMETHING THE HOUSE WOULD PAY TO RELAY?
+ *
+ * Validating the method, the entryPoint, the paymaster fields and the sender does
+ * not make a relay "a recovery submit path" — none of those look at what the
+ * operation DOES. Without this check, anyone holding a ticket can push arbitrary
+ * UserOperations for their own account through app.merrymen.dev: swaps,
+ * approvals, any contract call on the chain, as a free transaction-submission
+ * service running on the house's bundler account. Refusing that structurally is
+ * cheaper than defending it with quotas.
+ *
+ * THE SHAPE recover.ts BUILDS: N ERC-20 `transfer(to, amount)` calls with zero
+ * value, optionally followed by ONE bare value transfer with empty calldata, and
+ * every leg paying the SAME destination. That last part is what makes it a
+ * withdrawal rather than a payment — money leaves for one address the caller
+ * nominated and nothing else happens on the way.
+ *
+ * DECODED THE WAY KERNEL ENCODES IT, read out of the installed SDK rather than
+ * assumed. `execute(bytes32 execMode, bytes executionCalldata)`, where execMode's
+ * first byte is the call type:
+ *
+ *   0x00 SINGLE — executionCalldata is PACKED: to(20) ++ value(32) ++ data
+ *   0x01 BATCH  — executionCalldata is abi.encode((address,uint256,bytes)[])
+ *   0xFF DELEGATE — refused outright; a delegatecall is not a withdrawal
+ *
+ * The single form matters and is easy to miss: encodeCallData switches on
+ * `calls.length > 1`, so a recovery that sweeps ONE token is not a batch at all.
+ * A decoder that only understood batches would strand exactly the simplest case.
+ *
+ * FAIL CLOSED, BUT PINNED. A false reject here strands somebody's money, so the
+ * test feeds this the output of the SDK's OWN encoders — a Kernel encoding change
+ * then fails a test rather than quietly turning this into an escape hatch or a
+ * wall.
+ */
+
+import { decodeAbiParameters, decodeFunctionData, erc20Abi, type Hex } from "viem";
+
+/** Kernel v3 `execute(bytes32,bytes)`. */
+const EXECUTE_ABI = [
+  {
+    type: "function",
+    name: "execute",
+    inputs: [
+      { name: "execMode", type: "bytes32" },
+      { name: "executionCalldata", type: "bytes" },
+    ],
+    outputs: [],
+    stateMutability: "payable",
+  },
+] as const;
+
+/** `executeUserOp(PackedUserOperation,bytes32)` — the hook-enabled wrapper's selector. */
+const EXECUTE_USER_OP_SELECTOR = "0x8dd7712f";
+
+const BATCH_TUPLE = [
+  {
+    name: "executionBatch",
+    type: "tuple[]",
+    components: [
+      { name: "target", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "callData", type: "bytes" },
+    ],
+  },
+] as const;
+
+export type ShapeVerdict =
+  | { ok: true; to: `0x${string}`; tokenLegs: number; nativeLeg: boolean }
+  | { ok: false; why: string };
+
+interface Leg {
+  to: `0x${string}`;
+  value: bigint;
+  data: Hex;
+}
+
+function legsOf(callData: Hex): Leg[] | { why: string } {
+  // A hook-enabled account wraps the whole thing behind executeUserOp; the
+  // execute() call follows immediately after that selector.
+  let data = callData;
+  if (data.toLowerCase().startsWith(EXECUTE_USER_OP_SELECTOR)) {
+    data = (`0x${data.slice(EXECUTE_USER_OP_SELECTOR.length)}`) as Hex;
+  }
+
+  let mode: Hex;
+  let exec: Hex;
+  try {
+    const d = decodeFunctionData({ abi: EXECUTE_ABI, data });
+    [mode, exec] = d.args as unknown as [Hex, Hex];
+  } catch {
+    return { why: "this operation is not a Kernel execute() call, so it cannot be a withdrawal" };
+  }
+
+  const callType = mode.slice(0, 4).toLowerCase(); // "0x" + first byte
+  if (callType === "0xff") return { why: "a delegatecall is never a withdrawal" };
+
+  if (callType === "0x01") {
+    try {
+      const [batch] = decodeAbiParameters(BATCH_TUPLE, exec);
+      return (batch as readonly { target: `0x${string}`; value: bigint; callData: Hex }[]).map((c) => ({
+        to: c.target,
+        value: c.value,
+        data: c.callData,
+      }));
+    } catch {
+      return { why: "the batch could not be decoded" };
+    }
+  }
+
+  if (callType === "0x00") {
+    // PACKED, not abi-encoded: to(20 bytes) ++ value(32 bytes) ++ data.
+    const body = exec.slice(2);
+    if (body.length < 104) return { why: "the single call is too short to be well-formed" };
+    return [
+      {
+        to: `0x${body.slice(0, 40)}` as `0x${string}`,
+        value: BigInt(`0x${body.slice(40, 104)}`),
+        data: (`0x${body.slice(104)}` || "0x") as Hex,
+      },
+    ];
+  }
+
+  return { why: `unrecognised Kernel call type ${callType}` };
+}
+
+/** Is this the withdrawal shape, and where is the money going? */
+export function isRecoveryShape(callData: Hex): ShapeVerdict {
+  const legs = legsOf(callData);
+  if (!Array.isArray(legs)) return { ok: false, why: legs.why };
+  if (legs.length === 0) return { ok: false, why: "nothing is being withdrawn" };
+  if (legs.length > 64) return { ok: false, why: "too many legs for a withdrawal" };
+
+  let dest: `0x${string}` | null = null;
+  let tokenLegs = 0;
+  let nativeLeg = false;
+
+  const sameDest = (to: `0x${string}`): boolean => {
+    if (dest && dest.toLowerCase() !== to.toLowerCase()) return false;
+    dest = to;
+    return true;
+  };
+
+  for (const leg of legs) {
+    // The bare value transfer — at most one.
+    if (leg.data === "0x" || leg.data === "") {
+      if (nativeLeg) return { ok: false, why: "more than one native transfer in one operation" };
+      if (leg.value === 0n) return { ok: false, why: "a value leg that moves nothing" };
+      nativeLeg = true;
+      if (!sameDest(leg.to)) return { ok: false, why: "the legs do not all pay one destination" };
+      continue;
+    }
+
+    // Everything else must be an ERC-20 transfer carrying no value.
+    if (leg.value !== 0n) return { ok: false, why: "a token call carrying native value" };
+    let decoded;
+    try {
+      decoded = decodeFunctionData({ abi: erc20Abi, data: leg.data });
+    } catch {
+      return { ok: false, why: "a call this relay cannot decode as an ERC-20 transfer" };
+    }
+    if (decoded.functionName !== "transfer") {
+      return { ok: false, why: `only transfer() may be relayed, not ${String(decoded.functionName)}` };
+    }
+    const to = (decoded.args as readonly unknown[])[0] as `0x${string}`;
+    if (!sameDest(to)) return { ok: false, why: "the legs do not all pay one destination" };
+    tokenLegs++;
+  }
+
+  if (!dest) return { ok: false, why: "nothing is being withdrawn" };
+  return { ok: true, to: dest, tokenLegs, nativeLeg };
+}

--- a/web/src/lib/recovery-ticket.test.ts
+++ b/web/src/lib/recovery-ticket.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+import { mintTicket, readTicket, recoveryChallengeMessage, TICKET_TTL_MS } from "./recovery-ticket";
+
+/**
+ * The ticket is an anti-abuse token, not a fund-safety control — but it still
+ * has to be a real token. A forgeable or immortal one turns the relay into an
+ * open bundler proxy on the house's account.
+ */
+
+const ACCOUNT = "0x032da6a0ccf866474e45854e7fdef9afd1509036" as const;
+
+before(() => {
+  process.env.MERRYMEN_SESSION_SECRET = "x".repeat(48);
+});
+
+describe("recovery tickets", () => {
+  it("round-trips the account and chain it was minted for", () => {
+    const t = readTicket(mintTicket({ smartAccount: ACCOUNT, chainId: 4663 }));
+    assert.ok(t);
+    assert.equal(t!.smartAccount, ACCOUNT);
+    assert.equal(t!.chainId, 4663);
+  });
+
+  it("EXPIRES — a leaked ticket must not be useful tomorrow", () => {
+    const now = Date.now();
+    const t = mintTicket({ smartAccount: ACCOUNT, chainId: 4663 }, now);
+    assert.ok(readTicket(t, now + TICKET_TTL_MS - 1_000), "still valid inside the window");
+    assert.equal(readTicket(t, now + TICKET_TTL_MS + 1_000), null, "and dead after it");
+  });
+
+  it("refuses a tampered account — the signature covers the payload", () => {
+    // The whole point: the relay trusts ticket.smartAccount, so editing it must
+    // invalidate the token rather than redirect the permission.
+    const t = mintTicket({ smartAccount: ACCOUNT, chainId: 4663 });
+    const parts = t.split(".");
+    parts[0] = "0x1111111111111111111111111111111111111111";
+    assert.equal(readTicket(parts.join(".")), null);
+  });
+
+  it("refuses a tampered chain id", () => {
+    const t = mintTicket({ smartAccount: ACCOUNT, chainId: 46630 });
+    const parts = t.split(".");
+    parts[1] = "4663";
+    assert.equal(readTicket(parts.join(".")), null);
+  });
+
+  it("refuses an extended expiry", () => {
+    const t = mintTicket({ smartAccount: ACCOUNT, chainId: 4663 });
+    const parts = t.split(".");
+    parts[2] = String(Date.now() + 10 * 365 * 24 * 3600 * 1000);
+    assert.equal(readTicket(parts.join(".")), null);
+  });
+
+  it("refuses junk", () => {
+    for (const junk of ["", "a.b.c", "a.b.c.d.e", "not-a-ticket", null, undefined]) {
+      assert.equal(readTicket(junk as string | null | undefined), null, String(junk));
+    }
+  });
+});
+
+describe("the challenge text", () => {
+  it("binds BOTH origin and nonce into what gets signed", () => {
+    // A fixed message would make the signature a permanent bearer credential:
+    // anyone who ever saw it — a log line, a support paste, a screenshot — could
+    // mint tickets for that account forever, and could replay it at another site.
+    const m = recoveryChallengeMessage("https://app.merrymen.dev", "NONCE123");
+    assert.match(m, /https:\/\/app\.merrymen\.dev/);
+    assert.match(m, /NONCE123/);
+    assert.notEqual(
+      m,
+      recoveryChallengeMessage("https://evil.example", "NONCE123"),
+      "the same signature must not be valid at another origin",
+    );
+    assert.notEqual(
+      m,
+      recoveryChallengeMessage("https://app.merrymen.dev", "OTHER"),
+      "and must not be reusable with a fresh nonce",
+    );
+  });
+
+  it("tells the signer, in words, that it moves no funds", () => {
+    // Somebody is being asked to sign with the key that controls all their
+    // money. They deserve a sentence rather than a hex blob.
+    const m = recoveryChallengeMessage("https://app.merrymen.dev", "N");
+    assert.match(m, /moves no funds/i);
+  });
+});

--- a/web/src/lib/recovery-ticket.ts
+++ b/web/src/lib/recovery-ticket.ts
@@ -1,0 +1,105 @@
+/**
+ * A RECOVERY TICKET — an anti-abuse token, and nothing more.
+ *
+ * WHAT IT IS NOT: a fund-safety control. What protects an owner's money is the
+ * EntryPoint's signature check over the userOpHash, which binds sender, nonce,
+ * callData, gas fields, chain and entryPoint. A ticket cannot authorise a
+ * transfer, cannot alter one, and cannot be used to move anything. It exists so
+ * that a stranger cannot point the house's paid bundler account at arbitrary
+ * traffic. Stating that plainly here because a token that sits in front of a
+ * money path invites the assumption that it is guarding the money.
+ *
+ * WHY NOT JUST USE THE TENANT SESSION. Because the recoveries that matter most
+ * are exactly the ones with no session. The hosted grants table is one row per
+ * tenant and the kill switch DELETES it, so after a kill the server no longer
+ * knows the account — and "I killed my agent and now I want my money" is the
+ * single most likely reason someone reaches for recovery. Binding to a session
+ * would refuse precisely those cases. So the ticket is minted from a signature
+ * instead, which works signed out, after a kill, and for superseded wallets.
+ *
+ * WHAT THE SIGNATURE PROVES, HONESTLY: that the caller holds SOME private key
+ * whose derived Kernel address is the one named. It does not prove the account
+ * has ever existed here. That is a real limit — a stranger can generate keys in
+ * a loop and mint tickets for accounts nobody has ever funded — and it is why
+ * the relay tiers its quota on whether this deployment has actually SEEN the
+ * account rather than trusting the ticket alone.
+ *
+ * THE SIGNED TEXT BINDS ORIGIN AND NONCE, reusing the same shape sign-in uses.
+ * A fixed message would make the signature a permanent bearer credential: anyone
+ * who ever saw it — a log line, a support paste, a screenshot — could mint
+ * tickets for that account forever.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/** Long enough to plan, read, confirm and submit; short enough to be worthless if leaked. */
+export const TICKET_TTL_MS = 15 * 60 * 1000;
+
+function secretOrThrow(): string {
+  const s = process.env.MERRYMEN_SESSION_SECRET;
+  if (!s || s.length < 32) {
+    throw new Error("MERRYMEN_SESSION_SECRET is not set (hosted mode requires a 32+ char secret)");
+  }
+  return s;
+}
+
+const hmac = (payload: string, secret: string) =>
+  createHmac("sha256", secret).update(payload).digest("base64url");
+
+/**
+ * The message the OWNER KEY signs, in the browser, to prove control.
+ *
+ * Deliberately says what it does and does not do, because a user is being asked
+ * to sign something with the key that controls all their money and deserves to
+ * read a sentence rather than a hex blob.
+ */
+export function recoveryChallengeMessage(origin: string, nonce: string): string {
+  return [
+    `${origin} — withdraw from your merrymen account.`,
+    "",
+    "This proves you control the owner key so the site will relay your withdrawal.",
+    "It moves no funds by itself and grants no permissions: the withdrawal itself",
+    "is a separate operation you sign next.",
+    "",
+    `URI: ${origin}`,
+    `Nonce: ${nonce}`,
+  ].join("\n");
+}
+
+export interface Ticket {
+  smartAccount: `0x${string}`;
+  chainId: number;
+  exp: number;
+}
+
+/** Stateless: the ticket IS its own proof, so no server-side store to keep or leak. */
+export function mintTicket(t: Omit<Ticket, "exp">, now = Date.now()): string {
+  const exp = now + TICKET_TTL_MS;
+  const body = `${t.smartAccount.toLowerCase()}.${t.chainId}.${exp}`;
+  return `${body}.${hmac(body, secretOrThrow())}`;
+}
+
+/** Verify and parse, or null. Constant-time on the signature compare. */
+export function readTicket(token: string | undefined | null, now = Date.now()): Ticket | null {
+  if (!token) return null;
+  const parts = token.split(".");
+  if (parts.length !== 4) return null;
+  const [account, chain, exp, sig] = parts as [string, string, string, string];
+  const body = `${account}.${chain}.${exp}`;
+  let want: Buffer;
+  let got: Buffer;
+  try {
+    want = Buffer.from(hmac(body, secretOrThrow()));
+    got = Buffer.from(sig);
+  } catch {
+    return null;
+  }
+  if (want.length !== got.length || !timingSafeEqual(want, got)) return null;
+
+  const expMs = Number(exp);
+  const chainId = Number(chain);
+  if (!Number.isFinite(expMs) || expMs <= now) return null;
+  if (!Number.isFinite(chainId)) return null;
+  if (!/^0x[0-9a-f]{40}$/.test(account)) return null;
+  return { smartAccount: account as `0x${string}`, chainId, exp: expMs };
+}


### PR DESCRIPTION
A user with **318 USDG** opened recovery on app.merrymen.dev, pressed the button, and got a red line: *"recovery is client-side in hosted mode"*.

He did nothing wrong. That refusal is correct — the server holds no owner key, so it cannot sweep — and its comment said recovery *"runs entirely in the browser ... which the client already knows how to do."* **No such client existed.** The refusal described something that was never built.

Worse: the panel **fetched that explanation and threw it away**. `Ctx` had no `detail` field, so both halves were parsed and dropped, and it fell through to a paste-a-key form whose button POSTs to a route that 403s before it parses the body. An empty form and one red line, on top of somebody's money.

## The browser side is not a new engine

`planRecovery`/`recoverFunds` are the same functions the CLI runs — viem, `@zerodev/*`, `packages/core`, no node builtins — and the `@merrymen/recover` alias already existed. The phone app has run this module unmodified for months.

Two things differ in a browser:

- **Reads need nothing.** The chain RPC answers browsers directly (`access-control-allow-origin: *`, probed against 4663), so `rpcUrl` stays undefined.
- **Submission needs the relay** from part 1, because the Pimlico key is a house secret and the bundler and paymaster URLs are the same string.

## Two design corrections worth noting

**The ticket rides as an httpOnly, path-scoped cookie.** My first version threaded it through a header by monkey-patching `globalThis.fetch`, because `recoverFunds` builds its own viem transport. Patching global fetch around a money path is a race waiting to happen; a cookie the browser attaches itself is simpler and unreadable to page scripts.

**The token list comes from the grant, not `/api/settings`.** Hosted, that route returns `{}` to a caller with no session — and working signed-out and after a kill is the entire point of this path. An empty list silently falls back to the builtin floor and leaves every owner-added token behind, which is the exact failure `sweepList` was written to prevent.

## The gas truth is told first

Recovery uses **no paymaster**, so an account with zero ETH cannot be swept by any design here — and most of this fleet reads `eth 0`. The plan step now says so **before** the sweep button, naming the account and what to send, instead of letting the user discover it as a bundler rejection.

`expectedSmartAccount` is always passed: the server route cannot check it for a pasted key, but the browser knows which account the wallet belongs to, so a wrong key fails loudly rather than sweeping a stranger's empty account. Errors are redacted for the owner key, any 32-byte value, and any `apikey=` — viem embeds the full request URL in `metaMessages`.

---

Tests 1571/1571, web build clean. **Not yet exercised against a live bundler** — that is the one thing left, and it needs a real withdrawal.