### PR TITLE
Rewind the mirror cursor when the ledger under it was rebuilt

### DIFF
--- a/web/src/app/api/grants/route.ts
+++ b/web/src/app/api/grants/route.ts
@@ -207,8 +207,13 @@ export async function POST(req: Request) {
     //
     // BEST EFFORT ON PURPOSE. The grant is already durably stored and the money
     // path is done; failing the request now would tell the owner their agent was
-    // not created when it was. Without an identity the agent simply has no
-    // public page until a later read backfills it.
+    // not created when it was.
+    //
+    // The backfill for an agent that misses this is in the ORCHESTRATOR, in
+    // writeGrantForChild — not "a later read", which is what this comment used
+    // to claim and which was never built. It could not be a read: the public
+    // routes are cached and unauthenticated, and an anonymous GET that mints
+    // identities is a write nobody asked for.
     try {
       await getIdentityStore().ensure(tenant, grant.smartAccount as `0x${string}`);
     } catch (e) {

--- a/worker/src/ledger-mirror.test.ts
+++ b/worker/src/ledger-mirror.test.ts
@@ -129,7 +129,10 @@ describe("the ledger mirror", () => {
     const shared = mem(DEST);
     await mirrorTenant({ tenant: "0xten", child, shared });
     const second = await mirrorTenant({ tenant: "0xten", child, shared });
-    assert.equal(second.copied.events, undefined, "nothing new to copy");
+    // Zero, not absent. An absent count is indistinguishable from a table
+    // nobody looked at, which is exactly how a stalled cursor hid in
+    // production for as long as it did.
+    assert.equal(second.copied.events, 0, "nothing new to copy, and it says so");
     assert.equal(await count(shared, "events"), 5, "events must not double");
     assert.equal(await count(shared, "trades"), 5, "trades must not double");
   });
@@ -189,7 +192,12 @@ describe("the ledger mirror", () => {
     raw.exec("INSERT INTO events (agent_id, level, message, created_at) VALUES ('0xa','ok','only',1)");
     const r = await mirrorTenant({ tenant: "0xten", child: wrapSqlite(raw), shared: mem(DEST) });
     assert.equal(r.copied.events, 1);
+    // A table that does not EXIST is a failure, not an empty one — the SELECT
+    // throws — so it has no count and is named in `failed` instead. That
+    // distinction is the point: "could not read" and "nothing to read" must
+    // never render the same, here or anywhere else in this codebase.
     assert.equal(r.copied.trades, undefined);
+    assert.ok(r.failed?.trades, "an unreadable table is reported as failed");
   });
 
   it("CARRIES THE FLOW TERM — without it a deposit reads as a gain", async () => {
@@ -418,6 +426,58 @@ describe("the ledger mirror", () => {
     await mirrorTenant({ tenant: "0xten", child, shared });
     const got = (await shared.prepare("SELECT COUNT(*) AS n FROM decisions WHERE at = 5000").get()) as { n: number };
     assert.equal(Number(got.n), 2, "both rows from that second survived");
+  });
+
+  it("RECOVERS WHEN THE CHILD LEDGER IS REBUILT BENEATH THE WATERMARK", async () => {
+    // The bug this pins cost the entire fleet its trade tape, indefinitely, and
+    // reported success the whole time.
+    //
+    // mirror_state lives in shared Postgres; `last_id` is an id in the CHILD's
+    // sqlite. Those two do not have the same lifetime — a child home sits on the
+    // orchestrator container's own filesystem with no volume behind it, so a
+    // redeploy destroys the ledger and AUTOINCREMENT restarts at 1 under a
+    // watermark that still reads five. `id > from` then matches nothing for
+    // ever, and the empty path recorded neither a count nor a failure.
+    //
+    // Nothing in this suite could have caught it: all the other cases reuse one
+    // seedChild(), so the source is never reborn.
+    const shared = mem(DEST);
+    await mirrorTenant({ tenant: "0xten", child: seedChild(), shared });
+    assert.equal(await count(shared, "trades"), 5, "the first incarnation arrived");
+
+    // The redeploy: a brand-new ledger, ids restarting at 1.
+    const rebornRaw = new DatabaseSync(":memory:");
+    rebornRaw.exec(SRC);
+    for (let i = 1; i <= 2; i++) {
+      rebornRaw.exec(
+        `INSERT INTO trades (agent_id, kind, target, amount_usdg, status, epoch, created_at)
+         VALUES ('0xagent','swap','0xt',${i},'paper',1,${900 + i})`,
+      );
+    }
+    const reborn = wrapSqlite(rebornRaw);
+
+    const r = await mirrorTenant({ tenant: "0xten", child: reborn, shared });
+    assert.equal(r.copied.trades, 2, "rows written after the rebuild must arrive");
+    assert.equal(r.restarted?.trades?.was, 5, "and the rewind is reported, not silent");
+    assert.equal(await count(shared, "trades"), 7);
+
+    // And still exactly-once against the NEW ledger.
+    const again = await mirrorTenant({ tenant: "0xten", child: reborn, shared });
+    assert.equal(again.copied.trades, 0, "no second delivery");
+    assert.equal(await count(shared, "trades"), 7);
+  });
+
+  it("does NOT rewind while the ledger is merely idle", async () => {
+    // The rewind must be impossible to trigger within one incarnation: this
+    // file's exactly-once property rests solely on the watermark, so a spurious
+    // rewind duplicates the tape — and a trade shown twice is worse than one
+    // shown late.
+    const child = seedChild();
+    const shared = mem(DEST);
+    await mirrorTenant({ tenant: "0xten", child, shared });
+    const second = await mirrorTenant({ tenant: "0xten", child, shared });
+    assert.equal(second.restarted, undefined, "an idle pass is not a rebuild");
+    assert.equal(await count(shared, "trades"), 5, "and nothing was copied twice");
   });
 
   it("carries the positions leg of the equity identity", async () => {

--- a/worker/src/ledger-mirror.ts
+++ b/worker/src/ledger-mirror.ts
@@ -150,8 +150,25 @@ export const MIRROR_STATE_DDL = `
 
 export interface MirrorReport {
   tenant: string;
-  /** Rows copied per table this pass. Absent tables were empty or unreadable. */
+  /**
+   * Rows copied per table this pass.
+   *
+   * An append-only table records its ZERO rather than being absent — leaving it
+   * out is what made a stalled cursor look exactly like a quiet table. A
+   * snapshot table is absent only when the tenant has no agent row at all.
+   */
   copied: Record<string, number>;
+  /**
+   * Tables whose cursor was rewound because the child ledger was rebuilt
+   * beneath it — `was` is the watermark that turned out to point at a row
+   * that no longer exists.
+   *
+   * Loud on purpose. A rewind is the mirror recovering from something that
+   * silently cost it every append-only row since the last redeploy, and an
+   * operator should see that it happened rather than infer it from a tape that
+   * quietly starts working again.
+   */
+  restarted?: Record<string, { was: number }>;
   /**
    * Why a table copied nothing, when the reason was an error rather than an
    * empty source.
@@ -203,6 +220,7 @@ export async function mirrorTenant(args: {
   const nowSec = args.nowSec ?? Math.floor(Date.now() / 1000);
   const copied: Record<string, number> = {};
   const failed: Record<string, string> = {};
+  const restarted: Record<string, { was: number }> = {};
 
   // ── append-only tables ────────────────────────────────────────────────────
   for (const { table, cols } of LOG_TABLES) {
@@ -210,12 +228,56 @@ export async function mirrorTenant(args: {
       const mark = (await shared
         .prepare(`SELECT last_id FROM mirror_state WHERE tenant = ? AND table_name = ?`)
         .get(tenant, table)) as { last_id: number } | undefined;
-      const from = mark?.last_id ?? 0;
+      let from = Number(mark?.last_id ?? 0);
+
+      // ── THE CURSOR OUTLIVES THE LEDGER IT POINTS INTO ──────────────────────
+      //
+      // `last_id` is an id in the CHILD's sqlite, and it is stored HERE, in
+      // shared Postgres. Those two do not have the same lifetime. A child home
+      // lives on the orchestrator container's own filesystem and railway.json
+      // declares no volume for it, so a redeploy destroys every child ledger
+      // while mirror_state survives untouched. Every LOG_TABLE is INTEGER
+      // PRIMARY KEY AUTOINCREMENT, so the rebuilt file restarts at id 1 beneath
+      // a watermark that still reads four thousand — after which `id > from`
+      // matches nothing, FOREVER, and the `!rows.length` path below records
+      // neither a count nor a failure, so every pass reports success.
+      //
+      // That is not hypothetical: it is why the entire fleet's trade tape was
+      // empty in production while `positions` and `cost_basis` — snapshots, no
+      // id cursor — arrived normally, and why `decisions`, which is cursored on
+      // a TIMESTAMP with a lookback, kept flowing past the same stalled state.
+      //
+      // THE TEST IS "IS THE ROW WE LAST COPIED STILL THERE", not MAX(id).
+      // Within one incarnation the watermark IS an id we copied, and these
+      // tables are append-only — nothing in this repo deletes from them — so
+      // that row can only be missing because the id space restarted underneath
+      // us. It cannot false-positive, which matters more than completeness
+      // here: this file's exactly-once property rests solely on the watermark
+      // (the INSERT below has no ON CONFLICT), so a spurious rewind would
+      // duplicate the tape, and a trade shown twice is worse than one shown
+      // late. MAX(id) < from would miss the case where the reborn ledger has
+      // grown to exactly the old mark; asking for the row itself does not.
+      if (from > 0) {
+        const still = (await child
+          .prepare(`SELECT 1 AS ok FROM ${table} WHERE id = ?`)
+          .get(from)) as { ok: number } | undefined;
+        if (!still) {
+          restarted[table] = { was: from };
+          from = 0;
+        }
+      }
 
       const rows = (await child
         .prepare(`SELECT id, ${cols.join(", ")} FROM ${table} WHERE id > ? ORDER BY id ASC LIMIT ?`)
         .all(from, batch)) as Record<string, unknown>[];
-      if (!rows.length) continue;
+      if (!rows.length) {
+        // RECORD THE ZERO. Leaving it absent is what made a wedged cursor
+        // indistinguishable from a quiet table for as long as this bug lived:
+        // the orchestrator prints only the keys present, so `trades` simply
+        // vanished from the line rather than reading `trades 0`.
+        copied[table] = 0;
+        continue;
+      }
 
       const highest = Number(rows[rows.length - 1]!.id);
       // One transaction: the rows and the watermark that says they arrived.
@@ -489,5 +551,10 @@ export async function mirrorTenant(args: {
     failed.snapshots = e instanceof Error ? e.message : String(e);
   }
 
-  return { tenant, copied, ...(Object.keys(failed).length ? { failed } : {}) };
+  return {
+    tenant,
+    copied,
+    ...(Object.keys(restarted).length ? { restarted } : {}),
+    ...(Object.keys(failed).length ? { failed } : {}),
+  };
 }

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -42,6 +42,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { merrymenHome } from "./home";
 import { getGrantStore } from "./grant-store";
+import { getIdentityStore } from "./identity-store";
 import { getSettingsStore } from "./settings-store";
 import { acquireTenantLease, type TenantLease } from "./tenant-lease";
 import { isHostedMode, type MerrymenSettings } from "../../packages/core/src/index";
@@ -168,6 +169,30 @@ function heartbeatAt(tenant: string): number | null {
 async function writeGrantForChild(tenant: `0x${string}`): Promise<boolean> {
   const grant = await getGrantStore().get(tenant);
   if (!grant) return false;
+
+  // BACKFILL THE PUBLIC ID.
+  //
+  // POST /api/grants mints one on SIGNATURE, and nothing re-signs — so every
+  // agent granted before the identity store existed has no row, and its posts
+  // render unlinked for ever. ensure() is idempotent and never changes an
+  // existing slug, so this is a no-op after the first pass.
+  //
+  // HERE AND NOT ELSEWHERE. The grant is already in hand, so this costs no
+  // extra read of a store that decrypts. Every tenant passes through here on
+  // spawn, so one deploy covers the fleet. It cannot live in a CHILD:
+  // CHILD_SECRET_STRIP removes DATABASE_URL and getIdentityStore() picks its
+  // backend on exactly that variable, so a child would silently write a file
+  // the web tier never reads. And it must not live in the public read path —
+  // those routes are cached and unauthenticated, and an anonymous GET that
+  // mints identities is a write nobody asked for.
+  //
+  // Best effort: an identity hiccup must never stop a tenant being armed.
+  try {
+    await getIdentityStore().ensure(tenant, grant.smartAccount as `0x${string}`);
+  } catch (e) {
+    log(`${tenant}: could not mint a public id — ${e instanceof Error ? e.message : String(e)}`);
+  }
+
   const home = childHome(tenant);
   mkdirSync(home, { recursive: true });
   // grant.json holds the SESSION key (the store already refused any owner key),
@@ -497,6 +522,16 @@ async function mirrorLedgers(): Promise<void> {
       // stall is permanent and silent. So the failures print unconditionally,
       // for the same reason fleetHealth prints unconditionally: an operator who
       // learns to read silence as health cannot see a wedged mirror.
+      // A REWIND MEANS ROWS WERE LOST BEFORE IT. Printed separately from the
+      // counts because it is not routine: it says this tenant's child ledger
+      // was rebuilt under a watermark that outlived it, and everything the
+      // append-only tables held before that point is gone with the old file.
+      if (r.restarted) {
+        const what = Object.entries(r.restarted)
+          .map(([k, v]) => `${k} (was ${v.was})`)
+          .join(", ");
+        log(`ledger mirror: ${tenant} CURSOR REWOUND — the child ledger was rebuilt beneath it: ${what}`);
+      }
       if (r.failed) {
         const why = Object.entries(r.failed)
           .map(([k, v]) => `${k}: ${v}`)


### PR DESCRIPTION
The whole fleet's trade tape has been missing from the shared database for as long as anything has been filling, and **every pass reported success**.

## The cause

`mirror_state` lives in shared Postgres. `last_id` is an id in the **child's** sqlite. Those two do not have the same lifetime.

A child home sits on the orchestrator container's own filesystem and `railway.json` declares no volume, so a redeploy destroys every child ledger while the watermark survives untouched. Every `LOG_TABLE` is `INTEGER PRIMARY KEY AUTOINCREMENT`, so the rebuilt file restarts at id 1 beneath a watermark that still reads four thousand — after which `WHERE id > ?` matches nothing, **for ever**.

It was invisible because of the `!rows.length` path: it recorded neither a count nor a failure, so a permanently wedged cursor and a quiet table produced byte-identical output.

The evidence is the partition it left behind, across 443 production mirror lines:

| | |
|---|---|
| `events`, `trades`, `equity`, `flows`, `fee_accruals` | id-cursored — **never appeared, once** |
| `agents`, `positions`, `cost_basis` | snapshots, no cursor — copied fine |
| `decisions` | cursored on a **timestamp** with a lookback, so it outruns a stale mark — copied fine |

## Why the check is "is that row still there" and not `MAX(id)`

Within one incarnation the watermark **is** an id we copied, and these tables are append-only — nothing in this repo deletes from them — so that row can only be missing because the id space restarted underneath us. It cannot false-positive.

That matters more than completeness. Exactly-once here rests **solely** on the watermark (the INSERT has no `ON CONFLICT`), so a spurious rewind duplicates the tape, and this file's own doctrine is that a trade shown twice is worse than one shown late.

A `MAX(id) < from` clamp would also miss the case where the reborn ledger has grown back to exactly the old mark. Asking for the row itself does not.

## Observability

An idle append-only table now records its **zero** instead of vanishing from the line — that absence is the whole reason this hid for so long. A rewind is logged loudly, because it means every row that table held before the rebuild is gone with the old file.

## Tests

Nothing in the suite could have caught this: all 21 cases reused one `seedChild()`, so the source was never reborn. Two cases now cover it — recovery after a rebuild, and the one that matters in the other direction: **an idle pass must not rewind.**

## Also: the slug backfill

`ensure()` had exactly one call site, on the grant-*signing* path, which no already-granted agent traverses again — so all 24 live agents had no public id and every post rendered unlinked. It goes in the orchestrator's `writeGrantForChild`: the grant is already in hand, and every tenant passes through on spawn.

It **cannot** live in a child — `CHILD_SECRET_STRIP` removes `DATABASE_URL` and the identity store picks its backend on exactly that variable, so a child would silently write a file the web tier never reads. And it must not live in the public read path, which is cached and unauthenticated: an anonymous GET that mints identities is a write nobody asked for.

The comment in the grants route promising "a later read backfills it" described a mechanism that was never built. It now points at the one that is.

## Not doing

**Attaching a Railway volume.** `docs/hosted-worker-design.md` argues a volume-mounted service cannot deploy concurrently, so every redeploy becomes a fleet-wide trading outage. With the mirror at 15s, at most 15s of tape is at risk per redeploy — the cheaper trade.

## Expect after deploy

The **existing 40 posts will not backfill** — deploying replaces the container, which destroys the child ledgers holding those rows. New ledgers start at id 1, the rewind fires on the first pass (~15s), and everything from that point forward mirrors. Persisting "pending" posts are not the fix failing.

## Verification

`npm test` 1720/1720 · `npm run typecheck` clean · `npm run build` clean.