### PR TITLE
Gate the API too — it was the whole disclosure

### DIFF
--- a/web/src/lib/site-gate.test.ts
+++ b/web/src/lib/site-gate.test.ts
@@ -37,13 +37,21 @@ describe("the gate is off unless somebody turns it on", () => {
 });
 
 describe("what the gate must never close", () => {
-  it("leaves the API open", () => {
-    // Telegram posts webhooks to it, the browser calls it after every page
-    // load, and anything else running against this deployment talks to it.
-    // Gating these would not hide an unfinished page, it would stop a fleet.
-    for (const p of ["/api/theses", "/api/telegram", "/api/gate", "/api/grants"]) {
-      assert.equal(isGatedPath(p), false, `${p} must stay open`);
+  it("gates the API too, because that was the whole disclosure", () => {
+    // With the pages behind a password and the API open, forty posts of agent
+    // reasoning and every agent name were still readable by anyone who knew the
+    // URLs. Nothing outside a browser calls this deployment — no worker,
+    // orchestrator, cli or gateway code fetches it, /api/telegram is a
+    // dashboard endpoint that calls OUT to the Bot API rather than receiving
+    // from it, and no healthcheck path is configured.
+    for (const p of ["/api/theses", "/api/telegram", "/api/grants", "/api/leaderboard", "/api/market"]) {
+      assert.equal(isGatedPath(p), true, `${p} should be behind the notice`);
     }
+  });
+
+  it("leaves the door itself open", () => {
+    // Gate /api/gate and the password could never be handed in.
+    assert.equal(isGatedPath("/api/gate"), false, "the password endpoint must stay reachable");
   });
 
   it("leaves the framework's own assets open", () => {
@@ -106,5 +114,27 @@ describe("nothing sends a visitor to the internal listen address", () => {
     // internal origin cannot leak into one.
     assert.match(MW, /NextResponse\.rewrite\(to\)/);
     assert.ok(!/NextResponse\.redirect/.test(strip(MW)), "a redirect here would carry the internal host");
+  });
+});
+
+describe("a gated API request gets a status, not a page", () => {
+  const MW = readFileSync(new URL("../middleware.ts", import.meta.url), "utf8");
+
+  it("answers 401 rather than rewriting to the notice", () => {
+    // Handing a caller expecting JSON a lump of HTML with status 200 is worse
+    // than a refusal: the browser code reading it would parse the failure as
+    // data.
+    assert.match(MW, /if \(isApi\) \{\s*return NextResponse\.json\(/);
+    assert.match(MW, /status: 401/);
+  });
+
+  it("still runs the host and cross-site guards on the API first", () => {
+    // The gate is an addition, not a replacement. Losing either of these would
+    // reopen the DNS-rebinding and CSRF holes the middleware was written for.
+    const guards = MW.indexOf("possible DNS-rebinding");
+    const cross = MW.indexOf("cross-site request to the local API");
+    const gate = MW.indexOf("const expected = gatePassword()");
+    assert.ok(guards > 0 && cross > 0 && gate > 0);
+    assert.ok(guards < gate && cross < gate, "the API guards must run before the gate");
   });
 });

--- a/web/src/lib/site-gate.ts
+++ b/web/src/lib/site-gate.ts
@@ -45,16 +45,27 @@ export function sameSecret(a: string, b: string): boolean {
 }
 
 /**
- * Whether a path is the visitor-facing site rather than plumbing.
+ * Whether a path is behind the notice.
  *
- * THE API IS DELIBERATELY NOT GATED. Telegram posts webhooks to it, the browser
- * calls it after the page loads, and anything else running against this
- * deployment talks to it — putting a password in front of those would not hide
- * an unfinished page, it would break a live fleet. The same goes for the
- * framework's own assets: gate those and the notice itself renders unstyled.
+ * THE API IS GATED TOO, and the first version of this file was wrong about why
+ * it could not be. It claimed Telegram posts webhooks to /api/telegram — that
+ * route is a dashboard status endpoint the BROWSER calls, which reaches out to
+ * the Bot API rather than receiving from it. Checked properly, nothing outside
+ * a browser calls this deployment: no worker, orchestrator, cli or gateway code
+ * fetches it, /api/bundler is built from window.location.origin, and no
+ * healthcheck path is configured. A visitor who is through the door carries the
+ * cookie on same-origin requests, so the product keeps working for them.
+ *
+ * That is worth the change because the API was the whole disclosure. With the
+ * pages behind a password and the API open, forty posts of agent reasoning and
+ * every agent name were still readable by anyone who knew the URLs.
+ *
+ * TWO THINGS STAY OPEN. /api/gate, or the password could never be handed in;
+ * and the framework's own assets, or the notice itself renders unstyled.
  */
 export function isGatedPath(pathname: string): boolean {
-  if (pathname.startsWith("/api/")) return false;
+  if (pathname === GATE_API) return false;
+  if (pathname.startsWith("/api/")) return true;
   if (pathname.startsWith("/_next/")) return false;
   if (pathname === GATE_PATH) return false;
   // Files served straight out of public/: icons, the manifest, the service

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -78,7 +78,8 @@ export function middleware(req: NextRequest) {
   // Applying the host allowlist to a PAGE would newly refuse a self-hosted
   // install reached over a LAN or a domain — a behaviour change nobody asked
   // for, hidden inside a change about a holding page.
-  if (pathname.startsWith("/api/")) {
+  const isApi = pathname.startsWith("/api/");
+  if (isApi) {
     if (!HOSTED && !hostAllowed(req.headers.get("host"))) {
       return new NextResponse("blocked: unexpected Host header (possible DNS-rebinding)", { status: 403 });
     }
@@ -86,7 +87,10 @@ export function middleware(req: NextRequest) {
     if (site && site !== "same-origin" && site !== "none") {
       return new NextResponse("blocked: cross-site request to the local API", { status: 403 });
     }
-    return NextResponse.next();
+    // Falls through to the gate rather than returning. The API used to be
+    // exempt, which left every agent's name and forty posts of reasoning
+    // readable by anyone who knew the URLs while the pages showing them were
+    // behind a password.
   }
 
   // ── the holding page ────────────────────────────────────────────────────
@@ -102,6 +106,18 @@ export function middleware(req: NextRequest) {
 
   const held = req.cookies.get(GATE_COOKIE)?.value ?? "";
   if (sameSecret(held, expected)) return NextResponse.next();
+
+  // AN API REQUEST GETS A STATUS, NOT A PAGE. Rewriting it to the notice would
+  // hand a caller expecting JSON a lump of HTML with status 200, which is a
+  // worse answer than a refusal — the browser code reading it would parse the
+  // failure as data. 401 says what happened, and a visitor through the door
+  // never sees it: their cookie rides along on same-origin requests.
+  if (isApi) {
+    return NextResponse.json(
+      { error: "gated", detail: "This deployment is behind a password while it is being worked on." },
+      { status: 401 },
+    );
+  }
 
   // A REWRITE, NOT A REDIRECT, and the difference is load-bearing here.
   //


### PR DESCRIPTION
With the pages behind a password and the API open, **forty posts of agent reasoning and every agent name** were still readable by anyone who knew the URLs. The gate hid the room and left the window open.

The reason originally given for leaving it open was wrong. It claimed Telegram posts webhooks to `/api/telegram` — that route is a dashboard status endpoint the *browser* calls, which reaches out to the Bot API rather than receiving from it.

Checked properly this time:
- no `worker`, `orchestrator`, `cli` or `gateway` code fetches this deployment
- `/api/bundler` is built from `window.location.origin`
- `MERRYMEN_PUBLIC_ORIGIN` is only read for SIWE origin validation
- `railway.json` configures no healthcheck path

Nothing outside a browser calls it, and a visitor through the door carries the cookie on same-origin requests.

**An API request gets 401 and JSON, not the notice.** Rewriting it to an HTML page with status 200 would hand a caller expecting JSON a lump of markup its own code would parse as data.

`/api/gate` stays open, or the password could never be handed in. The host-allowlist and cross-site guards still run on the API **before** the gate — this is an addition, not a replacement, and a test now asserts that order.

Verified locally with the password set: six API routes answer 401 with no cookie, `/api/gate` and `/gate` stay reachable, everything returns 200 once the cookie is held, and the gate form was driven by hand in a browser.

1,801 tests, typecheck clean, production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)