### PR TITLE
/you: de-box the slices, and one section rhythm for every sheet

### DIFF
--- a/web/src/app/(app)/you/YouClient.tsx
+++ b/web/src/app/(app)/you/YouClient.tsx
@@ -281,7 +281,16 @@ export function YouClient() {
                       {p.token ? <Link href={`/t/${p.token}`}>{p.symbol}</Link> : p.symbol}
                     </span>
                     <span className="a mono">{money(Number(p.value_usdg ?? 0))}</span>
-                    {p.price_stale ? <span className="mm-chip warn">stale</span> : <span />}
+                    {/* QUIET, NOT WARN. --mm-warn is the wall saying no, and a
+                        price nobody has refreshed is not something the wall
+                        did. The token page already chips this case quietly. */}
+                    {p.price_stale ? (
+                      <span className="mm-chip quiet" title="This mark has not been refreshed recently">
+                        stale
+                      </span>
+                    ) : (
+                      <span />
+                    )}
                     <span />
                   </li>
                 ))}

--- a/web/src/styles/agent.css
+++ b/web/src/styles/agent.css
@@ -12,7 +12,7 @@
 /* Deliberately NOT --mm-warn. The wall band directly above is amber, and eight
    amber rows beneath it turn a masthead colour into a table treatment. */
 .mm-agent-lanes {
-  padding: var(--mm-4) 0 var(--mm-5);
+  padding: var(--mm-sec-y);
 }
 
 .mm-agent-lanes ul {
@@ -120,7 +120,7 @@
 }
 
 .mm-equity-wrap {
-  padding: var(--mm-6) 0 var(--mm-5);
+  padding: var(--mm-sec-y);
 }
 
 .mm-equity {
@@ -168,7 +168,7 @@
 
 .mm-holdings,
 .mm-agent-feed {
-  padding: var(--mm-5) 0;
+  padding: var(--mm-sec-y);
 }
 
 .mm-agent-feed {

--- a/web/src/styles/cards.css
+++ b/web/src/styles/cards.css
@@ -6,7 +6,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: var(--mm-3);
-  padding: var(--mm-4) 0;
+  padding: var(--mm-sec-y);
 }
 
 /*

--- a/web/src/styles/token.css
+++ b/web/src/styles/token.css
@@ -11,7 +11,7 @@
  */
 .mm-tok-when,
 .mm-tok-holders {
-  padding: var(--mm-6) 0 var(--mm-5);
+  padding: var(--mm-sec-y);
 }
 
 /* ── the entry timeline ──────────────────────────────────────────────────── */
@@ -236,7 +236,7 @@
  * emits .mm-tok-flowbars, so this selector had been dead since it shipped.
  */
 .mm-tok-facts {
-  padding: var(--mm-5) 0;
+  padding: var(--mm-sec-y);
   border-bottom: 1px solid var(--mm-edge);
 }
 
@@ -408,7 +408,7 @@
 /* ── the oracle's series ─────────────────────────────────────────────────── */
 
 .mm-tok-chart {
-  padding: var(--mm-6) 0 var(--mm-5);
+  padding: var(--mm-sec-y);
 }
 
 .mm-priceline {

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -147,6 +147,20 @@ body {
   --mm-band-h-sm: 132px;     /* the band on /, <860 */
   --mm-band-h-agent: 96px;   /* the still band on /a/<slug> */
 
+  /* ── vertical rhythm ───────────────────────────────────────────────────
+   *
+   * ONE SECTION SPACING, DEFINED ONCE.
+   *
+   * Eleven section rules across six sheets used six different paddings —
+   * 24/20, 20/20, 16/20, 16/16, 20/16, 12/16 — each chosen against whatever
+   * happened to sit above it. Read down a page they make the gaps look
+   * arbitrary, which is precisely what a rhythm is not.
+   *
+   * A shorthand in a custom property, so the sheets keep their own selectors
+   * and there is still exactly one place to change the spacing.
+   */
+  --mm-sec-y: var(--mm-6) 0 var(--mm-5);
+
   /* ── motion ──────────────────────────────────────────────────────────── */
   --mm-ease: cubic-bezier(0.2, 0.7, 0.3, 1);
   --mm-fast: 140ms;

--- a/web/src/styles/wall.css
+++ b/web/src/styles/wall.css
@@ -43,7 +43,7 @@
   display: flex;
   align-items: baseline;
   gap: var(--mm-4);
-  padding: var(--mm-5) 0 var(--mm-4);
+  padding: var(--mm-sec-y);
   border-bottom: 1px solid var(--mm-edge-2);
 }
 

--- a/web/src/styles/you.css
+++ b/web/src/styles/you.css
@@ -55,7 +55,7 @@
 /* ── the hero ────────────────────────────────────────────────────────────── */
 
 .mm-hero {
-  padding: var(--mm-4) 0 var(--mm-5);
+  padding: var(--mm-sec-y);
   border-bottom: 1px solid var(--mm-edge);
 }
 
@@ -106,11 +106,14 @@
   margin: var(--mm-4) 0 0;
 }
 
+/*
+ * NO BOXES. Three bordered tiles under a hero is twelve edges separating
+ * three numbers the grid already separates — and this page is the one the
+ * audit called the pattern the others should copy. It should not be the one
+ * still drawing them.
+ */
 .mm-slice {
-  padding: var(--mm-3);
-  border: 1px solid var(--mm-edge);
-  border-radius: var(--mm-r-chip);
-  background: var(--mm-surface);
+  padding: 0;
 }
 
 .mm-slice dd {
@@ -126,7 +129,7 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--mm-6);
-  padding: var(--mm-5) 0;
+  padding: var(--mm-sec-y);
   border-bottom: 1px solid var(--mm-edge);
 }
 
@@ -141,8 +144,8 @@
   grid-template-columns: minmax(0, 1fr) auto auto auto;
   align-items: center;
   gap: var(--mm-2);
+  /* Space, not a rule: a tape of twenty rows drew twenty lines. */
   padding: 7px 0;
-  border-bottom: 1px solid var(--mm-edge);
   font-size: var(--mm-t-body);
   color: var(--mm-tx-2);
 }
@@ -173,7 +176,7 @@
 }
 
 .mm-money {
-  padding: var(--mm-5) 0;
+  padding: var(--mm-sec-y);
 }
 
 /* ── 860 ─────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Closes the last two items on the cleanliness audit.

## One section spacing, defined once

Eleven section rules across six sheets used **six different paddings** — 24/20, 20/20, 16/20, 16/16, 20/16, 12/16. Each was chosen against whatever happened to sit above it *in that file*, so read down a page the gaps look arbitrary, which is precisely what a rhythm is not.

They are now one custom property:

```css
--mm-sec-y: var(--mm-6) 0 var(--mm-5);
```

A shorthand in a property rather than a shared class, so every sheet keeps its own selectors and there is still exactly one place to change the spacing.

The one section-looking padding left alone is `agent.css:193` — a holdings **row**, not a section. Giving a row a section's air would be applying the rule to the wrong thing.

## /you stops drawing boxes nobody else draws

The audit called `/you` the pattern the other pages should copy. It was still the one drawing rectangles:

- **`.mm-slice`** put a border, a radius and a surface tint around each of cash / vault / positions — twelve edges separating three numbers the grid already separates.
- **`.mm-tape li`** drew a rule under every row. A tape of twenty rows drew twenty lines to say what the row spacing says for free.

Both gone. Space does the work.

## A stale price is not the wall saying no

`YouClient.tsx` chipped a stale mark `warn` — the amber reserved for *an intent was refused*. Nobody refused anything; a price simply has not been refreshed. It is `quiet` now, with a `title` explaining it, matching how the token page has always chipped this case.

## Verification

- `npm test` — **1807 pass, 0 fail**
- `npm run typecheck` — clean
- `styles/scoped.test.ts` — 16/16, so every touched rule is still `.mm`-scoped
- Rendered against seeded data on `/you`, `/a/[key]`, `/t/[token]`, `/leaderboard` and `/tokens`; measured every section in the browser and confirmed all resolve to a single `24px 0 20px`, slices to `0`, tape rows to no border

🤖 Generated with [Claude Code](https://claude.com/claude-code)