### PR TITLE
Fix: the gate redirected to the internal listen address

### DIFF
--- a/web/src/app/api/gate/route.ts
+++ b/web/src/app/api/gate/route.ts
@@ -5,6 +5,18 @@
  * browser's history, in the referer of every outbound request, and in whatever
  * logs sit in front of this service. The cookie is httpOnly so no script on the
  * page can read it back out.
+ *
+ * EVERY REDIRECT HERE IS RELATIVE, and that is not a style choice. This service
+ * is started with `next start -H 0.0.0.0`, so inside a route handler `req.url`
+ * is the INTERNAL listen address — building a redirect from it sent the visitor
+ * to https://0.0.0.0:8080/, which is a dead host. Caught by asking the deployed
+ * site for it.
+ *
+ * The obvious repair is to reconstruct the public origin from x-forwarded-host,
+ * and that is worse: the header is attacker-supplied, so a redirect built from
+ * it is an open redirect wearing a helmet. HTTP has allowed a relative Location
+ * since forever and every browser resolves it against the address the visitor
+ * actually used, which is the one thing here nobody can forge.
  */
 import { NextResponse } from "next/server";
 import { GATE_COOKIE, gatePassword, sameSecret } from "@/lib/site-gate";
@@ -15,11 +27,15 @@ export const dynamic = "force-dynamic";
 /** A month. Long enough that nobody is typing it twice a day. */
 const MAX_AGE = 60 * 60 * 24 * 30;
 
+/** 303, so the browser follows with GET and a refresh cannot re-post. */
+const seeOther = (path: string) =>
+  new NextResponse(null, { status: 303, headers: { Location: path } });
+
 export async function POST(req: Request) {
   const expected = gatePassword();
   // No password configured means no gate; nothing to open, and refusing here
   // would strand a deployment whose owner had just turned it off.
-  if (!expected) return NextResponse.redirect(new URL("/", req.url), 303);
+  if (!expected) return seeOther("/");
 
   let given = "";
   try {
@@ -33,16 +49,17 @@ export async function POST(req: Request) {
   if (!sameSecret(given, expected)) {
     // The password is never echoed back into the URL, so a shoulder-surfer and
     // the server log see the same thing: that someone got it wrong.
-    return NextResponse.redirect(new URL("/gate?again=1", req.url), 303);
+    return seeOther("/gate?again=1");
   }
 
-  const res = NextResponse.redirect(new URL("/", req.url), 303);
+  const res = seeOther("/");
   res.cookies.set(GATE_COOKIE, expected, {
     httpOnly: true,
     sameSite: "lax",
-    // Set on any https origin. Left off for plain http so a local check of the
-    // gate does not silently fail to store the cookie.
-    secure: new URL(req.url).protocol === "https:",
+    // Behind Railway's proxy the inbound request is plain http, so deciding
+    // this from the request would never set Secure on a site that is HTTPS to
+    // every actual visitor. It follows the deployment instead.
+    secure: process.env.NODE_ENV === "production",
     path: "/",
     maxAge: MAX_AGE,
   });

--- a/web/src/lib/site-gate.test.ts
+++ b/web/src/lib/site-gate.test.ts
@@ -74,3 +74,37 @@ describe("the comparison", () => {
     assert.equal(sameSecret("", ""), true);
   });
 });
+
+describe("nothing sends a visitor to the internal listen address", () => {
+  const ROUTE = readFileSync(new URL("../app/api/gate/route.ts", import.meta.url), "utf8");
+  const MW = readFileSync(new URL("../middleware.ts", import.meta.url), "utf8");
+  const strip = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
+
+  it("the POST handler builds no absolute redirect", () => {
+    // This service starts with `next start -H 0.0.0.0`, so req.url inside a
+    // route handler is the INTERNAL address. The first version redirected to
+    // `new URL("/", req.url)` and the deployed site duly answered
+    // 303 -> https://0.0.0.0:8080/ — a dead host, and the gate would have been
+    // broken the moment anyone typed the right password.
+    assert.ok(!/new URL\([^)]*req\.url/.test(strip(ROUTE)), "no redirect may be built from req.url");
+    assert.match(ROUTE, /Location: path/);
+  });
+
+  it("does not trust a forwarded host to rebuild the origin", () => {
+    // The obvious repair is worse than the bug: x-forwarded-host is supplied by
+    // the caller, so a redirect built from it is an open redirect. A relative
+    // Location resolves against the address the visitor actually used.
+    // Comments stripped: both files explain at length why this header is not
+    // trusted, and scanning the raw text would fail the rule on the paragraph
+    // describing it.
+    assert.ok(!/x-forwarded-host/i.test(strip(ROUTE)));
+    assert.ok(!/x-forwarded-host/i.test(strip(MW)));
+  });
+
+  it("the middleware rewrites rather than redirects", () => {
+    // A rewrite is resolved server-side and never reaches the browser, so the
+    // internal origin cannot leak into one.
+    assert.match(MW, /NextResponse\.rewrite\(to\)/);
+    assert.ok(!/NextResponse\.redirect/.test(strip(MW)), "a redirect here would carry the internal host");
+  });
+});

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -103,13 +103,21 @@ export function middleware(req: NextRequest) {
   const held = req.cookies.get(GATE_COOKIE)?.value ?? "";
   if (sameSecret(held, expected)) return NextResponse.next();
 
+  // A REWRITE, NOT A REDIRECT, and the difference is load-bearing here.
+  //
+  // This service runs behind a proxy with `next start -H 0.0.0.0`, so the
+  // origin the server sees is the internal listen address. A redirect built
+  // from it would send the visitor to 0.0.0.0:8080 — which is exactly the bug
+  // the POST handler had, found by asking the deployed site for it.
+  //
+  // A rewrite is resolved server-side and never reaches the browser, so an
+  // internal host cannot leak into one. It also leaves the visitor's own URL
+  // alone, which means that once they are through they are already where they
+  // were trying to go.
   const to = req.nextUrl.clone();
   to.pathname = GATE_PATH;
-  // Where they were going is not carried through. It would put the visitor's
-  // destination in a query string for no gain, and everything behind this
-  // door is being rebuilt anyway.
   to.search = "";
-  return NextResponse.redirect(to);
+  return NextResponse.rewrite(to);
 }
 
 /**


### PR DESCRIPTION
Asked the deployed site for it and it answered:

```
POST /api/gate -> 303 https://0.0.0.0:8080/
```

`next start -H 0.0.0.0` means `req.url` inside a route handler is the internal listen address, so every redirect built from it points at a host no browser can reach. The gate would have been broken the moment anyone typed the right password — it just had not been reachable yet, because the variable that arms it is not set.

Every redirect is relative now. Rebuilding the origin from `x-forwarded-host` would be worse than the bug: the caller supplies that header, so a login redirect built from it is an open redirect.

The middleware rewrites rather than redirects — resolved server-side, so an internal origin cannot leak into one, and the visitor's URL is preserved so they land where they were going.

Verified against a running server with the password set: gated pages answer 200 with the notice and the original URL, the API stays open, a wrong password returns to the notice, and the right one sends `Location: /` with no host at all. Three properties pinned.