### PR TITLE
Refuse to rank an agent that has never filled a trade

### DIFF
--- a/web/src/app/leaderboard/page.tsx
+++ b/web/src/app/leaderboard/page.tsx
@@ -57,9 +57,11 @@ export default async function LeaderboardPage() {
               <section className="mm-unranked">
                 <h2 className="mm-kicker">Unranked</h2>
                 <p>
-                  No deposit on record, so there is no capital to measure a return against. That is
-                  unknown, not zero — publishing equity minus nothing as performance would be the
-                  bankroll dressed up as a result.
+                  Two different reasons an agent has no rank, and they are not the same problem.
+                  Without a deposit on record there is no capital to measure a return against.
+                  Without a filled trade there is no return to measure — an agent&rsquo;s equity
+                  while it is only simulating is its pretend book, and dividing that by a real
+                  deposit publishes a number that never happened.
                 </p>
                 <ol className="mm-board">
                   {unranked.map((a) => (
@@ -86,7 +88,13 @@ function Row({ a, rank }: { a: LeaderRow; rank: number | null }) {
         {a.handle && <span className="at mono">@{a.handle}</span>}
       </span>
       <Sparkline points={a.curve} tone={tone} />
-      <span className={`pnl mono ${tone}`}>{a.pnlBps === null ? "unranked" : pct(a.pnlBps)}</span>
+      <span className={`pnl mono ${tone}`}>
+        {a.pnlBps === null
+          ? a.unrankedWhy === "never-filled"
+            ? "never filled"
+            : "no deposit"
+          : pct(a.pnlBps)}
+      </span>
       <span className="dd mono">
         {a.maxDdBps === null ? "—" : `${(a.maxDdBps / 100).toFixed(1)}% dd`}
       </span>

--- a/web/src/lib/rank-pnl.test.ts
+++ b/web/src/lib/rank-pnl.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { rankPnl } from "./rank-pnl";
+
+/**
+ * A PUBLIC RANKING MAY NOT PUBLISH A NUMBER IT CANNOT BACK.
+ *
+ * This shipped and was caught in production within the hour. The board showed
+ * an agent at **+2643.3%**, top of the table, and every figure behind it was
+ * real — the arithmetic was simply measuring the wrong two things against each
+ * other:
+ *
+ *   equity curve : a flat 1000.0000 across all 39 points
+ *   contributed  : about 36 USDG
+ *   landed       : 0        refused: 1,225
+ *
+ * 1000.0000, flat, is the PAPER BOOK'S OPENING BALANCE. `agents.mode` is only
+ * the last heartbeat's value and `equity` carries no per-row mode, so an agent
+ * that wrote those rows while simulating and is labelled live now hands the
+ * ranking a pretend balance to divide by a real deposit.
+ *
+ * The fix is not a smarter formula, it is a refusal: an agent that has never
+ * filled a trade has not produced a return, and the board already has a word
+ * for that.
+ */
+
+describe("what may be ranked", () => {
+  it("ranks an agent that actually traded", () => {
+    const r = rankPnl({ contributed: 500, latest: 612.4, gasUsdg: 0.04, landed: 3 });
+    assert.equal(r.unrankedWhy, null);
+    // (612.4 − 500 − 0.04) / 500 = 22.47%
+    assert.equal(r.pnlBps, 2247);
+  });
+
+  it("a loss is published as readily as a gain", () => {
+    const r = rankPnl({ contributed: 250, latest: 231.8, gasUsdg: 0.04, landed: 2 });
+    assert.equal(r.pnlBps, -730);
+  });
+
+  it("THE +2643% ROW: pretend equity over a real deposit is NOT a return", () => {
+    // The exact production figures.
+    const r = rankPnl({ contributed: 36.45, latest: 1000, gasUsdg: 0, landed: 0 });
+    assert.equal(r.pnlBps, null, "an agent with no fills has no return to publish");
+    assert.equal(r.unrankedWhy, "never-filled");
+  });
+
+  it("no deposit and no fill are DIFFERENT answers", () => {
+    // Only one of them is fixed by depositing, so the page must not say the
+    // wrong one — it would send an owner to do work that will not help.
+    assert.equal(rankPnl({ contributed: null, latest: 100, gasUsdg: 0, landed: 9 }).unrankedWhy, "no-deposit");
+    assert.equal(rankPnl({ contributed: 0, latest: 100, gasUsdg: 0, landed: 9 }).unrankedWhy, "no-deposit");
+    assert.equal(rankPnl({ contributed: 100, latest: 120, gasUsdg: 0, landed: 0 }).unrankedWhy, "never-filled");
+  });
+
+  it("an equity reading is required, not assumed", () => {
+    // A funded agent that has filled but whose equity history is missing has an
+    // unknown return, not a zero one.
+    const r = rankPnl({ contributed: 100, latest: null, gasUsdg: 0, landed: 4 });
+    assert.equal(r.pnlBps, null);
+  });
+
+  it("never returns a number and a reason at the same time", () => {
+    // They are the two arms of one answer; both set would mean the page could
+    // render a rank and an excuse for not having one.
+    for (const a of [
+      { contributed: 500, latest: 600, gasUsdg: 0, landed: 1 },
+      { contributed: null, latest: 600, gasUsdg: 0, landed: 1 },
+      { contributed: 500, latest: 600, gasUsdg: 0, landed: 0 },
+      { contributed: 500, latest: null, gasUsdg: 0, landed: 1 },
+    ]) {
+      const r = rankPnl(a);
+      assert.equal(
+        (r.pnlBps === null) !== (r.unrankedWhy === null),
+        true,
+        `exactly one of pnlBps / unrankedWhy must be set for ${JSON.stringify(a)}`,
+      );
+    }
+  });
+
+  it("gas is charged against the return, not ignored", () => {
+    const withGas = rankPnl({ contributed: 100, latest: 110, gasUsdg: 5, landed: 1 }).pnlBps;
+    const without = rankPnl({ contributed: 100, latest: 110, gasUsdg: 0, landed: 1 }).pnlBps;
+    assert.equal(without, 1000);
+    assert.equal(withGas, 500, "net of gas, or the board overstates every agent");
+  });
+});

--- a/web/src/lib/rank-pnl.ts
+++ b/web/src/lib/rank-pnl.ts
@@ -1,0 +1,67 @@
+/**
+ * MAY THIS AGENT'S RETURN BE PUBLISHED, AND IF NOT, WHY NOT.
+ *
+ * Its own module, with NO IMPORTS, for the same reason the publication gate is:
+ * it is the rule the public leaderboard exists to get right, and a rule buried
+ * in the middle of a database read is a rule nobody can test. Keeping it
+ * dependency-free is what lets a test call it directly instead of standing up a
+ * ledger.
+ *
+ * Three things must all hold:
+ *
+ *   - capital on record, or there is no denominator;
+ *   - an equity reading, or there is no numerator;
+ *   - AT LEAST ONE LANDED TRADE.
+ *
+ * That third one is not obvious and it is the one that matters. `agents.mode`
+ * is only the LAST HEARTBEAT's value, and the `equity` table carries no
+ * per-row mode — so an agent that wrote its equity rows while simulating and is
+ * labelled live now hands this a PRETEND balance to divide by a REAL deposit.
+ *
+ * Production published +2643.3% exactly that way, at the top of the board: a
+ * flat 1000.0000 equity curve — the paper book's opening balance — over about
+ * 36 USDG of contributions, from an agent with zero landed trades and 1,225
+ * refusals. Every figure was real; the arithmetic was measuring the wrong two
+ * things against each other.
+ *
+ * The fix is a refusal rather than a smarter formula. An agent that has never
+ * filled a trade has not produced a return, and the board already has a word
+ * for that.
+ */
+
+export type UnrankedWhy = "no-deposit" | "never-filled";
+
+export interface RankInputs {
+  /** Capital in, less capital out. Null when nothing is on record. */
+  contributed: number | null;
+  /** The newest equity reading. Null when there is no history. */
+  latest: number | null;
+  /** Gas charged against the return, in USDG. */
+  gasUsdg: number;
+  /** Trades that actually filled. Zero means there is no return to measure. */
+  landed: number;
+}
+
+export interface Rank {
+  pnlBps: number | null;
+  unrankedWhy: UnrankedWhy | null;
+}
+
+/**
+ * Exactly one of `pnlBps` and `unrankedWhy` is ever set — they are the two arms
+ * of one answer, and both being set would let a page render a rank alongside an
+ * excuse for not having one.
+ */
+export function rankPnl(a: RankInputs): Rank {
+  // Checked before the fill count, because "no deposit" is the more fundamental
+  // fact: an agent with neither should be told to fund, not to wait.
+  if (a.contributed === null || a.contributed <= 0) {
+    return { pnlBps: null, unrankedWhy: "no-deposit" };
+  }
+  if (a.landed <= 0) return { pnlBps: null, unrankedWhy: "never-filled" };
+  if (a.latest === null) return { pnlBps: null, unrankedWhy: "never-filled" };
+  return {
+    pnlBps: Math.round(((a.latest - a.contributed - a.gasUsdg) / a.contributed) * 10_000),
+    unrankedWhy: null,
+  };
+}

--- a/web/src/lib/read-leaderboard.ts
+++ b/web/src/lib/read-leaderboard.ts
@@ -29,10 +29,19 @@
  */
 import { withReadDb } from "@/lib/ledger";
 import { getIdentityStore } from "@merrymen/identity-store";
+import { rankPnl, type UnrankedWhy } from "@/lib/rank-pnl";
 
 export interface LeaderRow {
   /** The public id. Null means no identity yet, and the row renders unlinked. */
   slug: string | null;
+  /**
+   * Why this agent has no rank, when it has none.
+   *
+   * The page must not guess: "no deposit on record" and "has never filled a
+   * trade" are different facts about an agent, and only one of them is fixed by
+   * depositing.
+   */
+  unrankedWhy: UnrankedWhy | null;
   name: string;
   handle: string | null;
   /** Return over capital contributed, in basis points. Null = unknown. */
@@ -52,6 +61,7 @@ export interface LeaderboardRead {
 
 /** Points in the sparkline. Enough to show a shape, few enough to inline. */
 const CURVE_POINTS = 40;
+
 
 export async function readLeaderboard(): Promise<LeaderboardRead> {
   return withReadDb(async (db): Promise<LeaderboardRead> => {
@@ -146,17 +156,13 @@ export async function readLeaderboard(): Promise<LeaderboardRead> {
           /* older ledger */
         }
 
-        // A return needs both a numerator and a denominator we can back. Either
-        // missing means unknown, and unknown is published as unknown.
-        const pnlBps =
-          contributed !== null && contributed > 0 && latest !== null
-            ? Math.round(((latest - contributed - gasUsdg) / contributed) * 10_000)
-            : null;
+        const { pnlBps, unrankedWhy } = rankPnl({ contributed, latest, gasUsdg, landed });
 
         const maxDdBps = drawdownBps(curve);
 
         return {
           slug: slugFor.get(account.toLowerCase()) ?? null,
+          unrankedWhy,
           name: String(r.name ?? "Agent"),
           handle: (r.x_handle ?? "").trim() || null,
           pnlBps,


### PR DESCRIPTION
Caught on the live board within an hour of the redesign deploying.

## What production showed

An agent at the **top of the public leaderboard at +2643.3%**. Every figure behind it was real; the arithmetic was measuring the wrong two things against each other:

| | |
|---|---|
| equity curve | a flat `1000.0000` across all 39 points |
| contributed | ~36 USDG |
| landed / refused | **0** / 1,225 |

`1000.0000`, flat, is the **paper book's opening balance**. `agents.mode` is only the *last heartbeat's* value and the `equity` table carries no per-row mode — so an agent that wrote those rows while simulating and is labelled live now hands the ranking a pretend balance to divide by a real deposit. `WHERE mode = 'live'` cannot stop that, because the mode it filters on is not the mode the rows were written under.

A second agent (`Chaz`) showed a flat `10.0000` at −50.0% for the same reason.

## The fix

A refusal, not a smarter formula: **an agent that has never filled a trade has not produced a return.** The board already has a word for that. It is the rule the rest of this codebase applies everywhere else — don't publish a figure you cannot back.

"No deposit on record" and "has never filled" are now **different answers**, and the page says which. Only one of them is fixed by depositing, so collapsing them would send an owner to do work that will not help.

## Why `rankPnl` moved

Into its own module with zero imports, for the same reason the publication gate has one: the rule the board exists to get right was buried in the middle of a database read, where nothing could test it.

The test pins the exact production figures, that gas is charged against the return, and that `pnlBps` and `unrankedWhy` are never both set — they are two arms of one answer, and both being set would let a page render a rank beside an excuse for not having one.

## Verification

`npm test` 1718/1718 · `npm run typecheck` clean.