### PR TITLE
Count the day, draw a sample of it

### DIFF
--- a/web/src/app/a/[key]/page.tsx
+++ b/web/src/app/a/[key]/page.tsx
@@ -87,6 +87,7 @@ export default async function AgentPage({ params }: { params: Promise<{ key: str
               <b>turned back in the last day</b>
               <span>
                 against this agent&rsquo;s own signed caps. {tape.counts.through} got through.
+                {tape.capped && <> The band draws the most recent {tape.cells.length}.</>}
               </span>
             </span>
           </div>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -53,9 +53,15 @@ export default async function FeedPage() {
             <span className="mm-wall-said">
               <b>turned back in the last day</b>
               <span>
-                Every intent above flew at the permission wall each agent signed. {turned} stopped;{" "}
-                {tape.counts.through} got through. The caps are the owner&rsquo;s, and nothing can
-                be moved outside them.
+                {turned} stopped at the permission wall each agent signed; {tape.counts.through} got
+                through. The caps are the owner&rsquo;s, and nothing can be moved outside them.
+                {tape.capped && (
+                  <>
+                    {" "}
+                    The band above draws the most recent {tape.cells.length} of them — the count is
+                    the whole day.
+                  </>
+                )}
               </span>
             </span>
           </div>

--- a/web/src/lib/read-wall-tape.ts
+++ b/web/src/lib/read-wall-tape.ts
@@ -54,7 +54,17 @@ export interface WallTape {
   cells: WallCell[];
   /** Index-aligned labels. The last is always the catch-all. */
   lanes: string[];
+  /**
+   * The WHOLE window, counted — not the drawn sample.
+   *
+   * These are what the page prints, and `cells` is only what the canvas can
+   * hold. Deriving them from the capped rows published "400 turned back in the
+   * last day" on a day that had more than four hundred, which is a truncation
+   * wearing the clothes of a measurement.
+   */
   counts: { intents: number; turned: number; through: number; flight: number };
+  /** True when the day held more than the band can draw. */
+  capped: boolean;
   from: number;
   to: number;
   /** Stable identity for the render, so an effect does not restart on every poll. */
@@ -66,6 +76,7 @@ const EMPTY: WallTape = {
   cells: [],
   lanes: [],
   counts: { intents: 0, turned: 0, through: 0, flight: 0 },
+  capped: false,
   from: 0,
   to: 0,
   key: "0:0",
@@ -106,6 +117,32 @@ export async function readWallTape(opts: { agentSlug?: string } = {}): Promise<W
     }
     args.push(CAP);
 
+    // THE COUNT IS OF THE WINDOW, THE SAMPLE IS FOR THE CANVAS. One extra
+    // aggregate over the same predicate, served by trades_time.
+    let total = { turned: 0, through: 0, flight: 0 };
+    try {
+      const c = (await db
+        .prepare(
+          `SELECT
+             SUM(CASE WHEN t.status IN ('rejected','reverted') THEN 1 ELSE 0 END) AS turned,
+             SUM(CASE WHEN t.status IN ('landed','paper') THEN 1 ELSE 0 END) AS through,
+             SUM(CASE WHEN t.status = 'submitted' THEN 1 ELSE 0 END) AS flight
+           FROM trades t
+           JOIN agents a ON a.smart_account = t.agent_id
+          WHERE ${where.join(" AND ")}`,
+        )
+        .get(...args.slice(0, args.length - 1))) as
+        | { turned: number | null; through: number | null; flight: number | null }
+        | undefined;
+      total = {
+        turned: Number(c?.turned ?? 0),
+        through: Number(c?.through ?? 0),
+        flight: Number(c?.flight ?? 0),
+      };
+    } catch {
+      /* older ledger — the drawn sample stands in below */
+    }
+
     let rows: { at: number; status: string | null; rule: string | null }[] = [];
     try {
       rows = (await db
@@ -123,6 +160,7 @@ export async function readWallTape(opts: { agentSlug?: string } = {}): Promise<W
       // that; it is never a 500 and never a claim that nothing happened.
       return { ...EMPTY, source: "sqlite", from, to };
     }
+    const capped = rows.length >= CAP;
 
     // ── lanes ──────────────────────────────────────────────────────────────
     // The vocabulary comes from the publication policy, not from a second
@@ -165,11 +203,20 @@ export async function readWallTape(opts: { agentSlug?: string } = {}): Promise<W
       counts[fate] += 1;
     }
 
+    // The counted window wins wherever it is available; the sampled tally is
+    // the fallback for a ledger too old to answer the aggregate.
+    const summed = total.turned + total.through + total.flight;
+    const published =
+      summed > 0
+        ? { intents: summed, turned: total.turned, through: total.through, flight: total.flight }
+        : counts;
+
     return {
       source: "sqlite",
       cells,
       lanes,
-      counts,
+      counts: published,
+      capped,
       from,
       to,
       key: `${cells.length}:${to}`,


### PR DESCRIPTION
Production published **"400 turned back in the last day"** within a minute of the band going live.

Four hundred is the query's `LIMIT`. The real figure was larger and unknown — a truncation wearing the clothes of a measurement, in Geist Pixel at 72px, on the hero of a public page. Exactly the class of claim the rest of this codebase refuses: `read-leaderboard` publishes `unranked` rather than a number it cannot back, and the discoveries page says "could not read" rather than "nothing there".

## The fix

The counts now come from an aggregate over the **whole 24h window**, served by the `trades_time` index the band's own branch added. The 400-row read stays what it always was — the sample the canvas can hold.

When the day held more than the band can draw, the caption says so and gives the drawn number, so the picture and the figure are never quietly measuring different things:

> 1,842 stopped at the permission wall each agent signed; 31 got through. The caps are the owner's, and nothing can be moved outside them. **The band above draws the most recent 400 of them — the count is the whole day.**

The sampled tally survives as the fallback for a ledger too old to answer the aggregate: such a ledger gets an understated count rather than none, and the band is still honest about being a sample.

## Verification

`npm test` 1719/1719 · `npm run typecheck` clean.