### PR TITLE
Stop telling hosted owners to add a key they cannot add

### DIFF
--- a/web/src/components/RecoverPanel.tsx
+++ b/web/src/components/RecoverPanel.tsx
@@ -226,7 +226,15 @@ export function RecoverPanel({ initialOwnerKey = "" }: { initialOwnerKey?: strin
   const smartAccount = plan?.smartAccount ?? ctx?.smartAccount;
   const explorer = plan?.explorer ?? ctx?.explorer;
   const activeChain = plan?.chainId ?? ctx?.chainId ?? chainId;
-  const hasBundler = ctx?.hasBundler ?? false;
+  // CAN THIS WITHDRAWAL BE SUBMITTED AT ALL?
+  //
+  // Hosted, the answer is always yes: the relay holds the house bundler key, and
+  // that is the entire reason it exists. `ctx.hasBundler` describes the SERVER’s
+  // own key, which hosted is deliberately absent — so reading it alone told a
+  // hosted owner to add a Pimlico key in settings, a field the hosted settings
+  // route silently strips, and then disabled the button so they could not proceed
+  // even if they ignored the advice. A dead end dressed as an instruction.
+  const canSubmit = clientSide || (ctx?.hasBundler ?? false);
   // Do we know what's in the account yet? (stored-key ctx, or a checked paste.)
   const known = !!(plan || (ctx?.hasStoredKey && ctx));
   // "Empty" is a CLAIM, and it may only be made when everything was actually
@@ -393,7 +401,7 @@ export function RecoverPanel({ initialOwnerKey = "" }: { initialOwnerKey?: strin
                     ))}
                   </div>
 
-                  {!hasBundler && (
+                  {!canSubmit && (
                     <p className="recover-warn">
                       Recovery sends an on-chain transaction, so it needs your bundler key. Add a free
                       Pimlico key in <a href="/settings">settings</a>, then come back.
@@ -411,7 +419,7 @@ export function RecoverPanel({ initialOwnerKey = "" }: { initialOwnerKey?: strin
                   <button
                     className="recover-btn go"
                     onClick={() => void (clientSide ? sweepInBrowser() : sweep())}
-                    disabled={busy !== null || !hasBundler || !isAddr(to)}
+                    disabled={busy !== null || !canSubmit || !isAddr(to)}
                   >
                     {busy === "sweeping" ? "signing & sending (up to a minute)…" : "recover funds →"}
                   </button>


### PR DESCRIPTION
> "It says I have to add a pinlico key in settings."
> "Got a step further but that's now the error."

He is **one button** from his 318 USDG, and the button is disabled.

## What happened

The panel gated both the warning and the sweep button on `ctx.hasBundler` — which describes the **server's** own bundler key. Hosted, that key is deliberately absent: the server signs nothing and needs no bundler. So the flag reads false, and the panel told him to add a free Pimlico key in settings.

That field is in `HOUSE_KEY_FIELDS`, so the hosted settings route **strips it silently**. He would have pasted a key, been told it saved, and nothing would have changed — and the button would have stayed disabled regardless.

A dead end dressed as an instruction, and the second one on this path today.

## The fix

Hosted, the answer to "can this be submitted" is always yes: the relay holds the house bundler key, and that is the entire reason it exists. One predicate now:

```ts
const canSubmit = clientSide || (ctx?.hasBundler ?? false);
```

## This was predicted

The scoping pass flagged this exact warning as *"unreachable today only because no hosted plan ever succeeds"* — and the relay is what made plans succeed. Worth recording that the review named it before a user did.

---

Tests 1571/1571, typecheck clean, web build clean.