### PR TITLE
A busy chain is not a broken wall

### DIFF
--- a/web/src/app/app/Console.tsx
+++ b/web/src/app/app/Console.tsx
@@ -331,6 +331,11 @@ function Loaded({ feed, status }: { feed: FeedResponse | null; status: AgentStat
           </nav>
           <div className="rail-foot">
             <nav className="nav util">
+              {/* The public feed. It lives on its own page and nothing here
+                  linked to it, so the only way to find it was to know the URL. */}
+              <Link className="navlink" href="/theses">
+                <Ic d="wallet" /> The feed
+              </Link>
               <Link className="navlink" href="/grant">
                 <Ic d="wallet" /> Wallet
               </Link>

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2189,13 +2189,32 @@ async function main() {
       );
     }
 
+    // A FAILED READ IS NOT A MISSING CONTRACT.
+    //
+    // This used to be `.catch(() => undefined)` and then treated undefined as
+    // absent — so an RPC that answered 429 produced an `err` event stating, as
+    // fact, that the wall's singletons have no code. That event becomes
+    // `lastError`, and the dashboard's status line ranks lastError above
+    // everything, so one rate-limited read told an owner their agent HAD STOPPED
+    // AND COULD NOT START AGAIN — permanently, until some newer error replaced
+    // it. All three contracts were deployed the whole time.
+    //
+    // The two cases are now told apart, because they have different remedies:
+    // a genuinely absent singleton means this grant can never trade, and an
+    // unreadable one means try again.
     const missingPolicyContracts: string[] = [];
+    const uncheckedPolicyContracts: string[] = [];
     for (const c of WALL_POLICY_CONTRACTS) {
-      const code = await client.getCode({ address: c.address }).catch(() => undefined);
-      // getCode returns `undefined` — not "0x" — for an address with no
-      // contract; viem normalises "0x" away. Both mean absent here, and a
-      // failed READ is indistinguishable from either, so this deliberately
-      // does not try to tell them apart: it says what it could not confirm.
+      let code: string | undefined;
+      try {
+        // viem normalises an empty result to `undefined`, so a SUCCESSFUL read
+        // of an address with no contract lands here as undefined — which is the
+        // real signal. A throw is a different fact entirely.
+        code = await client.getCode({ address: c.address });
+      } catch {
+        uncheckedPolicyContracts.push(c.name);
+        continue;
+      }
       if (code === undefined || code === "0x") missingPolicyContracts.push(`${c.name} (${c.address})`);
     }
     if (missingPolicyContracts.length > 0) {
@@ -2206,6 +2225,18 @@ async function main() {
         `the wall depends on contracts that have no code on chain ${chain.id}: ${missingPolicyContracts.join(", ")}. ` +
           `Every UserOp this grant signs will be validated against them, so live trading cannot work until this is resolved. ` +
           `Paper and every read-only surface are unaffected.`,
+      );
+    }
+    if (uncheckedPolicyContracts.length > 0) {
+      // A WARNING, not an error, and it says what it is: we could not look.
+      // Claiming the wall is broken because the chain was busy is the more
+      // expensive mistake — it stops an agent that was fine.
+      console.log(`[worker] could not check wall policy contracts: ${uncheckedPolicyContracts.join(", ")}`);
+      await addEvent(
+        agentId,
+        "warn",
+        `couldn't check the wall's contracts this time (${uncheckedPolicyContracts.join(", ")}) — the chain did not answer. ` +
+          `This says nothing about whether they are there; it retries on the next arm.`,
       );
     }
 


### PR DESCRIPTION
Your agent was halted by a **false claim**.

The wall's policy-contract probe did `.catch(() => undefined)` and then treated `undefined` as absent, so an RPC answering 429 emitted an `err` event stating as fact that the wall's singletons have no code on 4663 and that *"live trading cannot work until this is resolved"*.

That event becomes `lastError`, and the status line ranks `lastError` above everything — so one rate-limited read told an owner their agent **had stopped and could not start again**, permanently, until some newer error replaced it.

**All three contracts were deployed the whole time.** Verified on-chain against two independent endpoints:

| contract | code |
|---|---|
| TimestampPolicy | 1441 bytes |
| CallPolicy V0_0_4 | 6539 bytes |
| ECDSA signer | 1609 bytes |

The two cases are now told apart, because they have different remedies. A *successful* read returning nothing means the singleton is genuinely absent and the grant can never trade — still an error. A *thrown* read means the chain did not answer — a warning that says so and retries on the next arm.

Same rule this codebase applies everywhere else: a failed read is not a zero.

Also links the console to the feed, which lived on its own page with nothing pointing at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)