### PR TITLE
A disabled button that explains itself, and accepts a pasted address

### DIFF
--- a/web/src/components/RecoverPanel.tsx
+++ b/web/src/components/RecoverPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { listSavedWallets } from "@/lib/session";
+import { isAddr, normalizeAddr } from "@/lib/address";
 import { planFromBrowser, sweepFromBrowser, redact, type BrowserWallet } from "@/lib/recover-client";
 
 /**
@@ -59,7 +60,7 @@ interface SweepRes {
 }
 
 const short = (a: string) => `${a.slice(0, 6)}…${a.slice(-4)}`;
-const isAddr = (v: string) => /^0x[0-9a-fA-F]{40}$/.test(v.trim());
+
 const isKey = (v: string) => /^0x[0-9a-fA-F]{64}$/.test(v.trim());
 const MAINNET = 4663;
 const TESTNET = 46630;
@@ -180,14 +181,14 @@ export function RecoverPanel({ initialOwnerKey = "" }: { initialOwnerKey?: strin
     const list = balances.map((b) => `${b.amount} ${b.symbol}`).join(", ") || "the balance";
     if (
       !window.confirm(
-        `Sweep ${list} to ${to.trim()}?\n\nThis is real and irreversible. The account keeps a little ETH to pay for gas.`,
+        `Sweep ${list} to ${normalizeAddr(to)}?\n\nThis is real and irreversible. The account keeps a little ETH to pay for gas.`,
       )
     ) {
       return;
     }
     setBusy("sweeping");
     try {
-      const r = await sweepFromBrowser(w, to.trim() as `0x${string}`);
+      const r = await sweepFromBrowser(w, normalizeAddr(to) as `0x${string}`);
       setResult(r as unknown as SweepRes);
     } catch (e) {
       setError(redact(e, w.ownerKey));
@@ -251,12 +252,12 @@ export function RecoverPanel({ initialOwnerKey = "" }: { initialOwnerKey?: strin
       return;
     }
     const list = balances.map((b) => `${b.amount} ${b.symbol}`).join(", ") || "the balance";
-    if (!window.confirm(`Sweep ${list} to ${to.trim()}?\n\nThis is real and irreversible. The account keeps a little ETH to pay for gas.`)) {
+    if (!window.confirm(`Sweep ${list} to ${normalizeAddr(to)}?\n\nThis is real and irreversible. The account keeps a little ETH to pay for gas.`)) {
       return;
     }
     setBusy("sweeping");
     try {
-      const body: Record<string, unknown> = { mode: "sweep", to: to.trim() };
+      const body: Record<string, unknown> = { mode: "sweep", to: normalizeAddr(to) };
       if (plan) {
         body.ownerKey = ownerKey.trim();
         body.chainId = chainId;
@@ -416,6 +417,17 @@ export function RecoverPanel({ initialOwnerKey = "" }: { initialOwnerKey?: strin
                     onChange={(e) => setTo(e.target.value)}
                     autoComplete="off"
                   />
+                  {/* A DISABLED BUTTON THAT EXPLAINS ITSELF.
+                      Silence here cost a user his whole attempt: he had done
+                      everything right and the only feedback was a button that
+                      would not press. */}
+                  {to.trim().length > 0 && !isAddr(to) && (
+                    <p className="recover-warn">
+                      That doesn&rsquo;t look like an address yet — it should be 40 characters of
+                      hex, with or without the <code>0x</code>. Paste the receiving address from
+                      your wallet or exchange.
+                    </p>
+                  )}
                   <button
                     className="recover-btn go"
                     onClick={() => void (clientSide ? sweepInBrowser() : sweep())}

--- a/web/src/lib/address.ts
+++ b/web/src/lib/address.ts
@@ -1,0 +1,35 @@
+/**
+ * WHAT A PERSON ACTUALLY PASTES, turned into an address.
+ *
+ * A user with 1010 USDG followed every step correctly, pasted his exchange
+ * address into the withdrawal form, and found the button disabled with nothing
+ * said. His address was bare 40-hex with no `0x` — which plenty of wallets and
+ * explorers copy that way. A 40-character hex string is unambiguously an address
+ * missing its prefix; there is nothing else it could be, so refusing it is
+ * pedantry with somebody's money on the other side.
+ *
+ * THE RULE IS NARROW ON PURPOSE: normalise only what cannot be anything else,
+ * and leave everything else invalid so the person is TOLD rather than guessed
+ * at. A normaliser that got clever here would send funds somewhere nobody typed,
+ * and that is not a mistake anyone can undo.
+ *
+ * Its own module, not a helper inside the panel, because it is a pure string
+ * rule that decides where money goes — so it should be testable without a
+ * browser, and it is used by more than one call site.
+ */
+
+/** Trim, drop an `ethereum:` URI wrapper, and supply a missing `0x`. */
+export function normalizeAddr(v: string): string {
+  const t = v
+    .trim()
+    .replace(/^ethereum:/i, "")
+    .split("?")[0]!
+    .trim();
+  if (/^[0-9a-fA-F]{40}$/.test(t)) return `0x${t}`;
+  return t;
+}
+
+/** Is this something we can pay, once normalised? */
+export function isAddr(v: string): boolean {
+  return /^0x[0-9a-fA-F]{40}$/.test(normalizeAddr(v));
+}

--- a/web/src/lib/normalize-addr.test.ts
+++ b/web/src/lib/normalize-addr.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+
+/**
+ * WHERE THE MONEY GOES, so this is worth pinning precisely.
+ *
+ * A user with 1010 USDG followed every step correctly, pasted his exchange
+ * address, and found the sweep button disabled with nothing said. The address
+ * was bare 40-hex with no `0x` — which plenty of wallets and explorers copy that
+ * way, and which is unambiguously an address missing its prefix.
+ *
+ * The rule this file guards is narrow on purpose: normalise ONLY what cannot be
+ * anything else, and leave everything else invalid so the user is told rather
+ * than guessed at. A normaliser that got clever here would send funds somewhere
+ * nobody typed.
+ *
+ * The rule lives in its own module rather than inside the panel precisely so it
+ * can be tested without a browser — the component is "use client", the rule is
+ * pure. The last assertion still reads the component source, because what it
+ * checks is a property OF the panel: that the confirm dialog shows the same
+ * address the operation will pay.
+ */
+
+import { isAddr, normalizeAddr } from "./address";
+
+const SRC = readFileSync(new URL("../components/RecoverPanel.tsx", import.meta.url), "utf8");
+const REAL = "0x7060B218E0B11F37450A8835664fa748dB1FcC1E";
+const BARE = "7060B218E0B11F37450A8835664fa748dB1FcC1E";
+
+describe("what a person may paste", () => {
+  it("accepts a normal address unchanged", () => {
+    assert.equal(normalizeAddr(REAL), REAL);
+    assert.equal(isAddr(REAL), true);
+  });
+
+  it("ACCEPTS bare 40-hex — the case that blocked a real withdrawal", () => {
+    assert.equal(normalizeAddr(BARE), `0x${BARE}`);
+    assert.equal(isAddr(BARE), true);
+  });
+
+  it("survives the whitespace a phone paste adds", () => {
+    for (const v of [` ${REAL}`, `${REAL} `, `\n${REAL}\n`, ` ${BARE} `]) {
+      assert.equal(isAddr(v), true, JSON.stringify(v));
+      assert.match(normalizeAddr(v), /^0x[0-9a-fA-F]{40}$/);
+    }
+  });
+
+  it("handles an ethereum: URI from a QR scan", () => {
+    assert.equal(normalizeAddr(`ethereum:${REAL}`), REAL);
+    assert.equal(normalizeAddr(`ethereum:${REAL}?value=0`), REAL);
+    assert.equal(isAddr(`ethereum:${REAL}`), true);
+  });
+});
+
+describe("what it must NOT quietly accept", () => {
+  it("refuses anything that is not exactly an address", () => {
+    // Each of these could only be normalised by GUESSING, and a guess here sends
+    // somebody's balance to an address they never typed.
+    for (const v of [
+      "",
+      "0x",
+      REAL.slice(0, -1), // one char short
+      `${REAL}0`, // one char long
+      BARE.slice(0, -1),
+      "0xZZZZ218E0B11F37450A8835664fa748dB1FcC1E",
+      "my okx wallet",
+      "0x7060B218E0B11F37450A8835664fa748dB1FcC1E extra",
+    ]) {
+      assert.equal(isAddr(v), false, `must refuse: ${JSON.stringify(v)}`);
+    }
+  });
+
+  it("does not invent a prefix for a short hex string", () => {
+    // 39 hex is not an address with a missing prefix; it is a typo.
+    assert.equal(isAddr("7060B218E0B11F37450A8835664fa748dB1FcC1"), false);
+  });
+});
+
+describe("the confirm dialog shows the address that will be paid", () => {
+  it("uses the normalised value, not the raw input", () => {
+    // Otherwise the prompt says one thing and the operation does another — which
+    // on an irreversible transfer is the worst possible place for a mismatch.
+    assert.doesNotMatch(
+      SRC,
+      /Sweep \$\{list\} to \$\{to\.trim\(\)\}/,
+      "the confirm text must show the normalised destination",
+    );
+    assert.match(SRC, /Sweep \$\{list\} to \$\{normalizeAddr\(to\)\}/);
+  });
+});


### PR DESCRIPTION
**Red Shoe's withdrawal worked** — the first real one through the relay, and very likely the first successful UserOperation this system has ever landed.

Then a second user, 1010 USDG, followed the steps exactly and wrote them out to check:

> 1- click on the "recover my funds" button.
> 2- plug in the recovery key into owner key space.
> 3- click "check what's in it"
> 4- then plug in my OKX wallet address into "send to" field.
> 5- then click "recover funds" button.
>
> At step #5 the recover funds button is disabled.

**He did everything right.** His address was bare 40-hex with no `0x` — which plenty of wallets and exchanges copy that way — so `isAddr` refused it, and the button was disabled with **nothing said**.

That is the same failure as the relay's silent 4xx earlier today: a refusal with no reason, on top of somebody's money.

## Two fixes, and the second matters more

**Accept what people actually paste.** A 40-character hex string is unambiguously an address missing its prefix — there is nothing else it could be — so supply the `0x`. Also strips whitespace and an `ethereum:` URI wrapper from a QR scan.

Deliberately narrow: anything that cannot be normalised **without guessing** stays invalid, because a clever normaliser here sends funds somewhere nobody typed, and that cannot be undone.

**Say why the button is dead.** A disabled control with no explanation is indistinguishable from a broken site — this user only got unstuck by writing out his steps and asking.

## Where the rule lives

It moved into its own module: a pure string function that decides where money goes should be testable without a browser. 7 tests. One asserts a property of the **panel** rather than the rule — that the confirm dialog shows the *normalised* destination — because a prompt that names one address while the operation pays another is the worst possible mismatch on an irreversible transfer.

---

Tests 1578/1578, typecheck clean, web build clean.