### PR TITLE
The relay refused a good withdrawal, and hid why

### DIFF
--- a/web/src/app/api/bundler/[chainId]/route.ts
+++ b/web/src/app/api/bundler/[chainId]/route.ts
@@ -72,19 +72,74 @@ const OP_METHODS = new Set(["eth_estimateUserOperationGas", "eth_sendUserOperati
 const KNOWN_CHAINS = new Set<number>([robinhoodChain.id, robinhoodTestnet.id]);
 const MAX_BODY = 32 * 1024;
 
-/** Any hint of a paymaster is a refusal — see gate 4. */
-const PAYMASTER_FIELDS = [
-  "paymaster",
-  "paymasterData",
-  "paymasterAndData",
-  "paymasterVerificationGasLimit",
-  "paymasterPostOpGasLimit",
-] as const;
+/**
+ * IS THERE ACTUALLY A PAYMASTER, or just a field set to zero?
+ *
+ * The first version refused any of these fields that was not undefined, null,
+ * "0x" or "" — which is wrong, because a client with NO paymaster still emits
+ * the gas-limit fields as `0x0`. A zero gas limit is not sponsorship; it is the
+ * absence of it, spelled out. That refusal turned a perfectly good withdrawal
+ * into a 403 and cost a user their first attempt.
+ *
+ * So each field is judged by what it actually means:
+ *   paymaster            — an ADDRESS. Absent, or the zero address, means none.
+ *   paymasterData        — BYTES. Empty means none.
+ *   paymasterAndData     — the packed 0.6-era form. Empty means none.
+ *   *GasLimit            — NUMBERS. Zero means none.
+ *
+ * The gate itself is unchanged in intent: any real paymaster is refused, so
+ * house sponsorship stays impossible on this path by construction.
+ */
+function paymasterOn(op: Record<string, unknown>): string | null {
+  const empty = (v: unknown) =>
+    v === undefined || v === null || v === "" || v === "0x";
+  const zeroNum = (v: unknown) => {
+    if (empty(v)) return true;
+    try {
+      return BigInt(v as string | number | bigint) === 0n;
+    } catch {
+      return false; // unparseable is not provably zero — treat as present
+    }
+  };
+  const addr = op.paymaster;
+  if (!empty(addr) && !/^0x0{40}$/i.test(String(addr))) return "paymaster";
+  for (const f of ["paymasterData", "paymasterAndData"] as const) {
+    if (!empty(op[f])) return f;
+  }
+  for (const f of ["paymasterVerificationGasLimit", "paymasterPostOpGasLimit"] as const) {
+    if (!zeroNum(op[f])) return f;
+  }
+  return null;
+}
 
 function scrub(s: string): string {
   return s.replace(/apikey=[^&\s"']+/gi, "apikey=<redacted>").replace(/api\.pimlico\.io\S*/gi, "<bundler>");
 }
 
+/**
+ * REFUSE IN THE PROTOCOL THE CALLER IS SPEAKING.
+ *
+ * This returned HTTP 4xx with a JSON body, and viem collapsed every one of
+ * them to `HTTP request failed` — so a user watching their own withdrawal fail
+ * saw a transport error and no reason, and the server logged nothing at all. I
+ * was blind to my own gate.
+ *
+ * A JSON-RPC endpoint should answer with a JSON-RPC error: viem then surfaces
+ * `message` the same way it surfaces a bundler's own rejection, which is
+ * exactly what this is. HTTP status stays 200 because the HTTP request
+ * succeeded — it is the CALL that was refused.
+ *
+ * Codes are in the JSON-RPC application range (-32000 block), which is what a
+ * bundler uses for its own refusals.
+ */
+function refuse(id: unknown, message: string, code = -32_001) {
+  // Logged so the next failure is diagnosable from the server rather than from
+  // a screenshot of a phone.
+  console.warn(`[relay] refused: ${message}`);
+  return NextResponse.json({ jsonrpc: "2.0", id: id ?? 1, error: { code, message } });
+}
+
+/** For the few failures that really are transport-level. */
 const bad = (status: number, message: string) => NextResponse.json({ error: message }, { status });
 
 export async function POST(req: Request, ctx: { params: Promise<{ chainId: string }> }) {
@@ -113,35 +168,35 @@ export async function POST(req: Request, ctx: { params: Promise<{ chainId: strin
   if (Array.isArray(rpc)) return bad(400, "batched requests are not relayed");
 
   const method = typeof rpc.method === "string" ? rpc.method : "";
-  if (!ALLOWED.has(method)) return bad(403, `this relay does not forward ${method || "that method"}`);
+  if (!ALLOWED.has(method)) {
+    return refuse(rpc.id, `this relay does not forward ${method || "that method"}`);
+  }
 
   const params = Array.isArray(rpc.params) ? rpc.params : [];
 
   if (OP_METHODS.has(method)) {
     const op = params[0] as Record<string, unknown> | undefined;
-    if (!op || typeof op !== "object") return bad(400, "missing user operation");
+    if (!op || typeof op !== "object") return refuse(rpc.id, "missing user operation");
 
     const sender = typeof op.sender === "string" ? op.sender.toLowerCase() : "";
     if (sender !== ticket.smartAccount.toLowerCase()) {
-      return bad(403, "this ticket does not cover that account");
+      return refuse(rpc.id, "this ticket does not cover that account");
     }
 
     const entryPoint = typeof params[1] === "string" ? params[1].toLowerCase() : "";
     if (entryPoint !== ENTRYPOINT.v07.toLowerCase()) {
-      return bad(400, "only EntryPoint v0.7 is relayed");
+      return refuse(rpc.id, `only EntryPoint v0.7 is relayed, not ${entryPoint || "(none given)"}`);
     }
 
-    for (const f of PAYMASTER_FIELDS) {
-      const v = op[f];
-      if (v !== undefined && v !== null && v !== "0x" && v !== "") {
-        return bad(403, "sponsored operations are not relayed on this path");
-      }
+    const sponsored = paymasterOn(op);
+    if (sponsored) {
+      return refuse(rpc.id, `sponsored operations are not relayed on this path (${sponsored})`);
     }
 
     const callData = typeof op.callData === "string" ? (op.callData as `0x${string}`) : "0x";
     const shape = isRecoveryShape(callData);
     if (!shape.ok) {
-      return bad(403, `this relay only carries withdrawals — ${shape.why}`);
+      return refuse(rpc.id, `this relay only carries withdrawals — ${shape.why}`);
     }
   }
 
@@ -163,6 +218,11 @@ export async function POST(req: Request, ctx: { params: Promise<{ chainId: strin
   }
 
   const text = await upstream.text();
+  if (!upstream.ok || text.includes('"error"')) {
+    console.warn(`[relay] ${method} -> ${upstream.status} ${scrub(text).slice(0, 300)}`);
+  } else {
+    console.log(`[relay] ${method} -> ok`);
+  }
   // Pass the JSON-RPC envelope through so viem can read a result or an error
   // normally — but scrubbed, because an upstream error can quote the URL.
   return new NextResponse(scrub(text), {

--- a/web/src/lib/recover-client.ts
+++ b/web/src/lib/recover-client.ts
@@ -61,10 +61,14 @@ export const relayUrl = (chainId: number) =>
 export function redact(e: unknown, ownerKey?: string): string {
   let msg = e instanceof Error ? e.message : String(e);
   if (ownerKey) msg = msg.split(ownerKey).join("<owner key>");
+  // NOT a blanket 64-hex replacement. That rule replaced the callData in the
+  // one error a user actually sent us — eating the function selector and
+  // leaving an unreadable smear of zeros — because calldata, hashes, and
+  // signatures are all long hex and none of them are secret. The only 32-byte
+  // secret in scope is the owner key, and it is replaced by VALUE above.
   return msg
     .replace(/apikey=[^&\s"']+/gi, "apikey=<redacted>")
-    .replace(/0x[0-9a-fA-F]{64}/g, "<32-byte value>")
-    .slice(0, 400);
+    .slice(0, 600);
 }
 
 /**

--- a/worker/src/gas.ts
+++ b/worker/src/gas.ts
@@ -54,7 +54,15 @@ export async function chainFees(publicClient: PublicClient): Promise<UserOpFees>
  * chain's public client so it never depends on the bundler exposing a proprietary method.
  */
 export function userOpGasConfig(publicClient: PublicClient, bundlerUrl: string) {
-  const isPimlico = /pimlico\.io/i.test(bundlerUrl);
+  // Pimlico DIRECTLY, or through our own recovery relay — which forwards this
+  // exact method and nothing else that could substitute for it.
+  //
+  // Matching only the vendor hostname meant a relayed withdrawal silently
+  // skipped the oracle and priced itself from the chain, which Pimlico is then
+  // free to reject as underpriced. The whole reason this function exists is that
+  // a bundler accepts the fees IT quoted; routing through a proxy does not
+  // change whose bundler it is.
+  const isPimlico = /pimlico\.io/i.test(bundlerUrl) || /\/api\/bundler\//.test(bundlerUrl);
   return {
     estimateFeesPerGas: async ({ bundlerClient }: { bundlerClient: Client }): Promise<UserOpFees> => {
       if (isPimlico) {


### PR DESCRIPTION
He got all the way there — the browser read **318 USDG** off the chain, the button worked, the sweep was built and signed. Then:

> An error occurred while executing user operation: HTTP request failed.
> Request Arguments: callData: `<32-byte value>0000000000…`

**Three bugs in that one screenshot, all mine.**

## 1. The paymaster gate refused an op that has no paymaster

It rejected any of the five paymaster fields that was not `undefined`/`null`/`""`/`"0x"`. But a client with **no** paymaster still emits the gas-limit fields as `0x0`. A zero gas limit is not sponsorship — it is the absence of it, spelled out.

Each field is now judged by what it means: `paymaster` is an address (zero = none), the data fields are bytes (empty = none), the limits are numbers (zero = none). The gate's intent is unchanged — a real paymaster is still refused, so house sponsorship stays impossible on this path.

## 2. The refusal was invisible

The relay answered HTTP 4xx, and viem collapsed every one into `HTTP request failed` — so the user saw a transport error with no reason, and the server logged **nothing**. I was blind to my own gate.

A JSON-RPC endpoint should refuse in JSON-RPC: the HTTP request succeeded, it was the *call* that was refused. viem now surfaces the reason the same way it surfaces a bundler's own rejection, and every refusal is logged server-side.

## 3. My redactor ate the diagnostic

`redact` replaced every 64-hex run with `<32-byte value>`, which in that error swallowed the function selector and left an unreadable smear of zeros. Calldata, hashes and signatures are all long hex and none are secret; the only 32-byte secret in scope is the owner key, and it is already replaced **by value**.

## And one that would have bitten the next attempt

`userOpGasConfig` decides whether to use Pimlico's fee oracle by matching `pimlico.io` in the URL. The relay URL is `app.merrymen.dev/api/bundler/…`, so a relayed withdrawal silently skipped the oracle and priced itself from the chain — which Pimlico is free to reject as underpriced. The relay forwards that exact method; routing through a proxy does not change whose bundler it is.

---

Tests 1571/1571, typecheck clean, web build clean.