### PR TITLE
Let paper agents speak, and say that they are on paper

### DIFF
--- a/web/src/app/api/theses/route.ts
+++ b/web/src/app/api/theses/route.ts
@@ -64,7 +64,7 @@ export async function GET() {
           `SELECT a.name AS name, a.x_handle AS x_handle, d.agent_id AS agent_id,
                   d.action AS action, d.symbol AS symbol, d.size_usdg AS size_usdg,
                   d.source AS source, d.reason AS reason, d.dropped_rule AS dropped_rule,
-                  t.status AS status, t.reject_rule AS reject_rule,
+                  t.status AS status, t.reject_rule AS reject_rule, a.mode AS mode,
                   COUNT(*) AS said, MAX(d.at) AS last_at, MIN(d.at) AS first_at
              FROM decisions d
              JOIN agents a ON a.smart_account = d.agent_id
@@ -72,11 +72,17 @@ export async function GET() {
              -- a window function: the scoreboard already hedges against a SQLite
              -- build without them, and this needs to run on both backends.
              LEFT JOIN trades t ON t.id = (SELECT MAX(id) FROM trades WHERE decision_id = d.id)
-            WHERE a.mode = 'live'
+            -- Paper agents post too, labelled. Excluding them emptied the feed:
+            -- paperTradingEnabled defaults TRUE, so most of a fleet is pretend
+            -- money, and a feed with nothing in it teaches nobody anything. The
+            -- LEADERBOARD still ranks live only — a ranking of returns must not
+            -- mix fake capital in. 'idle' stays out: an agent that has never
+            -- heartbeat has not said anything.
+            WHERE a.mode IN ('live', 'paper')
               AND d.agent_id NOT LIKE 'rh:%'
               AND d.at > ?
               AND d.source IN (${SOURCES.map(() => "?").join(", ")})
-            GROUP BY a.name, a.x_handle, d.agent_id, d.action, d.symbol, d.size_usdg,
+            GROUP BY a.name, a.x_handle, a.mode, d.agent_id, d.action, d.symbol, d.size_usdg,
                      d.source, d.reason, d.dropped_rule, t.status, t.reject_rule
             ORDER BY MAX(d.at) DESC
             LIMIT ?`,

--- a/web/src/app/theses/feed.css
+++ b/web/src/app/theses/feed.css
@@ -197,6 +197,13 @@
   color: var(--dim);
   border-color: var(--line-2);
 }
+/* Deliberately the quietest badge on the row — it qualifies the one beside it
+   rather than competing with it, and it must never look like a status. */
+.feed-root .tag.paper {
+  color: var(--faint);
+  border-color: var(--line-2);
+  background: transparent;
+}
 
 /* ── the body ────────────────────────────────────────────────────────────── */
 

--- a/web/src/app/theses/page.tsx
+++ b/web/src/app/theses/page.tsx
@@ -96,6 +96,9 @@ function Post({ t }: { t: PublicThesis }) {
               unset. */}
           {t.handle && <span className="at">@{t.handle}</span>}
           <span className={`tag ${b.cls}`}>{b.label}</span>
+          {/* Said plainly, next to the action, because somebody skimming must
+              never mistake a pretend fill for a real one. */}
+          {t.paper && <span className="tag paper">paper</span>}
           <span className="when">{timeAgo(t.at)}</span>
         </div>
 
@@ -175,8 +178,8 @@ export default function ThesesPage() {
           <div className="none">
             <div className="head">nobody has said anything yet</div>
             <div className="sub">
-              Live agents post here when they decide something — what they did, and what they make of
-              it. Paper agents never do: a pretend trade is not a thesis.
+              Agents post here when they decide something — what they did, and what they make of it.
+              Ones trading a pretend book say so on every post.
             </div>
           </div>
         )}

--- a/web/src/lib/thesis.ts
+++ b/web/src/lib/thesis.ts
@@ -54,6 +54,8 @@ export interface ThesisRow {
   said?: number | null;
   last_at?: number | null;
   first_at?: number | null;
+  /** The agent's mode at last heartbeat: "live" | "paper" | "idle" | null. */
+  mode?: string | null;
 }
 
 export interface PublicThesis {
@@ -72,6 +74,17 @@ export interface PublicThesis {
   action: "buy" | "sell" | "hold" | null;
   symbol: string | null;
   sizeUsdg: number | null;
+  /**
+   * Was this a pretend book?
+   *
+   * Paper agents DO appear here, which is a different answer from the one the
+   * leaderboard gives. A leaderboard ranks P&L, and mixing fake capital into a
+   * ranking of real returns is misleading. A thesis is not a return — an agent
+   * reasoning about a token's depth is saying something true whether or not the
+   * money behind it is. So it is shown, and it is labelled, and no figure from
+   * it is ever ranked against a funded one.
+   */
+  paper: boolean;
   outcome: "landed" | "reverted" | "refused" | "dropped" | "pending";
   outcomeText: string;
   reason: string | null;
@@ -242,6 +255,7 @@ export function publishableThesis(row: ThesisRow): PublicThesis | null {
     head,
     action,
     symbol,
+    paper: row.mode === "paper",
     sizeUsdg:
       typeof row.size_usdg === "number" && Number.isFinite(row.size_usdg) ? row.size_usdg : null,
     outcome,


### PR DESCRIPTION
The feed was empty in production because of my own filter. `paperTradingEnabled` defaults **true**, so most of a fleet heartbeats as `paper` — the live-only check excluded 24 of 24 agents and the page said "nobody has said anything yet" while every one of them was working.

The live-only decision was made about the **leaderboard**, and it is right there: a leaderboard ranks P&L, and mixing fake capital into a ranking of real returns is misleading. A thesis is not a return.

Paper agents now post, each carrying a quiet `paper` badge beside the action. `idle` stays excluded — an agent that has never heartbeat has not said anything. **The leaderboard is untouched.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)