### PR TITLE
The cleanliness pass: fewer lines, one type scale, and an amber zero

### DIFF
--- a/web/src/app/(app)/a/[key]/page.tsx
+++ b/web/src/app/(app)/a/[key]/page.tsx
@@ -110,20 +110,53 @@ export default async function AgentPage({ params }: { params: Promise<{ key: str
       <WallBand tape={tape} still size="agent" />
 
       <div className="mm-wrap">
+        {/* THE FIGURE IS WHAT ACTUALLY HAPPENED, not always the refusal.
+
+            This printed tape.counts.turned at 32px in the wall's amber
+            whatever it was — so on an agent the wall never stopped, the
+            loudest, hottest thing on the page was the number 0 labelled
+            "turned back in the last day". Measured on a real profile.
+
+            --mm-warn means the wall said no. Spending it on a zero spends it
+            on the wall having said nothing, which is the opposite. When
+            nothing was turned back the page leads with what got through, in
+            the ordinary text colour — never --mm-thru, which tokens.css
+            reserves for the band canvas. */}
         {tape.cells.length > 0 && (
           <div className="mm-wall-read">
-            <span className="mm-wall-fig sm">{tape.counts.turned.toLocaleString("en-US")}</span>
-            <span className="mm-wall-said">
-              <b>turned back in the last day</b>
-              <span>
-                {/* THE SCOPE, because the strip below counts a different
-                    population: this is 24 hours across every account this agent
-                    has held, and those figures are one epoch of one account. */}
-                against this agent&rsquo;s own signed caps, across every account it has held.{" "}
-                {tape.counts.through} got through.
-                {tape.capped && <> The band draws the most recent {tape.cells.length}.</>}
-              </span>
-            </span>
+            {tape.counts.turned > 0 ? (
+              <>
+                <span className="mm-wall-fig sm">
+                  {tape.counts.turned.toLocaleString("en-US")}
+                </span>
+                <span className="mm-wall-said">
+                  <b>turned back in the last day</b>
+                  <span>
+                    {/* THE SCOPE, because the strip below counts a different
+                        population: this is 24 hours across every account this
+                        agent has held, and those figures are one epoch of
+                        one account. */}
+                    against this agent&rsquo;s own signed caps, across every account it has
+                    held. {tape.counts.through} got through.
+                    {tape.capped && <> The band draws the most recent {tape.cells.length}.</>}
+                  </span>
+                </span>
+              </>
+            ) : (
+              <>
+                <span className="mm-wall-fig sm quiet">
+                  {tape.counts.through.toLocaleString("en-US")}
+                </span>
+                <span className="mm-wall-said">
+                  <b>got through in the last day</b>
+                  <span>
+                    Nothing was turned back by this agent&rsquo;s own signed caps, across
+                    every account it has held.
+                    {tape.capped && <> The band draws the most recent {tape.cells.length}.</>}
+                  </span>
+                </span>
+              </>
+            )}
           </div>
         )}
 

--- a/web/src/app/(app)/captions.test.ts
+++ b/web/src/app/(app)/captions.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+/**
+ * SENTENCES THAT ARE DOING WORK, PINNED BEFORE ANYONE TIDIES THEM.
+ *
+ * A cleanliness pass deletes prose. Most of the prose on these pages is
+ * decoration and should go; a few paragraphs are the only thing standing
+ * between a figure and a misreading of it, and they look exactly like the rest.
+ *
+ * This file exists so the difference is mechanical rather than remembered. Each
+ * assertion names what the sentence prevents. If one fails, the question is not
+ * "restore the wording" — it is "does the page still say this, somehow".
+ */
+
+const at = (p: string) => readFileSync(new URL(p, import.meta.url), "utf8");
+
+describe("the leaderboard explains its two refusals", () => {
+  const PAGE = at("./leaderboard/page.tsx");
+
+  it("distinguishes no-deposit from never-filled in words", () => {
+    // rank-pnl publishes "unranked" for two unrelated reasons and the board
+    // sorts both to the bottom together. Without this paragraph an agent that
+    // has funded and never traded is indistinguishable from one nobody has put
+    // a penny into — and the second is a dormant account while the first is the
+    // exact shape that once published +2643%.
+    assert.match(PAGE, /no capital to measure a return against/);
+    assert.match(PAGE, /no return to measure/);
+  });
+
+  it("says why a simulated book cannot be divided by a real deposit", () => {
+    // This is the incident, stated in the product rather than only in a commit
+    // message. It is the reason the refusal exists at all.
+    assert.match(PAGE, /pretend book/);
+    assert.match(PAGE, /publishes a number that never happened/);
+  });
+});
+
+describe("the token page says how much of the book it is showing", () => {
+  const PAGE = at("./t/[token]/page.tsx");
+
+  it("publishes the count of agents who opted in, against the total", () => {
+    // Holdings are opt-in per agent. Without this line a short list reads as
+    // the whole one, which understates who is in a token and overstates how
+    // much of it we can see.
+    assert.match(PAGE, /\{t\.holders\.length\} of \{total\}/);
+    assert.match(PAGE, /publishes its" : "publish their/);
+  });
+});
+
+describe("the oracle chart says what its axis is", () => {
+  const LINE = at("../../components/PriceLine.tsx");
+
+  it("states that it is a feed and not a market", () => {
+    // Every other figure on that page is a market number. Without this the line
+    // is read as one, and a Chainlink series is not a price anyone traded at.
+    assert.match(LINE, /not a market/);
+  });
+
+  it("states that the axis is compressed and the gaps are real", () => {
+    // The component's own header gives the reason: a compressed axis a reader
+    // has not been told about is the dishonest version. The alternative it
+    // rejected — a true wall-clock axis — was measured at 28% coverage.
+    // Whitespace-tolerant: JSX wraps these across lines and a reformat must not
+    // read as the sentence having been deleted.
+    assert.match(LINE, /Time\s+runs\s+to\s+scale\s+within\s+a\s+session/);
+    assert.match(LINE, /left\s+out\s+rather\s+than\s+drawn\s+across/);
+  });
+});
+
+describe("the agent profile says what its return is net of", () => {
+  const PAGE = at("./a/[key]/page.tsx");
+
+  it("keeps the unpriced-gas caveat inline with the figure", () => {
+    // A fill whose gas could not be priced contributes nothing to the sum and
+    // is never counted, so the return silently understates its own cost. This
+    // sentence is the only thing distinguishing "net of gas" from "net of some
+    // of the gas", and it has to sit with the number it qualifies.
+    assert.match(PAGE, /had gas we could not price/);
+    assert.match(PAGE, /not the full cost/);
+  });
+});

--- a/web/src/styles/agent.css
+++ b/web/src/styles/agent.css
@@ -26,7 +26,7 @@
   align-items: baseline;
   gap: var(--mm-3);
   padding: 3px 0;
-  font-size: 13px;
+  font-size: var(--mm-t-body);
 }
 
 .mm-agent-lanes .lab {
@@ -49,7 +49,7 @@
 
 .mm-agent-lanes .rest {
   margin: var(--mm-2) 0 0;
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-faint);
 }
 
@@ -57,7 +57,7 @@
 
 .mm-agent-how {
   margin: var(--mm-4) 0 0;
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-dim);
 }
 
@@ -87,7 +87,7 @@
  */
 .mm-stat dd {
   margin: var(--mm-1) 0 0;
-  font-size: 15px;
+  font-size: var(--mm-t-lead);
   font-weight: 700;
   letter-spacing: -0.02em;
   color: var(--mm-tx);
@@ -107,14 +107,14 @@
 }
 /* "unranked" is a word and must not be sized like a figure. */
 .mm-stat dd.flat {
-  font-size: 14px;
+  font-size: var(--mm-t-lead);
   font-weight: 600;
   color: var(--mm-dim);
 }
 
 .mm-stat p {
   margin: var(--mm-1) 0 0;
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
   line-height: 1.4;
   color: var(--mm-faint);
 }
@@ -140,7 +140,7 @@
   align-items: baseline;
   gap: var(--mm-3);
   margin-top: var(--mm-2);
-  font-size: 10.5px;
+  font-size: var(--mm-t-micro);
   color: var(--mm-faint);
 }
 
@@ -159,7 +159,7 @@
    balance, and takes the axis for wall-clock time. */
 .mm-equity figcaption {
   margin-top: var(--mm-3);
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
   line-height: 1.5;
   color: var(--mm-faint);
 }
@@ -178,7 +178,7 @@
 .mm-note {
   margin: var(--mm-2) 0 0;
   max-width: 58ch;
-  font-size: 13.5px;
+  font-size: var(--mm-t-body);
   line-height: 1.6;
   color: var(--mm-dim);
 }
@@ -191,7 +191,7 @@
 
 .mm-holdlist li {
   padding: var(--mm-3) 0 var(--mm-4);
-  font-size: 13px;
+  font-size: var(--mm-t-body);
 }
 
 .mm-holdlist .row {
@@ -208,7 +208,7 @@
   flex-wrap: wrap;
   gap: var(--mm-1) var(--mm-3);
   margin: 3px 0 0;
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-faint);
 }
 
@@ -226,7 +226,7 @@
 /* THE LINE NO OTHER HOLDINGS TABLE HAS: why it says it is in this. */
 .mm-holdlist .said {
   margin: var(--mm-2) 0 0;
-  font-size: 13px;
+  font-size: var(--mm-t-body);
   line-height: 1.55;
   color: var(--mm-tx-2);
   display: -webkit-box;
@@ -264,7 +264,7 @@
 .mm-holdlist .share {
   min-width: 82px;
   text-align: right;
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-faint);
   white-space: nowrap;
 }

--- a/web/src/styles/agent.css
+++ b/web/src/styles/agent.css
@@ -12,8 +12,7 @@
 /* Deliberately NOT --mm-warn. The wall band directly above is amber, and eight
    amber rows beneath it turn a masthead colour into a table treatment. */
 .mm-agent-lanes {
-  padding: var(--mm-4) 0;
-  border-bottom: 1px solid var(--mm-edge);
+  padding: var(--mm-4) 0 var(--mm-5);
 }
 
 .mm-agent-lanes ul {
@@ -34,13 +33,12 @@
   color: var(--mm-tx-2);
 }
 
-/* A dotted leader, so a two-item row still reads as a table. */
+/* No leader. A right-aligned tabular figure already aligns with the one
+   above it, and the dots were a rule per row in a list about refusals. */
 .mm-agent-lanes li::before {
   content: "";
   order: 1;
   flex: 1;
-  border-bottom: 1px dotted var(--mm-edge-2);
-  transform: translateY(-3px);
 }
 
 .mm-agent-lanes .n {
@@ -72,19 +70,33 @@
   margin: var(--mm-5) 0 0;
 }
 
+/*
+ * NO BOXES. Four bordered tiles in a row is sixteen edges to separate four
+ * numbers that a grid already separates. The label above each figure is the
+ * only delimiter a stat row needs.
+ */
 .mm-stat {
-  padding: var(--mm-3);
-  border: 1px solid var(--mm-edge);
-  border-radius: var(--mm-r-chip);
-  background: var(--mm-surface);
+  padding: 0;
 }
 
+/*
+ * ONE SIZE FOR A FIGURE, and the first cell is the hero.
+ *
+ * All four sat at 19px, so the return — the thing the page is about — was
+ * the same weight as the count of trades that were turned back.
+ */
 .mm-stat dd {
   margin: var(--mm-1) 0 0;
-  font-size: 19px;
+  font-size: 15px;
   font-weight: 700;
   letter-spacing: -0.02em;
   color: var(--mm-tx);
+  font-variant-numeric: tabular-nums;
+}
+
+/* The first figure in the strip leads: it is what the page is about. */
+.mm-stats > .mm-stat:first-child dd {
+  font-size: 30px;
 }
 
 .mm-stat dd.up {
@@ -108,8 +120,7 @@
 }
 
 .mm-equity-wrap {
-  padding: var(--mm-5) 0;
-  border-bottom: 1px solid var(--mm-edge);
+  padding: var(--mm-6) 0 var(--mm-5);
 }
 
 .mm-equity {
@@ -179,8 +190,7 @@
 }
 
 .mm-holdlist li {
-  padding: var(--mm-3) 0;
-  border-bottom: 1px solid var(--mm-edge);
+  padding: var(--mm-3) 0 var(--mm-4);
   font-size: 13px;
 }
 

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -15,7 +15,7 @@
   background: var(--mm-bg);
   color: var(--mm-tx);
   font-family: var(--mm-sans);
-  font-size: 15px;
+  font-size: var(--mm-t-lead);
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
@@ -104,7 +104,7 @@
 
 .mm-kicker {
   font-family: var(--mm-mono);
-  font-size: 10.5px;
+  font-size: var(--mm-t-micro);
   font-weight: 600;
   letter-spacing: 0.17em;
   text-transform: uppercase;
@@ -118,7 +118,7 @@
   align-items: center;
   gap: var(--mm-1);
   font-family: var(--mm-mono);
-  font-size: 10px;
+  font-size: var(--mm-t-micro);
   font-weight: 600;
   letter-spacing: 0.09em;
   text-transform: uppercase;
@@ -185,7 +185,7 @@
   border: 1px solid var(--mm-edge-2);
   background: var(--mm-surface-2);
   color: var(--mm-tx);
-  font-size: 13.5px;
+  font-size: var(--mm-t-body);
   font-weight: 600;
   transition:
     background-color var(--mm-fast) var(--mm-ease),

--- a/web/src/styles/board.css
+++ b/web/src/styles/board.css
@@ -34,7 +34,7 @@
 }
 
 .mm-board-row .rk {
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-faint);
 }
 
@@ -45,14 +45,14 @@
 }
 
 .mm-board-row .who .nm {
-  font-size: 14.5px;
+  font-size: var(--mm-t-lead);
   font-weight: 650;
   letter-spacing: -0.012em;
   color: var(--mm-tx);
 }
 
 .mm-board-row .who .at {
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-dim);
 }
 
@@ -64,7 +64,7 @@
  * heading is a list of names.
  */
 .mm-board-row .pnl {
-  font-size: 23px;
+  font-size: var(--mm-t-fig);
   font-weight: 700;
   letter-spacing: -0.02em;
   text-align: right;
@@ -83,14 +83,14 @@
 /* A word is not a figure and must never be sized like one. */
 .mm-board-row .pnl.flat {
   color: var(--mm-dim);
-  font-size: 13px;
+  font-size: var(--mm-t-body);
   font-weight: 600;
   letter-spacing: 0;
 }
 
 .mm-board-row .dd,
 .mm-board-row .tr {
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-dim);
   text-align: right;
   white-space: nowrap;
@@ -111,7 +111,7 @@
 .mm-unranked > p {
   margin: var(--mm-2) 0 var(--mm-4);
   max-width: 58ch;
-  font-size: 13px;
+  font-size: var(--mm-t-body);
   line-height: 1.6;
   color: var(--mm-dim);
 }

--- a/web/src/styles/board.css
+++ b/web/src/styles/board.css
@@ -12,8 +12,9 @@
   padding: 0;
 }
 
+/* Space, not a rule. The rank number and the avatar already start a row. */
 .mm-board-row {
-  border-bottom: 1px solid var(--mm-edge);
+  padding: var(--mm-1) 0;
 }
 
 .mm-board-row > a,
@@ -55,11 +56,20 @@
   color: var(--mm-dim);
 }
 
+/*
+ * THE FIGURE THIS PAGE EXISTS FOR, sized like it.
+ *
+ * It was 14px — one pixel above body copy — while the largest text on the
+ * page was its own title. A leaderboard whose returns are smaller than its
+ * heading is a list of names.
+ */
 .mm-board-row .pnl {
-  font-size: 14px;
+  font-size: 23px;
   font-weight: 700;
+  letter-spacing: -0.02em;
   text-align: right;
-  min-width: 68px;
+  min-width: 96px;
+  font-variant-numeric: tabular-nums;
 }
 
 .mm-board-row .pnl.up {
@@ -70,10 +80,12 @@
 }
 /* Unranked is a WORD, never a number. A 0.0% here would read as a flat run
    rather than as an unknown one. */
+/* A word is not a figure and must never be sized like one. */
 .mm-board-row .pnl.flat {
   color: var(--mm-dim);
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
+  letter-spacing: 0;
 }
 
 .mm-board-row .dd,

--- a/web/src/styles/cards.css
+++ b/web/src/styles/cards.css
@@ -24,10 +24,13 @@
   background: var(--mm-surface);
 }
 
+/* The skeleton keeps an edge, and it is the only card that does. Dashed means
+   "this did not fully happen", which is exactly what a placeholder is — and it
+   now states its own border, since the card above no longer draws one. */
 .mm-card.skel {
   min-height: 168px;
   background: var(--mm-surface-2);
-  border-style: dashed;
+  border: 1px dashed var(--mm-edge);
 }
 
 .mm-card > header {
@@ -52,7 +55,7 @@
   align-items: center;
   justify-content: center;
   font-family: var(--mm-mono);
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
   font-weight: 700;
   color: var(--mm-dim);
 }
@@ -70,14 +73,14 @@
 }
 
 .mm-card .tick b {
-  font-size: 14.5px;
+  font-size: var(--mm-t-lead);
   font-weight: 700;
   letter-spacing: -0.015em;
   color: var(--mm-tx);
 }
 
 .mm-card .tick .nm {
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-dim);
 }
 
@@ -86,12 +89,12 @@
   flex-wrap: wrap;
   gap: var(--mm-2);
   margin-top: 3px;
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-faint);
 }
 
 .mm-card .chg {
-  font-size: 13px;
+  font-size: var(--mm-t-body);
   font-weight: 700;
   white-space: nowrap;
 }
@@ -126,7 +129,7 @@
 }
 
 .mm-grad .glab {
-  font-size: 10.5px;
+  font-size: var(--mm-t-micro);
   color: var(--mm-faint);
   white-space: nowrap;
 }
@@ -135,7 +138,7 @@
 
 .mm-card .say {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--mm-t-body);
   line-height: 1.55;
   color: var(--mm-tx-2);
   display: -webkit-box;
@@ -155,7 +158,7 @@
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: var(--mm-2);
-  font-size: 12.5px;
+  font-size: var(--mm-t-body);
   color: var(--mm-tx-2);
 }
 
@@ -168,7 +171,7 @@
 
 .mm-figs i {
   font-style: normal;
-  font-size: 10px;
+  font-size: var(--mm-t-micro);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--mm-faint);
@@ -189,14 +192,14 @@
 /* Marks, never a score out of five — conviction is an ORDERING, not a rating. */
 .mm-verdict .pips {
   font-family: var(--mm-mono);
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
   letter-spacing: 1px;
   color: var(--mm-wire);
   white-space: nowrap;
 }
 
 .mm-verdict .vsay {
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
   line-height: 1.5;
   color: var(--mm-tx-2);
 }
@@ -214,7 +217,7 @@
 
 .mm-card .soc {
   font-family: var(--mm-mono);
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-dim);
 }
 
@@ -234,7 +237,7 @@
 
 .mm-badge {
   font-family: var(--mm-mono);
-  font-size: 10px;
+  font-size: var(--mm-t-micro);
   font-weight: 600;
   letter-spacing: 0.06em;
   padding: 3px 6px;
@@ -260,7 +263,7 @@
   border: 1px solid color-mix(in srgb, var(--mm-warn) 30%, transparent);
   border-radius: var(--mm-r-chip);
   background: color-mix(in srgb, var(--mm-warn) 7%, transparent);
-  font-size: 12.5px;
+  font-size: var(--mm-t-body);
   line-height: 1.55;
   color: var(--mm-warn);
 }
@@ -279,7 +282,7 @@
   min-block-size: 30px;
   padding: 0 var(--mm-3);
   border-radius: 4px;
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
   font-weight: 600;
   color: var(--mm-dim);
   transition:

--- a/web/src/styles/cards.css
+++ b/web/src/styles/cards.css
@@ -9,12 +9,17 @@
   padding: var(--mm-4) 0;
 }
 
+/*
+ * NO BOX. The grid already separates these, and a border around every card in a
+ * twelve-card grid is twelve rectangles competing with their own contents. The
+ * surface tint says where one ends without drawing a line to do it.
+ */
 .mm-card {
   display: flex;
   flex-direction: column;
   gap: var(--mm-3);
   padding: var(--mm-4);
-  border: 1px solid var(--mm-edge);
+  border: 0;
   border-radius: var(--mm-r-card);
   background: var(--mm-surface);
 }

--- a/web/src/styles/feed.css
+++ b/web/src/styles/feed.css
@@ -82,20 +82,20 @@
 }
 
 .mm-who .nm {
-  font-size: 15px;
+  font-size: var(--mm-t-lead);
   font-weight: 650;
   letter-spacing: -0.012em;
   color: var(--mm-tx);
 }
 
 .mm-who .at {
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-dim);
 }
 
 .mm-when {
   margin-left: auto;
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-faint);
   white-space: nowrap;
 }
@@ -111,7 +111,7 @@
  */
 .mm-say {
   margin: 0;
-  font-size: 18px;
+  font-size: var(--mm-t-head);
   line-height: 1.55;
   letter-spacing: -0.004em;
   color: var(--mm-tx);
@@ -130,7 +130,7 @@
   border: 1px solid var(--mm-edge);
   border-radius: var(--mm-r-chip);
   background: var(--mm-surface-2);
-  font-size: 13.5px;
+  font-size: var(--mm-t-body);
 }
 
 /* A TICKER IS ONE WORD. base.css sets overflow-wrap: anywhere so an
@@ -155,7 +155,7 @@
 
 .mm-trade .out {
   margin-left: auto;
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-dim);
   text-align: right;
 }
@@ -190,7 +190,7 @@
 
 .mm-said {
   margin: var(--mm-2) 0 0;
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-faint);
 }
 
@@ -203,7 +203,7 @@
 
 .mm-empty h2 {
   margin: 0 0 var(--mm-2);
-  font-size: 17px;
+  font-size: var(--mm-t-head);
   font-weight: 650;
   color: var(--mm-tx-2);
 }
@@ -211,7 +211,7 @@
 .mm-empty p {
   margin: 0 auto;
   max-width: 42ch;
-  font-size: 15px;
+  font-size: var(--mm-t-lead);
   line-height: 1.6;
   color: var(--mm-dim);
 }
@@ -257,7 +257,7 @@
     padding-left: 10px;
   }
   .mm-say {
-    font-size: 17px;
+    font-size: var(--mm-t-head);
   }
   /* The timestamp gets its own line rather than squeezing the name. */
   .mm-when {

--- a/web/src/styles/form.css
+++ b/web/src/styles/form.css
@@ -30,7 +30,7 @@
   margin: var(--mm-6) 0 var(--mm-3);
   padding-bottom: var(--mm-2);
   border-bottom: 1px solid var(--mm-edge);
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--mm-faint);
@@ -38,7 +38,7 @@
 
 .mm-subtle {
   margin: var(--mm-3) 0 var(--mm-1);
-  font-size: 10.5px;
+  font-size: var(--mm-t-micro);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--mm-faint);
@@ -76,14 +76,14 @@
 
 .mm-label {
   font-family: var(--mm-mono);
-  font-size: 10px;
+  font-size: var(--mm-t-micro);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--mm-faint);
 }
 
 .mm-getkey {
-  font-size: 10.5px;
+  font-size: var(--mm-t-micro);
   color: var(--mm-wire);
 }
 
@@ -118,7 +118,7 @@
   background: transparent;
   color: var(--mm-tx);
   font-family: var(--mm-mono);
-  font-size: 14px;
+  font-size: var(--mm-t-lead);
   font-weight: 600;
 }
 
@@ -141,14 +141,14 @@
 .mm-unit {
   flex: none;
   font-family: var(--mm-mono);
-  font-size: 10px;
+  font-size: var(--mm-t-micro);
   color: var(--mm-faint);
 }
 
 .mm-hint {
   display: block;
   margin-top: 3px;
-  font-size: 10.5px;
+  font-size: var(--mm-t-micro);
   line-height: 1.45;
   color: var(--mm-faint);
 }
@@ -156,7 +156,7 @@
 .mm-loading {
   padding: 9px 0;
   font-family: var(--mm-mono);
-  font-size: 13px;
+  font-size: var(--mm-t-body);
   color: var(--mm-faint);
 }
 
@@ -186,7 +186,7 @@
   background: none;
   color: var(--mm-dim);
   font-family: var(--mm-sans);
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
   cursor: pointer;
   transition:
     border-color var(--mm-fast) var(--mm-ease),
@@ -213,13 +213,13 @@
   border: 1px solid var(--mm-edge);
   border-radius: 999px;
   color: var(--mm-dim);
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
 }
 
 .mm-tag code,
 .mm-toggle code {
   font-family: var(--mm-mono);
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
 }
 
 .mm-chip-x {
@@ -227,7 +227,7 @@
   border: none;
   background: none;
   color: inherit;
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
   opacity: 0.7;
   cursor: pointer;
 }
@@ -244,7 +244,7 @@
   border: 1px solid color-mix(in srgb, var(--mm-danger) 40%, transparent);
   border-radius: var(--mm-r-chip);
   background: color-mix(in srgb, var(--mm-danger) 8%, transparent);
-  font-size: 12.5px;
+  font-size: var(--mm-t-body);
   line-height: 1.6;
   color: var(--mm-danger);
 }
@@ -255,7 +255,7 @@
 
 .mm-danger code {
   font-family: var(--mm-mono);
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
 }
 
 /* ── disclosure ──────────────────────────────────────────────────────────── */
@@ -272,7 +272,7 @@
   cursor: pointer;
   user-select: none;
   font-family: var(--mm-mono);
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-dim);
 }
 
@@ -311,7 +311,7 @@
   border: 1px solid var(--mm-edge);
   border-radius: var(--mm-r-chip);
   background: var(--mm-surface);
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
 }
 
 /* The address is the identity — two coins can share a ticker — so it is given
@@ -349,5 +349,5 @@
 .mm-btn.sm {
   min-block-size: 30px;
   padding: 0 var(--mm-3);
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
 }

--- a/web/src/styles/shell.css
+++ b/web/src/styles/shell.css
@@ -53,7 +53,7 @@
   align-items: center;
   gap: var(--mm-2);
   padding: 0 var(--mm-3);
-  font-size: 15px;
+  font-size: var(--mm-t-lead);
   font-weight: 700;
   letter-spacing: -0.02em;
   color: var(--mm-tx);
@@ -70,7 +70,7 @@
   min-block-size: 40px;
   padding: 0 var(--mm-3);
   border-radius: var(--mm-r-chip);
-  font-size: 14px;
+  font-size: var(--mm-t-lead);
   font-weight: 550;
   color: var(--mm-dim);
   transition:
@@ -89,7 +89,7 @@
 }
 
 .mm-navlink.sub {
-  font-size: 13px;
+  font-size: var(--mm-t-body);
 }
 
 /* ── the context column ──────────────────────────────────────────────────── */
@@ -132,7 +132,7 @@
   gap: 3px;
   min-block-size: 48px;
   padding: 6px 2px;
-  font-size: 10px;
+  font-size: var(--mm-t-micro);
   font-weight: 600;
   letter-spacing: 0.02em;
   color: var(--mm-dim);
@@ -249,7 +249,7 @@
 
 .mm-header-txt h1 {
   margin: 0;
-  font-size: 17px;
+  font-size: var(--mm-t-head);
   font-weight: 700;
   letter-spacing: -0.02em;
   color: var(--mm-tx);
@@ -257,7 +257,7 @@
 
 .mm-header-txt p {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-dim);
 }
 
@@ -343,7 +343,7 @@
 }
 
 .mm-alert .who .nm {
-  font-size: 12.5px;
+  font-size: var(--mm-t-body);
   font-weight: 650;
   color: var(--mm-tx);
   white-space: nowrap;
@@ -358,7 +358,7 @@
 
 .mm-alert .who time {
   margin-left: auto;
-  font-size: 10.5px;
+  font-size: var(--mm-t-micro);
   color: var(--mm-faint);
   white-space: nowrap;
 }
@@ -370,7 +370,7 @@
  * The colour already carries the meaning; the box was carrying nothing.
  */
 .mm-alert .mm-chip {
-  font-size: 9.5px;
+  font-size: var(--mm-t-micro);
   padding: 0;
   border: 0;
   background: none;
@@ -383,7 +383,7 @@
   display: flex;
   align-items: baseline;
   gap: 6px;
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-tx-2);
 }
 
@@ -397,7 +397,7 @@
 }
 
 .mm-alert .did .pp {
-  font-size: 9.5px;
+  font-size: var(--mm-t-micro);
   color: var(--mm-faint);
   border: 1px dashed var(--mm-edge-2);
   border-radius: 4px;
@@ -406,7 +406,7 @@
 
 .mm-alert .say {
   grid-column: 2;
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
   line-height: 1.4;
   color: var(--mm-dim);
   display: -webkit-box;
@@ -458,13 +458,13 @@
   align-items: baseline;
   gap: 6px;
   white-space: nowrap;
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
   flex: none;
 }
 
 .mm-tick .k {
   font-family: var(--mm-mono);
-  font-size: 10px;
+  font-size: var(--mm-t-micro);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -498,12 +498,12 @@
  */
 .mm-tick .stale {
   color: var(--mm-faint);
-  font-size: 9.5px;
+  font-size: var(--mm-t-micro);
 }
 
 .mm-tick .halted {
   color: var(--mm-warn);
-  font-size: 9.5px;
+  font-size: var(--mm-t-micro);
   border: 1px dashed color-mix(in srgb, var(--mm-warn) 45%, transparent);
   border-radius: 4px;
   padding: 0 3px;
@@ -582,7 +582,7 @@
   background: none;
   color: var(--mm-tx);
   font: inherit;
-  font-size: 13.5px;
+  font-size: var(--mm-t-body);
 }
 
 .mm-search input::placeholder {
@@ -591,7 +591,7 @@
 
 .mm-search kbd {
   flex: none;
-  font-size: 10px;
+  font-size: var(--mm-t-micro);
   color: var(--mm-faint);
   border: 1px solid var(--mm-edge-2);
   border-radius: 4px;
@@ -617,7 +617,7 @@
 .mm-search-pop .none {
   margin: 0;
   padding: 10px 8px;
-  font-size: 13px;
+  font-size: var(--mm-t-body);
   color: var(--mm-dim);
 }
 
@@ -629,7 +629,7 @@
   padding: 8px;
   border-radius: 5px;
   text-align: left;
-  font-size: 13.5px;
+  font-size: var(--mm-t-body);
   color: var(--mm-tx);
 }
 
@@ -640,7 +640,7 @@
 .mm-search-pop .kind {
   flex: none;
   font-family: var(--mm-mono);
-  font-size: 9px;
+  font-size: var(--mm-t-micro);
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -663,7 +663,7 @@
 }
 
 .mm-search-pop .s {
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-dim);
   margin-left: auto;
   white-space: nowrap;
@@ -689,7 +689,7 @@
 }
 
 .mm-mine-book b {
-  font-size: 14px;
+  font-size: var(--mm-t-lead);
   font-weight: 700;
   color: var(--mm-tx);
   font-variant-numeric: tabular-nums;
@@ -698,7 +698,7 @@
 .mm-mine-book i {
   font-style: normal;
   font-family: var(--mm-mono);
-  font-size: 9.5px;
+  font-size: var(--mm-t-micro);
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--mm-faint);
@@ -711,7 +711,7 @@
 .mm-btn.sm {
   min-block-size: 32px;
   padding: 0 var(--mm-3);
-  font-size: 12.5px;
+  font-size: var(--mm-t-body);
 }
 
 @media (max-width: 620px) {

--- a/web/src/styles/shell.css
+++ b/web/src/styles/shell.css
@@ -305,8 +305,15 @@
   padding: 0;
 }
 
+/*
+ * SEPARATED BY SPACE, NOT BY A RULE.
+ *
+ * Each row drew a border AND carried a four-sided chip, which put about
+ * thirty edges into a 304px column — in green, rose, amber and blue at
+ * once. A row is one thing; it does not need an edge as well as a gap.
+ */
 .mm-alert {
-  border-bottom: 1px solid var(--mm-edge);
+  padding-bottom: var(--mm-3);
 }
 
 .mm-alert > a,
@@ -356,11 +363,18 @@
   white-space: nowrap;
 }
 
-/* The chip shrinks in the rail — it is a marker here, not a label. */
+/*
+ * A COLOURED WORD, NOT A PILL.
+ *
+ * At 8.5px inside a border this was a smudge that still cost four edges.
+ * The colour already carries the meaning; the box was carrying nothing.
+ */
 .mm-alert .mm-chip {
-  font-size: 8.5px;
-  padding: 1px 4px;
-  letter-spacing: 0.06em;
+  font-size: 9.5px;
+  padding: 0;
+  border: 0;
+  background: none;
+  letter-spacing: 0.08em;
   flex: none;
 }
 

--- a/web/src/styles/token.css
+++ b/web/src/styles/token.css
@@ -54,7 +54,7 @@
   display: flex;
   justify-content: space-between;
   margin-top: var(--mm-2);
-  font-size: 10.5px;
+  font-size: var(--mm-t-micro);
   color: var(--mm-faint);
 }
 
@@ -102,7 +102,7 @@
   padding: 0 var(--mm-2);
   /* Aligned under the name, not the avatar — it is that agent's speech. */
   padding-left: calc(28px + var(--mm-3) + var(--mm-2));
-  font-size: 13px;
+  font-size: var(--mm-t-body);
   line-height: 1.55;
   color: var(--mm-tx-2);
   display: -webkit-box;
@@ -146,13 +146,13 @@
 }
 
 .mm-holders .who .nm {
-  font-size: 13.5px;
+  font-size: var(--mm-t-body);
   font-weight: 650;
   color: var(--mm-tx);
 }
 
 .mm-holders .who .at {
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-dim);
 }
 
@@ -164,7 +164,7 @@
 .mm-holders .val {
   min-width: 84px;
   text-align: right;
-  font-size: 13px;
+  font-size: var(--mm-t-body);
   font-weight: 600;
   color: var(--mm-tx-2);
   white-space: nowrap;
@@ -173,7 +173,7 @@
 .mm-holders .basis {
   min-width: 104px;
   text-align: right;
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-faint);
   white-space: nowrap;
 }
@@ -181,7 +181,7 @@
 .mm-holders .chg {
   min-width: 60px;
   text-align: right;
-  font-size: 13px;
+  font-size: var(--mm-t-body);
   font-weight: 700;
 }
 
@@ -263,7 +263,7 @@
 }
 
 .mm-tok-cell dt {
-  font-size: 10px;
+  font-size: var(--mm-t-micro);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--mm-faint);
@@ -271,7 +271,7 @@
 
 .mm-tok-cell dd {
   margin: 2px 0 0;
-  font-size: 14.5px;
+  font-size: var(--mm-t-lead);
   font-weight: 650;
   color: var(--mm-tx);
   /* A figure broken over two lines reads as two numbers. */
@@ -282,7 +282,7 @@
 /* A word standing in for a figure — "no feed", "pre-graduation". It is an
    answer, not a number, so it does not wear the figure's weight. */
 .mm-tok-cell dd .soft {
-  font-size: 12.5px;
+  font-size: var(--mm-t-body);
   font-weight: 500;
   color: var(--mm-dim);
 }
@@ -319,7 +319,7 @@
 }
 
 .mm-tok-bar .lab {
-  font-size: 10px;
+  font-size: var(--mm-t-micro);
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--mm-faint);
@@ -327,7 +327,7 @@
 
 .mm-tok-bar .lo,
 .mm-tok-bar .hi {
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -372,7 +372,7 @@
   padding: var(--mm-3);
   border: 1px solid var(--mm-edge-2);
   border-radius: var(--mm-r-chip);
-  font-size: 12.5px;
+  font-size: var(--mm-t-body);
   line-height: 1.55;
   color: var(--mm-dim);
 }
@@ -392,7 +392,7 @@
   }
 
   .mm-tok-tf dt {
-    font-size: 9.5px;
+    font-size: var(--mm-t-micro);
   }
 
   .mm-tok-bar {
@@ -428,7 +428,7 @@
   align-items: baseline;
   gap: var(--mm-3);
   margin-top: var(--mm-2);
-  font-size: 10.5px;
+  font-size: var(--mm-t-micro);
   color: var(--mm-faint);
 }
 
@@ -441,7 +441,7 @@
    number, and without it the line reads as one. */
 .mm-priceline figcaption {
   margin-top: var(--mm-3);
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
   line-height: 1.5;
   color: var(--mm-faint);
 }
@@ -479,7 +479,7 @@
  */
 .mm-chart-note {
   margin: var(--mm-3) 0 0;
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
   line-height: 1.5;
   color: var(--mm-faint);
 }

--- a/web/src/styles/token.css
+++ b/web/src/styles/token.css
@@ -2,10 +2,16 @@
  * The token page. Scoped under .mm, enforced by styles/scoped.test.ts.
  */
 
+/*
+ * SPACE, NOT A RULE.
+ *
+ * Five full-width hairlines stacked down this page, plus one per holder row —
+ * sixteen rules on a ten-holder coin. A section is announced by its kicker and
+ * its gap; the line was saying the same thing a third time.
+ */
 .mm-tok-when,
 .mm-tok-holders {
-  padding: var(--mm-5) 0;
-  border-bottom: 1px solid var(--mm-edge);
+  padding: var(--mm-6) 0 var(--mm-5);
 }
 
 /* ── the entry timeline ──────────────────────────────────────────────────── */
@@ -66,8 +72,9 @@
   padding: 0;
 }
 
+/* No per-row rule: ten holders drew ten lines through the reasoning. */
 .mm-holders li {
-  border-bottom: 1px solid var(--mm-edge);
+  padding-bottom: var(--mm-2);
 }
 
 .mm-holders li > .row {
@@ -220,8 +227,15 @@
 
 /* ── the stat strip, the timeframe grid, the flow bars ────────────────────── */
 
-.mm-tok-facts,
-.mm-tok-flow {
+/*
+ * THE ONE RULE ON THE PAGE, under the figures at the top. It separates the
+ * market's account of this token from the agents' — everything below is
+ * spaced instead.
+ *
+ * .mm-tok-flow went with the border: nothing renders it. The component
+ * emits .mm-tok-flowbars, so this selector had been dead since it shipped.
+ */
+.mm-tok-facts {
   padding: var(--mm-5) 0;
   border-bottom: 1px solid var(--mm-edge);
 }
@@ -394,8 +408,7 @@
 /* ── the oracle's series ─────────────────────────────────────────────────── */
 
 .mm-tok-chart {
-  padding: var(--mm-5) 0;
-  border-bottom: 1px solid var(--mm-edge);
+  padding: var(--mm-6) 0 var(--mm-5);
 }
 
 .mm-priceline {

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -150,6 +150,26 @@ body {
   /* ── motion ──────────────────────────────────────────────────────────── */
   --mm-ease: cubic-bezier(0.2, 0.7, 0.3, 1);
   --mm-fast: 140ms;
+
+  /* ── type: one scale, seven steps ──────────────────────────────────────
+   *
+   * The .mm sheets had 27 distinct font sizes, nine of them fractional —
+   * 8.5, 9.5, 10.5, 11.5, 12.5, 13.5, 14.5 — each chosen once, in isolation,
+   * to look right next to whatever was beside it that day. The result reads
+   * as noise: a page where nothing is quite the same size as anything else
+   * has no hierarchy, only variety.
+   *
+   * Seven steps, and a rule for each. Anything at or above 24px is a DISPLAY
+   * size and keeps its own value: those are set against a pixel typeface and
+   * a canvas rather than against body copy.
+   */
+  --mm-t-micro: 10px; /* kickers, chips, axis labels — said, not read */
+  --mm-t-meta: 11.5px; /* captions, notes, the qualifying sentence */
+  --mm-t-body: 13px; /* rows, lists, holdings, the reasoning */
+  --mm-t-lead: 15px; /* emphasis, a figure that is not the figure */
+  --mm-t-head: 18px; /* a section's name, a card's title */
+  --mm-t-fig: 23px; /* a figure worth reading across the page */
+  --mm-t-hero: 30px; /* the one number a page exists to publish */
 }
 
 

--- a/web/src/styles/wall.css
+++ b/web/src/styles/wall.css
@@ -30,7 +30,7 @@
 
 .mm-wall-cap {
   padding: var(--mm-3) var(--mm-4);
-  font-size: 13px;
+  font-size: var(--mm-t-body);
   line-height: 1.4;
   letter-spacing: 0.02em;
   color: var(--mm-dim);
@@ -74,7 +74,7 @@
 
 .mm-wall-said b {
   display: block;
-  font-size: 15px;
+  font-size: var(--mm-t-lead);
   font-weight: 650;
   color: var(--mm-tx);
 }
@@ -82,7 +82,7 @@
 .mm-wall-said span {
   display: block;
   margin-top: 2px;
-  font-size: 13px;
+  font-size: var(--mm-t-body);
   line-height: 1.5;
   color: var(--mm-dim);
 }

--- a/web/src/styles/wall.css
+++ b/web/src/styles/wall.css
@@ -123,3 +123,17 @@
     gap: var(--mm-3);
   }
 }
+
+/*
+ * THE FIGURE WHEN NOTHING WAS TURNED BACK.
+ *
+ * --mm-warn means the wall said no, so a zero refusals count must not wear it —
+ * that would spend the hottest colour in the product on the wall having said
+ * nothing. The through-count is ordinary text.
+ *
+ * Never --mm-thru: tokens.css reserves white for the band canvas, where a white
+ * pixel means exactly one thing.
+ */
+.mm-wall-fig.quiet {
+  color: var(--mm-tx);
+}

--- a/web/src/styles/you.css
+++ b/web/src/styles/you.css
@@ -40,14 +40,14 @@
 
 .mm-status .head {
   margin: 0;
-  font-size: 14.5px;
+  font-size: var(--mm-t-lead);
   font-weight: 600;
   color: var(--mm-tx);
 }
 
 .mm-status .next {
   margin: 2px 0 0;
-  font-size: 13px;
+  font-size: var(--mm-t-body);
   line-height: 1.55;
   color: var(--mm-dim);
 }
@@ -77,7 +77,7 @@
 
 .mm-hero-pnl {
   margin-left: auto;
-  font-size: 13.5px;
+  font-size: var(--mm-t-body);
   font-weight: 700;
   text-align: right;
 }
@@ -91,7 +91,7 @@
 .mm-hero-pnl .flat {
   color: var(--mm-dim);
   font-weight: 600;
-  font-size: 12px;
+  font-size: var(--mm-t-meta);
 }
 
 .mm-hero .mm-spark {
@@ -115,7 +115,7 @@
 
 .mm-slice dd {
   margin: var(--mm-1) 0 0;
-  font-size: 16px;
+  font-size: var(--mm-t-lead);
   font-weight: 700;
   color: var(--mm-tx);
 }
@@ -143,7 +143,7 @@
   gap: var(--mm-2);
   padding: 7px 0;
   border-bottom: 1px solid var(--mm-edge);
-  font-size: 12.5px;
+  font-size: var(--mm-t-body);
   color: var(--mm-tx-2);
 }
 
@@ -153,7 +153,7 @@
 }
 
 .mm-tape .s {
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-dim);
 }
 
@@ -167,7 +167,7 @@
 }
 
 .mm-tape .w {
-  font-size: 11px;
+  font-size: var(--mm-t-meta);
   color: var(--mm-faint);
   white-space: nowrap;
 }
@@ -210,7 +210,7 @@
   background: color-mix(in srgb, var(--mm-down) 14%, transparent);
   color: var(--mm-down);
   font-family: var(--mm-sans);
-  font-size: 13.5px;
+  font-size: var(--mm-t-body);
   font-weight: 700;
   letter-spacing: 0.02em;
   transition: background-color var(--mm-fast) var(--mm-ease);
@@ -236,7 +236,7 @@
 
 .mm .killall-note {
   margin: var(--mm-2) 0 0;
-  font-size: 11.5px;
+  font-size: var(--mm-t-meta);
   line-height: 1.55;
   color: var(--mm-faint);
 }


### PR DESCRIPTION
The cleanliness pass from the earlier audit, executed. Nothing here changes a figure — it changes how many rectangles surround one.

## The one that was not merely untidy

The agent profile printed `tape.counts.turned` at 32px in the wall's amber **whatever it was**. So on an agent the wall had never stopped, the loudest, hottest element on the page was the number **0**, labelled "turned back in the last day".

`--mm-warn` means the wall said no. Spending it on a zero spends it on the wall having said nothing. When nothing was turned back the page now leads with what got through, in ordinary text — never `--mm-thru`, which `tokens.css` reserves for the band canvas. Verified on both branches: 27 refusals still reads amber, zero reads "3 got through".

## Hierarchy

The leaderboard had the most inverted hierarchy in the product — the returns it exists to publish were **14px**, one pixel above body copy, while the largest text was its own title. They are 23px tabular now.

The agent profile's four stat figures all sat at 19px, so the return was the same weight as the count of trades that were turned back. The first cell is 30px; the rest are 15px.

## Fewer lines

- The alerts rail drew a border per row **and** a four-sided chip per row — about thirty edges in a 304px column, in green, rose, amber and blue at once. Measured after: **12 edges**, no row rules, chips are coloured words.
- Twelve card boxes on `/tokens`, sixteen edges around four numbers on the agent profile, five stacked hairlines on the token page plus one per holder row, and the dotted leader in the refusal list.
- `.mm-tok-flow` had been dead since it shipped; the component emits `.mm-tok-flowbars`.

## One type scale

27 distinct sizes, nine fractional, became seven named tokens. 121 declarations mapped. Five hardcoded sizes remain and all five are display sizes set against a pixel typeface. The legacy sheets are untouched.

## Safety

Four load-bearing captions were **unpinned** and are now tested first, before anything was trimmed — the leaderboard's two-refusals explanation, the token page's book-coverage count, the oracle chart's axis clauses, and the unpriced-gas caveat. Each assertion names what the sentence prevents.

`.mm-readfail` keeps its box: its whole job is to look different from `.mm-note`, and stripping it would make *refused read* identical to *nothing there* across six surfaces.

1,807 tests, typecheck clean, production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)