### PR TITLE
Make the rail honest, then make it survive its own first operation

### DIFF
--- a/web/src/app/(app)/page.tsx
+++ b/web/src/app/(app)/page.tsx
@@ -28,8 +28,9 @@ export const revalidate = 30;
 
 export const metadata: Metadata = {
   title: "merrymen — agents that trade, and say why",
+  // No wire yet — see the note on OG_DESC in app/layout.tsx.
   description:
-    "AI trading agents on Robinhood Chain, thinking out loud. Read what they decided and why, and wire the ones worth listening to into your own agent.",
+    "AI trading agents on Robinhood Chain, thinking out loud. Read what they decided, why they decided it, and what happened next.",
 };
 
 export default async function FeedPage() {

--- a/web/src/app/(app)/you/YouClient.tsx
+++ b/web/src/app/(app)/you/YouClient.tsx
@@ -7,6 +7,7 @@ import { AgentAvatar } from "@/components/AgentAvatar";
 import { Sparkline } from "@/components/Sparkline";
 import { ThesisCard } from "@/components/ThesisCard";
 import { KillSwitch } from "@/components/KillSwitch";
+import { railNotices } from "@/lib/rail-notices";
 import { statusLine, type AgentSnapshot } from "@/lib/status-line";
 import { timeAgo } from "@/lib/time";
 import type { PublicThesis } from "@/lib/thesis";
@@ -186,6 +187,8 @@ export function YouClient() {
     (t) => (t.status === "rejected" || t.status === "reverted") && Date.parse(`${t.created_at}Z`) > today,
   ).length;
 
+  const rail = railNotices(feed?.events);
+
   const snap: AgentSnapshot = {
     name,
     mode: (grants?.mode as AgentSnapshot["mode"]) ?? "idle",
@@ -222,6 +225,34 @@ export function YouClient() {
             <p className="next">{status.next}</p>
           </div>
         </div>
+
+        {/* WHAT THE RAIL IS SAYING.
+
+            The worker has been writing `warn` events since it was built, /api/feed
+            has always returned them, and no surface in the product has ever
+            rendered one: the only consumer of `events` took `level === "err"`
+            for the status line and dropped the rest.
+
+            Among the messages that went nowhere is index.ts's "no bundler key —
+            this agent CANNOT trade live, and nothing it does will reach the
+            chain", whose own comment reads SAY IT WHERE THE OWNER WILL LOOK. It
+            was written, raised, stored, and filtered out of the only page that
+            reads events — so an audit of 1,311 intents and zero fills read as a
+            broken execution path, when the truth was that execution had never
+            been configured. */}
+        {rail.length > 0 && (
+          <section className="mm-rail" aria-label="Warnings from the trading rail">
+            <h2 className="mm-kicker">What the rail is saying</h2>
+            <ul>
+              {rail.map((e) => (
+                <li key={e.message}>
+                  <p>{e.message}</p>
+                  <span className="mono">{timeAgo(Date.parse(`${e.created_at}Z`) / 1000)}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
 
         <section className="mm-hero">
           <div className="mm-hero-top">

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -69,8 +69,14 @@ const jbmono = JetBrains_Mono({
 // the first thing anyone sees is other people's agents explaining themselves,
 // and deploying one is the second step rather than the pitch.
 const OG_TITLE = "merrymen — agents that trade, and say why";
+//
+// AND IT DESCRIBES WHAT IS BUILT. The previous version sold following and
+// wiring, neither of which exists in any form — no follow store, no API, no
+// tool, no button. A product whose entire pitch is that it will not publish a
+// figure it cannot source should not advertise a feature it cannot render.
+// Restore the second clause when the wire ships, not before.
 const OG_DESC =
-  "AI trading agents on Robinhood Chain, thinking out loud. Read what they decided and why, follow the ones worth listening to, and wire them into your own agent's thinking.";
+  "AI trading agents on Robinhood Chain, thinking out loud. Read what they decided, why they decided it, and what happened next.";
 
 export const metadata: Metadata = {
   // Absolute base for og:image + other relative metadata URLs (link previews

--- a/web/src/components/ThesisCard.tsx
+++ b/web/src/components/ThesisCard.tsx
@@ -16,7 +16,9 @@ import { AgentAvatar } from "@/components/AgentAvatar";
  * THE CARD IS NOT A LINK. There is no per-thesis id anywhere — decisions are
  * grouped by content over a 24h window, so a post is a group and not a row —
  * and faking a permalink would produce a URL that resolves to something else
- * tomorrow. Three real targets only: the agent, the token, and the wire.
+ * tomorrow. ONE real target: the agent. The token would need an address on
+ * PublicThesis, which carries only a symbol; the wire would need a follow graph,
+ * which is not built. This comment claimed all three.
  */
 
 const money = (n: number) =>

--- a/web/src/components/shell/nav.ts
+++ b/web/src/components/shell/nav.ts
@@ -6,9 +6,12 @@
  * width gave an unreadable label.
  *
  * The reference product's fifth pillar is Alerts — "real time notifications for
- * what the best are buying". Here that is the feed's Wired filter, which is the
- * same information and needs no push infrastructure. Real push sits on top of
- * the existing service worker later, and is not a reason to spend a tab now.
+ * what the best are buying". The plan is for that to become the feed's Wired
+ * filter, which would be the same information and need no push infrastructure.
+ * NEITHER IS BUILT: there is no Wired filter and no follow graph, so this
+ * paragraph currently justifies four tabs by pointing at a fifth thing that
+ * does not exist. It is still four tabs for the width reason above, which is
+ * the argument that actually holds.
  */
 export interface NavItem {
   href: string;

--- a/web/src/lib/rail-notices.test.ts
+++ b/web/src/lib/rail-notices.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { RAIL_LIMIT, railNotices, type WorkerEvent } from "./rail-notices";
+
+const w = (message: string, created_at = "2026-09-02 10:00:00"): WorkerEvent => ({
+  level: "warn",
+  message,
+  created_at,
+});
+
+describe("railNotices — what the owner finally gets to see", () => {
+  it("keeps warnings and drops everything else", () => {
+    // `err` already has a home: it becomes the status line's lastError. `ok` is
+    // the tape. This block exists for the level that had no reader at all.
+    const out = railNotices([
+      { level: "ok", message: "armed", created_at: "2026-09-02 10:00:00" },
+      w("no bundler key — this agent CANNOT trade live"),
+      { level: "err", message: "boom", created_at: "2026-09-02 10:00:00" },
+    ]);
+    assert.deepEqual(
+      out.map((n) => n.message),
+      ["no bundler key — this agent CANNOT trade live"],
+    );
+  });
+
+  it("DEDUPES BY MESSAGE — an agent that restarts hourly says it hourly", () => {
+    // The reason this function exists rather than a .filter() in the JSX. These
+    // are written once per arm, not once per condition, so twenty restarts turn
+    // one warning into twenty rows and bury the two other things that are wrong.
+    const out = railNotices([
+      w("no bundler key", "2026-09-02 12:00:00"),
+      w("no bundler key", "2026-09-02 11:00:00"),
+      w("this account does not exist on chain 4663 yet", "2026-09-02 11:00:00"),
+      w("no bundler key", "2026-09-02 10:00:00"),
+    ]);
+    assert.deepEqual(
+      out.map((n) => n.message),
+      ["no bundler key", "this account does not exist on chain 4663 yet"],
+    );
+  });
+
+  it("shows the MOST RECENT time it was said, not the first", () => {
+    // Follows from taking the first sighting under the API's newest-first order.
+    // The other choice — earliest — would date a live problem to last week.
+    const out = railNotices([w("still broken", "2026-09-02 12:00:00"), w("still broken", "2026-08-30 09:00:00")]);
+    assert.equal(out[0]!.created_at, "2026-09-02 12:00:00");
+  });
+
+  it("caps the list, counting DISTINCT messages", () => {
+    // The cap is on what is rendered, so it has to be applied after the dedupe.
+    // Applied before, a repeated warning would spend the whole budget on itself.
+    const events = [w("a"), w("a"), w("a"), w("b"), w("c"), w("d")];
+    assert.deepEqual(
+      railNotices(events).map((n) => n.message),
+      ["a", "b", "c"],
+    );
+    assert.equal(RAIL_LIMIT, 3);
+  });
+
+  it("survives an absent events array rather than throwing into a blank page", () => {
+    // /api/feed omits `events` entirely on the no-ledger path.
+    assert.deepEqual(railNotices(undefined), []);
+    assert.deepEqual(railNotices(null), []);
+    assert.deepEqual(railNotices([]), []);
+    assert.deepEqual(railNotices([w("a")], 0), []);
+  });
+});
+
+describe("the page actually renders them", () => {
+  it("YouClient reads railNotices and not a bare level filter", () => {
+    // THE HALF THAT WAS MISSING LAST TIME. A pure function with tests proves the
+    // rule; it does not prove anyone calls it, and the bug this whole block
+    // fixes was a call site that filtered events down to one level and dropped
+    // the rest. So pin the call.
+    const src = readFileSync(new URL("../app/(app)/you/YouClient.tsx", import.meta.url), "utf8");
+    assert.match(src, /railNotices\(/, "the page must go through the tested rule");
+    assert.match(src, /mm-rail/, "and must have somewhere to put the result");
+  });
+});

--- a/web/src/lib/rail-notices.ts
+++ b/web/src/lib/rail-notices.ts
@@ -1,0 +1,62 @@
+/**
+ * THE WARNINGS NOBODY HAS EVER SEEN.
+ *
+ * The worker has written `warn`-level events since it was built, and `/api/feed`
+ * has always returned forty of them. No surface in the product has ever rendered
+ * one: the single consumer of `events` picked `level === "err"` for the status
+ * line and dropped everything else on the floor.
+ *
+ * What went over the side matters. `index.ts` raises "no bundler key — this
+ * agent CANNOT trade live, and nothing it does will reach the chain" at exactly
+ * the moment that becomes true, under a comment reading SAY IT WHERE THE OWNER
+ * WILL LOOK. It was written, raised, stored, and filtered out of the only page
+ * that reads events — so an audit of 1,311 intents and zero fills read as a
+ * broken execution path, when the truth was that execution had never been
+ * configured at all.
+ *
+ * Pure, and separated from the component, so the two rules below are pinned by a
+ * test rather than by whoever next edits the JSX.
+ */
+
+export interface WorkerEvent {
+  level: string;
+  message: string;
+  created_at: string;
+}
+
+export interface RailNotice {
+  message: string;
+  created_at: string;
+}
+
+/** How many to show. Three fits the block without turning it into a log. */
+export const RAIL_LIMIT = 3;
+
+/**
+ * The distinct warnings worth putting in front of the owner, newest first.
+ *
+ * DEDUPED BY MESSAGE, because these are written once per ARM rather than once
+ * per condition. An agent that restarts hourly raises the same sentence twenty
+ * times, and an undeduped list would show one warning twenty times over instead
+ * of the three different things that are actually wrong — which is the same
+ * failure as showing none, arrived at from the other direction.
+ *
+ * Takes the FIRST sighting of each message and relies on the caller's newest-
+ * first order (`/api/feed` sorts `created_at DESC, id DESC`), so the timestamp
+ * shown is the most recent time the worker said it, not the first.
+ */
+export function railNotices(
+  events: readonly WorkerEvent[] | null | undefined,
+  limit: number = RAIL_LIMIT,
+): RailNotice[] {
+  if (!events || limit <= 0) return [];
+  const seen = new Set<string>();
+  const out: RailNotice[] = [];
+  for (const e of events) {
+    if (e.level !== "warn" || seen.has(e.message)) continue;
+    seen.add(e.message);
+    out.push({ message: e.message, created_at: e.created_at });
+    if (out.length === limit) break;
+  }
+  return out;
+}

--- a/web/src/lib/thesis.ts
+++ b/web/src/lib/thesis.ts
@@ -1,13 +1,15 @@
 /**
  * The publication gate, re-exported.
  *
- * The policy itself moved to `worker/src/thesis-policy.ts` when the
- * orchestrator became a second reader of it — it materialises each child's
- * followed theses into a file the agent's desk reads, and what it writes has to
- * be exactly what this feed publishes. The worker cannot import from `web/src`,
- * so the module moved rather than being copied: two copies of a publication
- * policy drift, and the drift is invisible until something private lands on a
- * page.
+ * The policy itself moved to `worker/src/thesis-policy.ts` ahead of a second
+ * reader: the orchestrator is to materialise each child's followed theses into
+ * a file the agent's desk reads, and what it writes has to be exactly what this
+ * feed publishes. The worker cannot import from `web/src`, so the module moved
+ * rather than being copied: two copies of a publication policy drift, and the
+ * drift is invisible until something private lands on a page.
+ *
+ * The follow graph is not built. Nothing reads the worker-side copy except this
+ * re-export, and this comment said otherwise for three weeks.
  *
  * This file exists so every `@/lib/thesis` import in the web tree keeps
  * working. Nothing here may add behaviour — a check that lives on this side

--- a/web/src/styles/you.css
+++ b/web/src/styles/you.css
@@ -54,6 +54,49 @@
 
 /* ── the hero ────────────────────────────────────────────────────────────── */
 
+/*
+ * The rail's own warnings. A LIST, not a banner: the messages that matter here
+ * arrive together — no bundler key, an account that has never deployed, a grant
+ * on the wrong chain — and each one names a different missing thing.
+ *
+ * --mm-warn earns its place. The strict reading of that token is "the wall said
+ * no", and these are not the wall; but every message in this block is the rail
+ * declining to carry a trade, which is the same news to the person reading it,
+ * and .mm-status.waiting already spends the token this way one section above.
+ */
+.mm-rail {
+  padding: var(--mm-sec-y);
+  border-bottom: 1px solid var(--mm-edge);
+}
+
+.mm-rail ul {
+  display: grid;
+  gap: var(--mm-2);
+  margin-top: var(--mm-2);
+}
+
+.mm-rail li {
+  display: flex;
+  align-items: baseline;
+  gap: var(--mm-3);
+  padding-left: var(--mm-3);
+  border-left: 2px solid var(--mm-warn);
+}
+
+.mm-rail li p {
+  flex: 1;
+  margin: 0;
+  font-size: var(--mm-t-body);
+  line-height: 1.55;
+  color: var(--mm-tx-2);
+}
+
+.mm-rail li span {
+  flex: none;
+  font-size: var(--mm-t-meta);
+  color: var(--mm-faint);
+}
+
 .mm-hero {
   padding: var(--mm-sec-y);
   border-bottom: 1px solid var(--mm-edge);

--- a/worker/src/bounded-read.test.ts
+++ b/worker/src/bounded-read.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { MAX_READ_BYTES, readBounded, readBoundedJson } from "./bounded-read";
+
+/**
+ * The property worth testing is not "it reports the size". It is that it STOPS.
+ * A check that buffers the whole body and then measures it answers the question
+ * after the memory is already spent, which is the failure being prevented.
+ */
+
+/** A response whose body arrives in chunks and counts how many were pulled. */
+function streaming(chunks: readonly string[], headers: Record<string, string> = {}) {
+  let i = 0;
+  let cancelled = false;
+  const enc = new TextEncoder();
+  return {
+    pulled: () => i,
+    wasCancelled: () => cancelled,
+    res: {
+      headers: { get: (n: string) => headers[n.toLowerCase()] ?? null },
+      body: {
+        getReader: () => ({
+          read: async () =>
+            i < chunks.length ? { done: false, value: enc.encode(chunks[i++]!) } : { done: true },
+          cancel: async () => {
+            cancelled = true;
+          },
+        }),
+      },
+      text: async () => chunks.join(""),
+    },
+  };
+}
+
+/** A response with no stream at all — the fallback path. */
+const buffered = (text: string, headers: Record<string, string> = {}) => ({
+  headers: { get: (n: string) => headers[n.toLowerCase()] ?? null },
+  text: async () => text,
+});
+
+test("an ordinary answer comes back whole", async () => {
+  const s = streaming(["{\"a\":", "1}"]);
+  const r = await readBounded(s.res, 1000);
+  assert.equal(r.ok, true);
+  assert.equal(r.ok === true ? r.text : null, '{"a":1}');
+  assert.equal(r.ok === true ? r.bytes : null, 7);
+  assert.equal(s.wasCancelled(), false);
+});
+
+test("EXACTLY AT THE LIMIT IS FINE; ONE BYTE PAST IT IS NOT", async () => {
+  // The boundary is the whole specification, so it is asserted from both sides.
+  const at = await readBounded(streaming(["a".repeat(64)]).res, 64);
+  assert.equal(at.ok, true);
+
+  const over = await readBounded(streaming(["a".repeat(65)]).res, 64);
+  assert.equal(over.ok, false);
+  assert.equal(over.ok === false ? over.rule : null, "too-large");
+  assert.equal(over.ok === false ? over.limit : null, 64);
+});
+
+test("IT STOPS PULLING — the point of the whole module", async () => {
+  // Ten chunks of ten bytes against a limit of 25. A reader that buffered first
+  // and measured after would pull all ten and report 100. This must stop on the
+  // third, having seen 30, and abandon the rest.
+  const s = streaming(Array.from({ length: 10 }, () => "0123456789"));
+  const r = await readBounded(s.res, 25);
+  assert.equal(r.ok, false);
+  assert.equal(r.ok === false ? r.bytes : null, 30, "stopped as soon as the count crossed");
+  assert.equal(s.pulled(), 3, "three chunks read, not ten");
+  assert.equal(s.wasCancelled(), true, "and the rest of the response was abandoned");
+});
+
+test("a declared content-length can save the work but is never trusted to allow it", async () => {
+  // Cheap exit when the server volunteers a damning number.
+  const declared = streaming(["small"], { "content-length": "999999999" });
+  const r = await readBounded(declared.res, 1000);
+  assert.equal(r.ok, false);
+  assert.equal(declared.pulled(), 0, "refused without reading a byte");
+
+  // AND A LYING HEADER CHANGES NOTHING. This is the case that matters: the one
+  // lane serving attacker-chosen pages is also the one that can set this.
+  const liar = streaming(["a".repeat(500)], { "content-length": "1" });
+  const w = await readBounded(liar.res, 100);
+  assert.equal(w.ok, false, "the stream is the check, not the header");
+  assert.equal(w.ok === false ? w.bytes : null, 500);
+
+  // An absent header is the ordinary case for a chunked response.
+  assert.equal((await readBounded(streaming(["ok"]).res, 100)).ok, true);
+});
+
+test("a response with no stream still gets bounded", async () => {
+  // Some fetch implementations, and every test double. Weaker by nature — there
+  // is nothing to stop pulling — but it must not silently become unbounded.
+  assert.equal((await readBounded(buffered("a".repeat(50)), 100)).ok, true);
+  const over = await readBounded(buffered("a".repeat(500)), 100);
+  assert.equal(over.ok, false);
+  assert.equal(over.ok === false ? over.bytes : null, 500);
+});
+
+test("bytes are counted as BYTES, not as characters", async () => {
+  // A multi-byte character counts for what it costs. Measuring `text.length`
+  // would let a UTF-8 body run to three times the intended ceiling.
+  const emoji = "🙂"; // 4 bytes, 2 UTF-16 code units
+  const r = await readBounded(streaming([emoji.repeat(10)]).res, 39);
+  assert.equal(r.ok, false, "40 bytes must not pass a 39-byte limit");
+  assert.equal((await readBounded(streaming([emoji.repeat(10)]).res, 40)).ok, true);
+});
+
+test("a refusal says it knows nothing, rather than implying emptiness", async () => {
+  // The honesty rule this repo applies everywhere else: "could not read" is not
+  // "there was nothing there", and a caller that confuses them publishes a
+  // confident zero.
+  const r = await readBounded(streaming(["a".repeat(500)]).res, 10);
+  assert.equal(r.ok, false);
+  assert.match(r.ok === false ? r.detail : "", /not the same as it being empty/);
+});
+
+test("readBoundedJson refuses an over-long body and unparseable JSON alike", async () => {
+  const good = await readBoundedJson<{ a: number }>(streaming(['{"a":1}']).res, 1000);
+  assert.deepEqual(good, { ok: true, value: { a: 1 } });
+
+  assert.equal((await readBoundedJson(streaming(["a".repeat(500)]).res, 10)).ok, false);
+  assert.equal((await readBoundedJson(streaming(["not json"]).res, 1000)).ok, false);
+});
+
+test("the default ceiling leaves real feeds far below it", async () => {
+  // A GeckoTerminal page is tens of kilobytes and a Rialto quote is smaller, so
+  // the bound must never be the reason a legitimate read fails.
+  assert.equal(MAX_READ_BYTES, 2_000_000);
+  assert.equal((await readBounded(streaming(["x".repeat(200_000)]).res)).ok, true);
+});
+
+test("EVERY VENUE READ GOES THROUGH THE BOUND", () => {
+  // A helper nothing calls is worth nothing. Before this, `worker/src` and
+  // `packages/core/src` contained no maxBytes, content-length or byteLength
+  // check of any kind, so one hostile or broken feed could decide this worker's
+  // memory ceiling — and the worker is a long-lived process holding an armed
+  // session key.
+  const at = (p: string) => readFileSync(new URL(p, import.meta.url), "utf8");
+  const lanes = [
+    "./venues/geckoterminal.ts",
+    "./venues/bitquery.ts",
+    "./venues/research.ts",
+    "./venues/rialto.ts",
+  ];
+  for (const lane of lanes) {
+    const src = at(lane);
+    // `[<(]` because most of these call sites are generic —
+    // `readBoundedJson<{ data?: unknown[] }>(res)` — so a regex demanding an
+    // immediate paren fails on code that is perfectly correct.
+    assert.match(src, /readBounded(Json)?[<(]/, `${lane} must read through the bound`);
+    // And must not have kept the unbounded read beside it. Comments are stripped
+    // first: several of these files explain the change in prose that names the
+    // very call being forbidden.
+    const code = src
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .split("\n")
+      .filter((l) => !l.trim().startsWith("//"))
+      .join("\n");
+    assert.doesNotMatch(code, /await (res|r)\.json\(\)/, `${lane} still has an unbounded json read`);
+  }
+});

--- a/worker/src/bounded-read.ts
+++ b/worker/src/bounded-read.ts
@@ -1,0 +1,117 @@
+/**
+ * HOW MUCH OF A STRANGER'S ANSWER ARE WE WILLING TO HOLD?
+ *
+ * Nothing in `worker/src` or `packages/core/src` has ever asked. Every venue
+ * read is `await res.json()` or `await res.text()`, which buffers whatever
+ * arrives — so a hostile or merely broken feed decides this worker's memory
+ * ceiling, and the worker is a long-lived process holding an armed session key.
+ *
+ * The reads are not obscure. GeckoTerminal's trending feed, Bitquery's GraphQL
+ * endpoint, the research reader (which fetches pages an ATTACKER chose, via
+ * `read_link`), Rialto's quote API, and the MCP transport. Four of the five are
+ * third parties and one of them serves arbitrary web pages.
+ *
+ * THE CAP IS ENFORCED WHILE READING, NOT MEASURED AFTERWARDS. Checking
+ * `text.length` once the body is in hand answers the question after the damage
+ * is done; the only useful version stops pulling. So this streams, counts, and
+ * abandons the response the moment the count exceeds the limit — the property
+ * the test pins by feeding it exactly `maxBytes + 1`.
+ *
+ * `content-length` is consulted as a cheap early exit and TRUSTED FOR NOTHING.
+ * It is absent on chunked responses and is attacker-supplied on the one lane
+ * that matters, so it can save work but must never be the thing that decides.
+ *
+ * Reimplemented from Vex's bounded reader, with its author's permission.
+ */
+
+/**
+ * 2 MB. Chosen against what these endpoints legitimately return — a
+ * GeckoTerminal page is tens of kilobytes, a Rialto quote is smaller, a research
+ * page read is capped in characters downstream — with two orders of magnitude of
+ * slack so a bound is never the reason a real read fails.
+ *
+ * Vex measured a live token name of 34,090 characters. The interesting failures
+ * on this surface are three orders of magnitude below this line; this exists for
+ * the response that never ends.
+ */
+export const MAX_READ_BYTES = 2_000_000;
+
+export type BoundedRead =
+  | { ok: true; text: string; bytes: number }
+  | { ok: false; rule: "too-large"; bytes: number; limit: number; detail: string };
+
+/**
+ * Read a response body, refusing rather than buffering past `maxBytes`.
+ *
+ * A refusal is returned, not thrown, so every caller books it the way it books
+ * an unreadable feed — this must never become the reason a tick dies, and an
+ * over-long answer is a fact about the answer rather than an error in us.
+ */
+export async function readBounded(
+  res: { headers: { get(name: string): string | null }; body?: unknown; text(): Promise<string> },
+  maxBytes: number = MAX_READ_BYTES,
+): Promise<BoundedRead> {
+  const tooLarge = (bytes: number): BoundedRead => ({
+    ok: false,
+    rule: "too-large",
+    bytes,
+    limit: maxBytes,
+    detail:
+      `the response was at least ${bytes} bytes, past the ${maxBytes}-byte limit — abandoned unread. ` +
+      `Nothing about the content is known, which is not the same as it being empty.`,
+  });
+
+  // Cheap exit when the server volunteers a number and the number is damning.
+  // A missing or lying header changes nothing: the stream below is the check.
+  const declared = Number(res.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > maxBytes) return tooLarge(declared);
+
+  const body = res.body as
+    | { getReader(): { read(): Promise<{ done: boolean; value?: Uint8Array }>; cancel(): Promise<void> } }
+    | null
+    | undefined;
+  // No stream to read — some fetch implementations and every test double. Fall
+  // back to the buffered read and bound what we were handed. Weaker, and it is
+  // the weaker case for a reason: there is nothing to stop pulling.
+  if (!body || typeof body.getReader !== "function") {
+    const text = await res.text();
+    const bytes = Buffer.byteLength(text, "utf8");
+    return bytes > maxBytes ? tooLarge(bytes) : { ok: true, text, bytes };
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    bytes += value.byteLength;
+    // STOP PULLING. Not "note that it was too big afterwards" — by then the
+    // memory is already spent, which is the entire failure being prevented.
+    if (bytes > maxBytes) {
+      await reader.cancel().catch(() => {});
+      return tooLarge(bytes);
+    }
+    chunks.push(value);
+  }
+  return { ok: true, text: Buffer.concat(chunks).toString("utf8"), bytes };
+}
+
+/**
+ * The same read, parsed. Returns `null` on a refusal OR on malformed JSON,
+ * because both mean the same thing to a caller: this feed said nothing usable.
+ * Callers that need to tell them apart should use `readBounded` directly.
+ */
+export async function readBoundedJson<T>(
+  res: Parameters<typeof readBounded>[0],
+  maxBytes: number = MAX_READ_BYTES,
+): Promise<{ ok: true; value: T } | { ok: false; detail: string }> {
+  const r = await readBounded(res, maxBytes);
+  if (!r.ok) return { ok: false, detail: r.detail };
+  try {
+    return { ok: true, value: JSON.parse(r.text) as T };
+  } catch (e) {
+    return { ok: false, detail: e instanceof Error ? e.message : "unparseable JSON" };
+  }
+}

--- a/worker/src/exec-mode.test.ts
+++ b/worker/src/exec-mode.test.ts
@@ -24,6 +24,7 @@ const base: ExecInputs = {
   executor: true,
   chainId: TRADEABLE_CHAIN_ID,
   cashUsdg: 100_000_000n,
+  deadPolicy: false,
   paperTradingEnabled: true,
 };
 
@@ -99,6 +100,17 @@ test("paper OFF refuses — it does not fall through to the live rail", () => {
     rule: "no-cash",
   });
   assert.deepEqual(execModeOf({ ...base, armed: false }), { mode: "refuse", rule: "not-armed" });
+  // Named ahead of no-executor, no-cash and wrong-chain, because it is the only
+  // one of the five that funding, a bundler key and a chain switch all fail to
+  // fix. A signature is frozen; only re-signing clears it.
+  assert.deepEqual(execModeOf({ ...base, deadPolicy: true, paperTradingEnabled: false }), {
+    mode: "refuse",
+    rule: "dead-policy",
+  });
+  assert.deepEqual(
+    execModeOf({ ...base, deadPolicy: true, executor: false, paperTradingEnabled: false }),
+    { mode: "refuse", rule: "dead-policy" },
+  );
 });
 
 test("the refusal names the most fundamental broken leg first", () => {
@@ -123,17 +135,31 @@ test("every input lands in exactly one mode — there is no fourth state", () =>
     for (const executor of [true, false]) {
       for (const chainId of [TRADEABLE_CHAIN_ID, 46630]) {
         for (const cashUsdg of [100_000_000n, 0n, null]) {
-          for (const paperTradingEnabled of [true, false]) {
-            const a: ExecInputs = { armed, executor, chainId, cashUsdg, paperTradingEnabled };
-            const m = execModeOf(a);
-            assert.ok(
-              m.mode === "paper" || m.mode === "live" || m.mode === "refuse",
-              "unreachable mode",
-            );
-            // live and canTradeForReal are the same claim; if they ever part,
-            // the fork's executor invariant becomes reachable at runtime.
-            assert.equal(m.mode === "live", canTradeForReal(a));
-            modes.add(m.mode);
+          for (const deadPolicy of [false, true]) {
+            for (const paperTradingEnabled of [true, false]) {
+              const a: ExecInputs = {
+                armed,
+                executor,
+                chainId,
+                cashUsdg,
+                deadPolicy,
+                paperTradingEnabled,
+              };
+              const m = execModeOf(a);
+              assert.ok(
+                m.mode === "paper" || m.mode === "live" || m.mode === "refuse",
+                "unreachable mode",
+              );
+              // live and canTradeForReal are the same claim; if they ever part,
+              // the fork's executor invariant becomes reachable at runtime.
+              assert.equal(m.mode === "live", canTradeForReal(a));
+              // A DEAD POLICY IS NEVER LIVE, whatever else is true. This is the
+              // whole point of the field: the grant that carries it arms, prices
+              // and looks healthy, and every operation it signs fails validation
+              // against an address with no code.
+              if (deadPolicy) assert.notEqual(m.mode, "live", "a dead policy cannot trade");
+              modes.add(m.mode);
+            }
           }
         }
       }

--- a/worker/src/exec-mode.ts
+++ b/worker/src/exec-mode.ts
@@ -28,7 +28,7 @@
  */
 import { TRADEABLE_CHAIN_ID } from "./preflight";
 
-export type RefuseRule = "not-armed" | "no-executor" | "wrong-chain" | "no-cash";
+export type RefuseRule = "not-armed" | "dead-policy" | "no-executor" | "wrong-chain" | "no-cash";
 
 export type ExecMode =
   | { mode: "paper" }
@@ -50,6 +50,22 @@ export interface ExecInputs {
    * only a read zero counts.
    */
   cashUsdg: bigint | null;
+  /**
+   * Does the signature seal a policy contract with no bytecode on this chain?
+   *
+   * A GRANT CAN BE DEAD ON ARRIVAL, AND NOTHING DOWNSTREAM CAN TELL. Every key
+   * signed before 2026-08-30 installed a rate-limit policy whose contract has
+   * zero bytes on 4663 and 46630 alike. Kernel calls `checkUserOpPolicy`
+   * expecting a uint256; a call to a codeless address succeeds with empty
+   * returndata, so validation fails — every operation, forever.
+   *
+   * This is the only leg here that funding, a bundler key and a chain switch all
+   * fail to fix, because a signature is frozen. It is also the only one that was
+   * previously detected and then ignored: the arm path wrote one `err` and
+   * carried on, so the agent armed, priced, and refused every trade for a reason
+   * that named nothing.
+   */
+  deadPolicy: boolean;
   /** Permission to simulate. NOT a request to: it never moves a working agent. */
   paperTradingEnabled: boolean;
 }
@@ -57,7 +73,9 @@ export interface ExecInputs {
 /** Could this agent put a real order on-chain right now? */
 export function canTradeForReal(a: ExecInputs): boolean {
   const readAsBroke = a.cashUsdg !== null && a.cashUsdg === 0n;
-  return a.armed && a.executor && a.chainId === TRADEABLE_CHAIN_ID && !readAsBroke;
+  return (
+    a.armed && a.executor && a.chainId === TRADEABLE_CHAIN_ID && !readAsBroke && !a.deadPolicy
+  );
 }
 
 /**
@@ -79,9 +97,12 @@ export function execModeOf(a: ExecInputs): ExecMode {
   // the owner has allowed it — that is the whole point of paper.
   if (a.paperTradingEnabled) return { mode: "paper" };
 
-  // Paper is off, so say which leg failed. Ordered most-fundamental first: a
-  // missing signer cannot be fixed by funding, and a dead chain cannot be fixed
-  // by either.
+  // Paper is off, so say which leg failed. Ordered most-fundamental first, by
+  // what the remedy costs: a dead policy is fixable ONLY by re-signing — not by
+  // funding, not by a bundler key, not by switching chain — so it is named
+  // ahead of all three. A missing signer cannot be fixed by funding, and a dead
+  // chain cannot be fixed by either.
+  if (a.deadPolicy) return { mode: "refuse", rule: "dead-policy" };
   if (!a.executor) return { mode: "refuse", rule: "no-executor" };
   if (a.chainId !== TRADEABLE_CHAIN_ID) return { mode: "refuse", rule: "wrong-chain" };
   return { mode: "refuse", rule: "no-cash" };

--- a/worker/src/executor.ts
+++ b/worker/src/executor.ts
@@ -20,7 +20,7 @@ import { KERNEL_V3_3, getEntryPoint } from "@zerodev/sdk/constants";
 import { deserializeFlaggedPermissionAccount } from "./session-account";
 import { WALL_POLICY_FLAG } from "../../packages/core/src/index";
 import { userOpGasConfig } from "./gas";
-import { boundGas, type UserOpGas } from "./gas-limits";
+import { boundGas, DEPLOY_GAS_BOUNDS, GAS_BOUNDS, type UserOpGas } from "./gas-limits";
 
 export interface Call {
   to: `0x${string}`;
@@ -171,6 +171,33 @@ export async function createAgentExecutor(opts: {
     userOperation: userOpGasConfig(publicClient, opts.bundlerUrl),
   });
 
+  /**
+   * Has this account ever operated?
+   *
+   * Asked here rather than passed in, because the answer CHANGES and the caller
+   * reads it once at arm: an `accountDeployed: false` threaded down from arm
+   * time would still say false for every later op of that arm, leaving them all
+   * under the wide deploy ceiling. That is a guard turning itself off silently.
+   *
+   * One read, memoised, and only on the first execute of a process that has an
+   * executor at all. A FAILED READ ANSWERS "not deployed", which is the safe
+   * direction here and the opposite of the rule elsewhere in this repo: being
+   * wrong that way widens a pre-sign ceiling for one operation, while being
+   * wrong the other way refuses the operation outright. The bound still holds —
+   * DEPLOY_GAS_BOUNDS is a ceiling, not an exemption.
+   */
+  let deployed: boolean | null = null;
+  const isDeployed = async (): Promise<boolean> => {
+    if (deployed !== null) return deployed;
+    try {
+      const code = await publicClient.getCode({ address: account.address });
+      deployed = code !== undefined && code !== "0x";
+    } catch {
+      deployed = false;
+    }
+    return deployed;
+  };
+
   return {
     address: account.address,
     async execute(calls: Call[], hooks?: ExecuteHooks) {
@@ -238,7 +265,10 @@ export async function createAgentExecutor(opts: {
       // Only probe a second time when the first succeeded: a null first is
       // already a refusal, and asking again would just be slower.
       const second = first ? await estimate() : null;
-      const bounded = boundGas(first, second);
+      // WHICH CEILING APPLIES DEPENDS ON WHETHER THIS ACCOUNT EXISTS YET.
+      // See DEPLOY_GAS_BOUNDS: the first op also deploys the account and enables
+      // the permission validator, and the steady-state ceiling would refuse it.
+      const bounded = boundGas(first, second, (await isDeployed()) ? GAS_BOUNDS : DEPLOY_GAS_BOUNDS);
       if (!bounded.ok) {
         // BEFORE the send, so nothing is spent and no 'submitted' row exists.
         // This is a pre-broadcast rejection in the same shape as a policy one.
@@ -269,6 +299,12 @@ export async function createAgentExecutor(opts: {
         // Explicit, so prepareUserOperation uses these instead of estimating.
         ...bounded.gas,
       } as never);
+      // Whatever happens to this op from here — landed, reverted, unresolved —
+      // the bundler accepted it, so the account is deployed or is being deployed
+      // by it. The wide deploy ceiling has done its job and must not apply to the
+      // next one; a stale `false` would leave every op of this arm loosely
+      // bounded, which is the guard quietly turning itself off.
+      deployed = true;
       // DURABILITY BEFORE THE WAIT. Between here and the ledger write in
       // index.ts sits a receipt wait, a network price call and a DB round
       // trip; nothing was written durably across any of it, so a SIGTERM from

--- a/worker/src/executor.ts
+++ b/worker/src/executor.ts
@@ -20,6 +20,7 @@ import { KERNEL_V3_3, getEntryPoint } from "@zerodev/sdk/constants";
 import { deserializeFlaggedPermissionAccount } from "./session-account";
 import { WALL_POLICY_FLAG } from "../../packages/core/src/index";
 import { userOpGasConfig } from "./gas";
+import { getUserOperationHash } from "viem/account-abstraction";
 import { boundGas, DEPLOY_GAS_BOUNDS, GAS_BOUNDS, type UserOpGas } from "./gas-limits";
 
 export interface Call {
@@ -92,6 +93,31 @@ export class UserOpUnresolved extends Error {
 }
 
 /**
+ * REFUSING TO BROADCAST UNTRACKED.
+ *
+ * The durable pre-broadcast row could not be written, so this operation would
+ * go out with nothing able to reconcile it: no 'submitted' row means
+ * `resolveStrandedOps` cannot see it, `inflight-reconcile` only sweeps ops that
+ * succeeded, and a crash before the outcome write loses it entirely.
+ *
+ * Only reachable because `onSubmitted` now runs BEFORE the send. While it ran
+ * after, this situation existed and there was nothing useful to do about it —
+ * the money was already committed, and the code said so in a comment. Now the
+ * cheaper answer is available: don't send.
+ *
+ * A sibling of GasRefused, not of a revert. Nothing was signed, nothing spent.
+ */
+export class NotRecorded extends Error {
+  constructor(readonly userOpHash: `0x${string}`) {
+    super(
+      `refusing to broadcast ${userOpHash}: the durable pre-broadcast row could not be written, ` +
+        `so nothing would be able to reconcile this operation. Nothing was sent.`,
+    );
+    this.name = "NotRecorded";
+  }
+}
+
+/**
  * Refused BEFORE broadcast, on gas grounds. Nothing was signed and nothing
  * spent, so this is a sibling of a policy rejection rather than of a revert —
  * index.ts must not book it as an on-chain failure.
@@ -108,14 +134,20 @@ const RECEIPT_ATTEMPTS = 3;
 
 export interface ExecuteHooks {
   /**
-   * Called with the hash the moment the op leaves, BEFORE the receipt wait, and
-   * awaited. Everything after this point can crash, hang or be SIGKILLed, so
-   * whatever durability this trade is going to get has to be taken here.
+   * Called with the hash BEFORE the operation is broadcast, and awaited.
    *
-   * A throw from this hook aborts before the wait — deliberately, because the
-   * reason to have it is that an unrecorded in-flight op is worse than a late
-   * one. The op is already sent by then; the error carries the hash so it is
-   * still recoverable.
+   * IT USED TO RUN AFTER THE SEND, and moving it is what makes the guarantee
+   * real rather than nearly-real. A userOpHash is a pure function of the packed
+   * operation, the EntryPoint and the chain id, so it is knowable before anyone
+   * is asked to accept it — which means the durable row can exist before the
+   * operation does, and every window after this point has something to attach
+   * itself to.
+   *
+   * A THROW FROM THIS HOOK NOW REFUSES TO BROADCAST. That is the whole benefit
+   * of the new ordering, and the caller is expected to use it: an operation
+   * whose row could not be written is an operation nothing can ever reconcile,
+   * so not sending it is strictly better than sending it blind. Nothing has been
+   * signed to the network at that point and nothing is spent.
    */
   onSubmitted?(userOpHash: `0x${string}`): Promise<void>;
 }
@@ -280,37 +312,94 @@ export async function createAgentExecutor(opts: {
         );
       }
 
+      // ── PREPARE, SIGN, HASH, PERSIST, *THEN* SEND ───────────────────
+      //
+      // THE HASH EXISTS BEFORE THE NETWORK DOES, and that ordering is the whole
+      // point of this block. It used to be one `sendUserOperation` with no
+      // try/catch, and `onSubmitted` fired after it returned — so a throw at the
+      // send edge produced three wrong answers at once in index.ts's generic
+      // catch: the budget was released, the row was written `reverted` (a claim
+      // about a chain that never saw the operation), and no hash was stored. The
+      // last one is the worst: `resolveStrandedOps` selects on
+      // `status='submitted' AND user_op_hash IS NOT NULL`, so the op was
+      // structurally unfindable by the sweep built to find it.
+      //
+      // And the failure that motivates it is not the tidy one. If the send lands
+      // on the wire but the RESPONSE is lost — a socket reset, a proxy 502, a
+      // client timeout after the bundler already accepted — then an operation is
+      // in flight, spending real money, with no record anywhere.
+      //
+      // Reimplemented from Vex's staged broadcast (permission on record from its
+      // author), which computes keccak256 of the signed transaction locally and
+      // persists it before `sendRawTransaction`. The 4337 analogue is exact: a
+      // userOpHash is a pure function of the packed operation, the EntryPoint and
+      // the chain id, so it can be known before anyone is asked to accept it.
+      //
+      // Sending the SAME object back through sendUserOperation is idempotent by
+      // construction, not by luck: viem's prepareUserOperation returns an
+      // explicit nonce, fees and factory unchanged, and sendUserOperation uses
+      // `parameters.signature ||` so a signed operation is never re-signed. It
+      // also issues the RPC with retryCount: 0, so the send is never repeated.
+      const prepared = (await client.prepareUserOperation({
+        callData,
+        // Explicit, so prepareUserOperation uses these instead of estimating.
+        ...bounded.gas,
+      } as never)) as Record<string, unknown>;
+
       // THE LIMITS WE SIGNED MUST BE THE LIMITS WE BOUNDED. viem spreads the
       // paymaster's reply OVER the prepared request, so a sponsor that returned
       // callGasLimit would replace boundGas's number with no error and no log —
       // and under sponsorship the payer of an out-of-gas is the house. The
       // allowlist in paymaster.ts stops our wrappers propagating that; this
       // proves it stayed stopped, against the operation about to be signed.
-      if (opts.sponsor) {
-        const prepared = (await client.prepareUserOperation({
-          callData,
-          ...bounded.gas,
-        } as never)) as Record<string, unknown>;
-        assertBoundsHeld(bounded.gas, prepared);
-      }
+      //
+      // It now runs against the operation we are ABOUT to send rather than a
+      // second preparation of it, which is strictly the stronger claim.
+      if (opts.sponsor) assertBoundsHeld(bounded.gas, prepared);
 
-      const userOpHash = await client.sendUserOperation({
-        callData,
-        // Explicit, so prepareUserOperation uses these instead of estimating.
-        ...bounded.gas,
-      } as never);
+      const signature = await account.signUserOperation(prepared as never);
+      const signed = { ...prepared, signature };
+      const userOpHash = getUserOperationHash({
+        chainId: opts.chain.id,
+        entryPointAddress: entryPoint.address,
+        entryPointVersion: entryPoint.version,
+        userOperation: signed as never,
+      });
+
+      // DURABLE BEFORE BROADCAST. From here on, every outcome — accepted,
+      // refused, or never answered — has a row to attach itself to.
+      if (hooks?.onSubmitted) await hooks.onSubmitted(userOpHash);
+
+      let accepted: `0x${string}`;
+      try {
+        accepted = await client.sendUserOperation(signed as never);
+      } catch (err) {
+        // NOT A REVERT. Nothing on-chain has said anything. We asked, and we do
+        // not know whether the ask arrived — which is precisely the state
+        // UserOpUnresolved names, and which index.ts already handles correctly:
+        // it holds the budget charged, leaves the row 'submitted', and warns
+        // with the hash so the resolver can pick it up. NEVER re-send.
+        throw new UserOpUnresolved(userOpHash, err instanceof Error ? err.message : String(err));
+      }
       // Whatever happens to this op from here — landed, reverted, unresolved —
       // the bundler accepted it, so the account is deployed or is being deployed
       // by it. The wide deploy ceiling has done its job and must not apply to the
       // next one; a stale `false` would leave every op of this arm loosely
       // bounded, which is the guard quietly turning itself off.
       deployed = true;
-      // DURABILITY BEFORE THE WAIT. Between here and the ledger write in
-      // index.ts sits a receipt wait, a network price call and a DB round
-      // trip; nothing was written durably across any of it, so a SIGTERM from
-      // a redeploy left a landed op with no record of its hash at all.
-      if (hooks?.onSubmitted) await hooks.onSubmitted(userOpHash);
 
+      // Both sides derive this from the same bytes by the same rule, so a
+      // difference is a defect in one of the two implementations rather than a
+      // condition of the network. Treated as UNRESOLVED rather than swallowed:
+      // the operation is genuinely in flight, and we no longer know which hash
+      // the chain will index it under, which is the definition of the state.
+      if (accepted.toLowerCase() !== userOpHash.toLowerCase()) {
+        throw new UserOpUnresolved(
+          userOpHash,
+          `the bundler indexed this operation as ${accepted}, not the hash it was signed under. ` +
+            `It IS in flight; which hash resolves it is now unknown.`,
+        );
+      }
       // ONLY THE READ IS RETRIED. A re-send is a second operation and a second
       // spend — the one mistake this whole shape exists to make impossible, so
       // sendUserOperation sits outside the loop by construction rather than by

--- a/worker/src/final-fence.test.ts
+++ b/worker/src/final-fence.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { encodeFunctionData, erc20Abi } from "viem";
+import test from "node:test";
+import { UNISWAP, UNISWAP_SWAP_ROUTER_ABI } from "../../packages/core/src/index";
+import { checkV3SwapCalls, type FenceCall } from "./final-fence";
+import { buildTradeCalls, encodePath } from "./venues/uniswap";
+
+/**
+ * FED FROM THE REAL BUILDER, deliberately.
+ *
+ * A fence tested against hand-written calldata proves the fence agrees with the
+ * test author. Feeding it `buildTradeCalls`'s own output means the pass case is
+ * the actual production shape, so an encoder change fails a test here rather
+ * than quietly turning this into a wall (every trade refused) or an escape hatch
+ * (every trade waved through). recovery-shape.test.ts makes the same argument
+ * about Kernel's encoders and it is the reason that gate is trustworthy.
+ *
+ * The refusals are then MUTATIONS of that real output — one field moved at a
+ * time — which is the only way to know the check is load-bearing rather than
+ * incidentally true.
+ */
+
+const ROUTER = UNISWAP.swapRouter02 as `0x${string}`;
+const USDG = "0x5fc5360d5d1cc6e3b0b0a4b3a0f5c5b5a5d5e5f1" as `0x${string}`;
+const QQQ = "0x1111111111111111111111111111111111111111" as `0x${string}`;
+const WETH = "0x2222222222222222222222222222222222222222" as `0x${string}`;
+const ME = "0x3333333333333333333333333333333333333333" as `0x${string}`;
+const THIEF = "0x4444444444444444444444444444444444444444" as `0x${string}`;
+
+const AMOUNT_IN = 50_000_000n;
+const MIN_OUT = 970_000_000_000_000_000n;
+
+const expect = {
+  router: ROUTER,
+  tokenIn: USDG,
+  tokenOut: QQQ,
+  recipient: ME,
+  amountIn: AMOUNT_IN,
+  minOut: MIN_OUT,
+};
+
+const build = (over: { path?: { tokens: readonly `0x${string}`[]; fees: readonly number[] } } = {}) =>
+  buildTradeCalls({
+    quote: { fee: 500, amountOut: 1_000_000_000_000_000_000n, gasEstimate: 0n, ...over },
+    tokenIn: USDG,
+    tokenOut: QQQ,
+    recipient: ME,
+    amountIn: AMOUNT_IN,
+    minAmountOut: MIN_OUT,
+    deadline: 1_800_000_300,
+  }) as unknown as FenceCall[];
+
+/** Replace the swap leg, keeping the approve as built. */
+const withSwap = (data: `0x${string}`): FenceCall[] => [build()[0]!, { to: ROUTER, value: 0n, data }];
+
+const single = (over: Partial<Record<string, unknown>> = {}): `0x${string}` =>
+  encodeFunctionData({
+    abi: UNISWAP_SWAP_ROUTER_ABI,
+    functionName: "exactInputSingle",
+    args: [
+      {
+        tokenIn: USDG,
+        tokenOut: QQQ,
+        fee: 500,
+        recipient: ME,
+        amountIn: AMOUNT_IN,
+        amountOutMinimum: MIN_OUT,
+        sqrtPriceLimitX96: 0n,
+        ...over,
+      } as never,
+    ],
+  });
+
+test("the real builder's output passes, single-hop and multi-hop", () => {
+  assert.deepEqual(checkV3SwapCalls(build(), expect), { ok: true });
+  const multi = build({ path: { tokens: [USDG, WETH, QQQ], fees: [500, 3000] } });
+  assert.deepEqual(checkV3SwapCalls(multi, expect), { ok: true });
+});
+
+test("THE 263x CLASS: a floor that is not the floor we approved", () => {
+  // Vex's incident, 2026-08-27 on Robinhood Chain: a confirmed fill 263x worse
+  // than quoted, because the execute path re-quoted at broadcast and derived its
+  // floor from the fresher route. This is the check that would have caught it
+  // regardless of which end the drift came from.
+  const low = checkV3SwapCalls(withSwap(single({ amountOutMinimum: MIN_OUT / 263n })), expect);
+  assert.equal(low.ok, false);
+  assert.equal(low.ok === false ? low.rule : null, "price-floor");
+
+  // EQUALITY, NOT "AT LEAST". A higher floor is not a safer trade, it is a
+  // different one — and it is also what a build carrying a stale quote looks
+  // like when the price moved the other way.
+  const high = checkV3SwapCalls(withSwap(single({ amountOutMinimum: MIN_OUT + 1n })), expect);
+  assert.equal(high.ok, false);
+  assert.equal(high.ok === false ? high.rule : null, "price-floor");
+});
+
+test("the output must land in the account", () => {
+  const v = checkV3SwapCalls(withSwap(single({ recipient: THIEF })), expect);
+  assert.equal(v.ok, false);
+  assert.equal(v.ok === false ? v.rule : null, "recipient");
+});
+
+test("both legs of the asset pair are read, not just the one that is easy", () => {
+  const inWrong = checkV3SwapCalls(withSwap(single({ tokenIn: WETH })), expect);
+  assert.equal(inWrong.ok === false ? inWrong.rule : null, "asset");
+  const outWrong = checkV3SwapCalls(withSwap(single({ tokenOut: THIEF })), expect);
+  assert.equal(outWrong.ok === false ? outWrong.rule : null, "asset");
+});
+
+test("A MULTI-HOP PATH IS CHECKED AT BOTH ENDS", () => {
+  // The output token of a packed path is the half that MOVES with hop count, so
+  // it is the one a decoder is most likely to skip — and the one an attacker
+  // would change. Vex's guard reads both floors of a native-output swap for the
+  // same reason: reading only the first leaves the other free.
+  const swapped = encodeFunctionData({
+    abi: UNISWAP_SWAP_ROUTER_ABI,
+    functionName: "exactInput",
+    args: [
+      {
+        path: encodePath([USDG, WETH, THIEF], [500, 3000]),
+        recipient: ME,
+        amountIn: AMOUNT_IN,
+        amountOutMinimum: MIN_OUT,
+      } as never,
+    ],
+  });
+  const v = checkV3SwapCalls(withSwap(swapped), expect);
+  assert.equal(v.ok, false);
+  assert.equal(v.ok === false ? v.rule : null, "asset");
+});
+
+test("the approval is bounded to this trade and to this router", () => {
+  const [, swap] = build();
+  const infinite: FenceCall = {
+    to: USDG,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: erc20Abi,
+      functionName: "approve",
+      args: [ROUTER, 2n ** 256n - 1n],
+    }),
+  };
+  const v = checkV3SwapCalls([infinite, swap!], expect);
+  assert.equal(v.ok, false);
+  assert.equal(v.ok === false ? v.rule : null, "approval");
+
+  // A spender that is not the router this swap calls is the whole shape of the
+  // hole the wall was closed for: approve somebody, then let them pull.
+  const elsewhere: FenceCall = {
+    to: USDG,
+    value: 0n,
+    data: encodeFunctionData({ abi: erc20Abi, functionName: "approve", args: [THIEF, AMOUNT_IN] }),
+  };
+  const w = checkV3SwapCalls([elsewhere, swap!], expect);
+  assert.equal(w.ok === false ? w.rule : null, "approval");
+});
+
+test("UNRECOGNISED IS A REFUSAL, NEVER A PASS", () => {
+  // The property that makes a decoder worth having. A shape this function does
+  // not understand must not fall through as fine.
+  const [approve, swap] = build();
+  assert.equal(checkV3SwapCalls([], expect).ok, false, "no calls");
+  assert.equal(checkV3SwapCalls([approve!], expect).ok, false, "one call");
+  assert.equal(checkV3SwapCalls([approve!, swap!, swap!], expect).ok, false, "three calls");
+  assert.equal(checkV3SwapCalls([{ ...approve!, data: "0xdeadbeef" }, swap!], expect).ok, false);
+  assert.equal(checkV3SwapCalls([approve!, { ...swap!, data: "0xdeadbeef" }], expect).ok, false);
+  // A different router function that happens to decode is still not a swap we build.
+  const sweep = encodeFunctionData({
+    abi: UNISWAP_SWAP_ROUTER_ABI,
+    functionName: "exactInput",
+    args: [
+      { path: encodePath([USDG, QQQ], [500]), recipient: ME, amountIn: AMOUNT_IN, amountOutMinimum: MIN_OUT } as never,
+    ],
+  });
+  // ...and the well-formed one still passes, so the refusals above are not the
+  // function simply rejecting everything.
+  assert.deepEqual(checkV3SwapCalls(withSwap(sweep), expect), { ok: true });
+});
+
+test("no ETH moves on this path", () => {
+  // Every permission in the wall carries valueLimit: 0n, so a non-zero value is
+  // refused on-chain anyway — but on-chain means after it was signed and paid for.
+  const [approve, swap] = build();
+  assert.equal(checkV3SwapCalls([{ ...approve!, value: 1n }, swap!], expect).ok, false);
+  assert.equal(checkV3SwapCalls([approve!, { ...swap!, value: 1n }], expect).ok, false);
+});
+
+test("the swap must be addressed to the router, not merely mention it", () => {
+  const [approve, swap] = build();
+  const v = checkV3SwapCalls([approve!, { ...swap!, to: THIEF }], expect);
+  assert.equal(v.ok, false);
+  assert.equal(v.ok === false ? v.rule : null, "build-integrity");
+});

--- a/worker/src/final-fence.ts
+++ b/worker/src/final-fence.ts
@@ -1,0 +1,188 @@
+/**
+ * THE LAST THING BETWEEN A BUILD AND A SIGNATURE.
+ *
+ * Every other check on this path judges the INTENT: the wall's mirror judges a
+ * notional, the impact guard judges a probe, the gas bounds judge an estimate.
+ * Nothing has ever read the bytes that are actually about to be signed and asked
+ * whether they say what we decided.
+ *
+ * WHY IT IS WORTH THE HUNDRED LINES. Vex took a confirmed production fill on
+ * Robinhood Chain 263x worse than quoted, on 2026-08-27, because the execute
+ * path re-quoted at broadcast time and derived its floor from the fresher route
+ * — so the approved quote never reached the signed transaction. merrymen does
+ * not have that bug (venues/uniswap.ts threads one quote object from bestRoute
+ * into buildTradeCalls, deliberately), but "does not have it today" and "cannot
+ * have it" are different claims, and only one of them survives a refactor.
+ *
+ * TWO INDEPENDENT LAYERS, which is the part worth copying:
+ *
+ *   PROVENANCE — the calls are the ones this trade built: two of them, the
+ *   right targets, no value moving.
+ *
+ *   MEANING — the calldata is DECODED and the floor read back out. An encoder
+ *   that started writing the wrong `amountOutMinimum` would satisfy every
+ *   structural check perfectly, which is precisely why the decode is not
+ *   redundant with the shape check above it.
+ *
+ * EQUALITY, NOT "AT LEAST". The build writes the approved floor and nothing
+ * else, so a difference in EITHER direction is a build nobody authorised. A
+ * higher floor is not a safer trade, it is a different one.
+ *
+ * SCOPE, STATED. This fences the v3 lane — an ERC-20 approve followed by
+ * `exactInputSingle` or `exactInput` — which is what every grant this repo can
+ * currently produce actually reaches. The v4 adapter and legacy Permit2 lanes
+ * are NOT fenced here and must not be passed to it: their calldata is built by
+ * different builders with a structurally pinned recipient, and a decoder that
+ * silently returned "fine" for a shape it does not understand would be worse
+ * than no decoder at all. Unrecognised input is a refusal, never a pass.
+ */
+
+import { decodeFunctionData, erc20Abi, type Hex } from "viem";
+import { UNISWAP_SWAP_ROUTER_ABI } from "../../packages/core/src/index";
+
+export type FenceRule =
+  /** The calls are not the shape this trade builds. */
+  | "build-integrity"
+  /** The signed floor is not the floor that was approved. */
+  | "price-floor"
+  /** The output would land somewhere other than the account. */
+  | "recipient"
+  /** A leg names a token this trade is not for. */
+  | "asset"
+  /** The approval is not bounded to this trade. */
+  | "approval";
+
+export type FenceVerdict = { ok: true } | { ok: false; rule: FenceRule; detail: string };
+
+export interface FenceCall {
+  to: `0x${string}`;
+  value: bigint;
+  data: Hex;
+}
+
+export interface FenceExpect {
+  router: `0x${string}`;
+  tokenIn: `0x${string}`;
+  tokenOut: `0x${string}`;
+  recipient: `0x${string}`;
+  amountIn: bigint;
+  /** The floor the trade was judged against. Compared by EQUALITY. */
+  minOut: bigint;
+}
+
+const same = (a: string, b: string) => a.toLowerCase() === b.toLowerCase();
+const no = (rule: FenceRule, detail: string): FenceVerdict => ({ ok: false, rule, detail });
+
+/** First and last 20-byte addresses of a packed v3 path. */
+function pathEnds(path: Hex): { first: `0x${string}`; last: `0x${string}` } | null {
+  const body = path.slice(2);
+  // token(20) ++ [fee(3) ++ token(20)]+ — 40 + n*46 hex characters.
+  if (body.length < 86 || (body.length - 40) % 46 !== 0) return null;
+  return {
+    first: `0x${body.slice(0, 40)}` as `0x${string}`,
+    last: `0x${body.slice(-40)}` as `0x${string}`,
+  };
+}
+
+/**
+ * Does this pair of calls do exactly the trade that was approved?
+ *
+ * Returns a refusal rather than throwing, so the caller books it the way it
+ * books every other pre-broadcast refusal: nothing signed, nothing spent.
+ */
+export function checkV3SwapCalls(
+  calls: readonly FenceCall[],
+  expect: FenceExpect,
+): FenceVerdict {
+  if (calls.length !== 2) {
+    return no("build-integrity", `expected an approve and a swap, got ${calls.length} call(s)`);
+  }
+  const [approve, swap] = calls as [FenceCall, FenceCall];
+
+  // NO ETH MOVES ON THIS PATH, EVER. Every permission in the wall carries
+  // `valueLimit: 0n`, so a non-zero value would be refused on-chain anyway —
+  // but it would be refused after being signed and paid for.
+  if (approve.value !== 0n || swap.value !== 0n) {
+    return no("build-integrity", "a v3 swap moves no ETH, and one of these legs carries value");
+  }
+
+  // ── leg one: the approval, bounded to this trade ────────────────────────
+  if (!same(approve.to, expect.tokenIn)) {
+    return no("asset", `the approval is against ${approve.to}, not the token being sold`);
+  }
+  let approveArgs: readonly unknown[];
+  try {
+    const d = decodeFunctionData({ abi: erc20Abi, data: approve.data });
+    if (d.functionName !== "approve") {
+      return no("approval", `the first leg is \`${d.functionName}\`, not an approval`);
+    }
+    approveArgs = d.args as readonly unknown[];
+  } catch {
+    return no("approval", "the first leg does not decode as an ERC-20 call");
+  }
+  const [spender, allowance] = approveArgs as [`0x${string}`, bigint];
+  if (!same(spender, expect.router)) {
+    return no("approval", `the approval names ${spender}, not the router this swap calls`);
+  }
+  // EXACTLY the input, not a ceiling above it. An allowance larger than the
+  // trade is a standing permission the next caller inherits.
+  if (allowance !== expect.amountIn) {
+    return no("approval", `the approval is for ${allowance}, but the trade sells ${expect.amountIn}`);
+  }
+
+  // ── leg two: the swap, and what it actually says ────────────────────────
+  if (!same(swap.to, expect.router)) {
+    return no("build-integrity", `the swap is addressed to ${swap.to}, not the router`);
+  }
+  let fn: string;
+  let params: Record<string, unknown>;
+  try {
+    const d = decodeFunctionData({ abi: UNISWAP_SWAP_ROUTER_ABI, data: swap.data });
+    fn = d.functionName;
+    params = (d.args as readonly unknown[])[0] as Record<string, unknown>;
+  } catch {
+    return no("build-integrity", "the swap leg does not decode against the router ABI");
+  }
+  if (fn !== "exactInputSingle" && fn !== "exactInput") {
+    return no("build-integrity", `the swap leg is \`${fn}\`, which this trade never builds`);
+  }
+
+  if (!same(params.recipient as string, expect.recipient)) {
+    return no("recipient", `the output would go to ${String(params.recipient)}, not the account`);
+  }
+  if (params.amountIn !== expect.amountIn) {
+    return no("build-integrity", `the swap sells ${String(params.amountIn)}, not ${expect.amountIn}`);
+  }
+
+  // THE ONE THE 263x INCIDENT WAS ABOUT.
+  if (params.amountOutMinimum !== expect.minOut) {
+    return no(
+      "price-floor",
+      `the floor about to be signed is ${String(params.amountOutMinimum)}, but this trade was ` +
+        `judged against ${expect.minOut}. A build carrying a different floor is a different trade.`,
+    );
+  }
+
+  if (fn === "exactInputSingle") {
+    if (!same(params.tokenIn as string, expect.tokenIn)) {
+      return no("asset", `the swap sells ${String(params.tokenIn)}, not the token quoted`);
+    }
+    if (!same(params.tokenOut as string, expect.tokenOut)) {
+      return no("asset", `the swap buys ${String(params.tokenOut)}, not the token quoted`);
+    }
+    return { ok: true };
+  }
+
+  // exactInput: the assets are the ENDS of a packed path, and the output token
+  // is the half that moves with hop count — which is exactly why reading it
+  // matters more here than in the single-hop form.
+  const ends = pathEnds(params.path as Hex);
+  if (!ends) return no("asset", "the multi-hop path is not a well-formed token/fee sequence");
+  if (!same(ends.first, expect.tokenIn)) {
+    return no("asset", `the path starts at ${ends.first}, not the token quoted`);
+  }
+  if (!same(ends.last, expect.tokenOut)) {
+    return no("asset", `the path ends at ${ends.last}, not the token quoted`);
+  }
+  return { ok: true };
+}

--- a/worker/src/gas-limits.test.ts
+++ b/worker/src/gas-limits.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { GAS_BOUNDS, boundGas, totalGas, type UserOpGas } from "./gas-limits";
+import { readFileSync } from "node:fs";
+import { DEPLOY_GAS_BOUNDS, GAS_BOUNDS, boundGas, totalGas, type UserOpGas } from "./gas-limits";
 
 /**
  * The gap this closes was total: no floor, no ceiling, whatever the bundler
@@ -145,4 +146,51 @@ test("REGRESSION: the zero check runs BEFORE the disagreement math", () => {
   const v = boundGas(est(0n, 10n, 10n), est(900_000n, 900_000n, 900_000n));
   assert.equal(v.ok, false);
   assert.equal(v.rule, "gas-unreadable", "not 'gas-unstable'");
+});
+
+test("THE DEPLOY CEILING: the op that creates the account is not the steady state", () => {
+  // GAS_BOUNDS.absoluteMax reasons about "an approve plus an exactInputSingle",
+  // which is a fair description of every operation EXCEPT the first one. That
+  // one also carries the Kernel factory initCode, the permission validator's
+  // plugin-enable (~960 bytes of ONE_OF lists on its own) and the verification
+  // of the enable signature.
+  //
+  // boundGas REFUSES rather than clamps, so applying the steady-state ceiling to
+  // the deploy presents as a flat pre-sign refusal on the one operation in an
+  // account's life that has to succeed — and it would refuse with the words "the
+  // operation is not the one it is meant to be", which would be exactly wrong.
+  //
+  // Sized so the ×2 headroom on a plausible deploy estimate clears it.
+  const deploy = est(400_000n, 1_100_000n, 250_000n); // ×2 = 3.5M
+  const narrow = boundGas(deploy, deploy);
+  assert.equal(narrow.ok, false, "the steady-state ceiling refuses a deploy");
+  assert.equal(narrow.ok === false ? narrow.rule : null, "gas-absurd");
+
+  const wide = boundGas(deploy, deploy, DEPLOY_GAS_BOUNDS);
+  assert.equal(wide.ok, true, "the deploy ceiling admits it");
+  assert.equal(totalGas((wide as { gas: UserOpGas }).gas), 3_500_000n);
+});
+
+test("the deploy ceiling is a CEILING, not an exemption", () => {
+  // The check still has to catch an operation that is not the one we think it
+  // is. A deploy plus an enable plus an approve plus a swap has a real upper
+  // bound; anything past it is as suspect as it would be later.
+  const absurd = est(3_000_000n, 3_000_000n, 3_000_000n); // ×2 = 18M
+  const v = boundGas(absurd, absurd, DEPLOY_GAS_BOUNDS);
+  assert.equal(v.ok, false);
+  assert.equal(v.rule, "gas-absurd");
+  // And it is the only field that moved.
+  assert.equal(DEPLOY_GAS_BOUNDS.headroomBps, GAS_BOUNDS.headroomBps);
+  assert.equal(DEPLOY_GAS_BOUNDS.disagreementBps, GAS_BOUNDS.disagreementBps);
+  assert.equal(DEPLOY_GAS_BOUNDS.absoluteMax > GAS_BOUNDS.absoluteMax, true);
+});
+
+test("THE CALL SITE: the executor picks the ceiling by whether the account exists", () => {
+  // A constant nothing reads is worth nothing, and the bug next door — a grant
+  // detected as dead and then armed anyway — was exactly a correct fact with no
+  // consequence. Pin that the wide ceiling is reached only when the account has
+  // no code, and that it stops applying once an op has been accepted.
+  const src = readFileSync(new URL("./executor.ts", import.meta.url), "utf8");
+  assert.match(src, /await isDeployed\(\)\) \? GAS_BOUNDS : DEPLOY_GAS_BOUNDS/);
+  assert.match(src, /deployed = true;/, "a landed send must retire the deploy ceiling");
 });

--- a/worker/src/gas-limits.ts
+++ b/worker/src/gas-limits.ts
@@ -79,6 +79,32 @@ export const GAS_BOUNDS: GasBounds = {
   absoluteMax: 3_000_000n,
 };
 
+/**
+ * THE FIRST OPERATION IS A DIFFERENT OPERATION.
+ *
+ * `absoluteMax` above is reasoned about the steady state, and says so: "an
+ * approve plus an `exactInputSingle` does not approach it". True — and the
+ * first operation an account ever sends is not an approve plus a swap. It also
+ * carries the Kernel factory initCode that deploys the account, the permission
+ * validator's plugin-enable (whose enable data is ~960 bytes of ONE_OF lists
+ * alone, per wall.ts), and the verification of the enable signature.
+ *
+ * That matters because `boundGas` REFUSES rather than clamps. A ceiling chosen
+ * for the steady state, applied to the deploy, presents as a flat pre-sign
+ * refusal on the one operation in an account's life that has to succeed — and
+ * the refusal would read "the operation is not the one it is meant to be", which
+ * would be exactly wrong.
+ *
+ * 8M rather than 3M. Deliberately not unbounded: the check still has to catch an
+ * operation that is not the one we think it is, and a deploy plus an enable plus
+ * an approve plus a swap has a real upper bound. It applies ONLY while the
+ * account has no code, and the executor stops using it the moment one op lands.
+ */
+export const DEPLOY_GAS_BOUNDS: GasBounds = {
+  ...GAS_BOUNDS,
+  absoluteMax: 8_000_000n,
+};
+
 export type GasVerdict =
   | { ok: true; gas: UserOpGas; total: bigint }
   /**

--- a/worker/src/identity-store.ts
+++ b/worker/src/identity-store.ts
@@ -8,7 +8,9 @@
  *      before this there was none — PublicThesis deliberately omits agent_id,
  *      and the feed page hashes the agent's NAME for its avatar colour because
  *      the route has nothing else to send. There was literally nothing a follow
- *      could target.
+ *      could target — which is why this exists, and is not a claim that a
+ *      follow now exists. The TARGET does; the edge, the store, the API and the
+ *      tool that would read it do not.
  *
  *   2. Which social account signed in? (Privy.) That half is declared here and
  *      wired later; it lives in this record because a DID resolves to a TENANT,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -62,6 +62,7 @@ import { fetchRialtoQuote, resolveRialtoRouter } from "./venues/rialto";
 import { impactBps, judgeImpact, probeAmountIn } from "./impact";
 import { bestRoute, buildTradeCalls, minOutWithSlippage, requoteRoute } from "./venues/uniswap";
 import {
+  NotRecorded,
   createAgentExecutor,
   GasRefused,
   UserOpReverted,
@@ -3161,18 +3162,21 @@ async function main() {
             decision_id,
             ...sim,
           });
-          // A failed write here is not fatal — the op is already sent and the
-          // outcome path still records it. It IS worth saying, because the
-          // protection this hook exists to provide is the thing that just
-          // failed, and the next crash would be unrecoverable in the old way.
+          // A FAILED WRITE NOW STOPS THE OPERATION, and that is only possible
+          // because this hook moved ahead of the send. It used to run after,
+          // where the honest note was that a failed write "is not fatal — the
+          // op is already sent": the money was committed and the best available
+          // answer was to say so and hope. Now nothing has been broadcast, so
+          // the cheaper answer is on the table.
+          //
+          // Refusing is the right call rather than the cautious one. This row is
+          // what every reconciliation path keys on — resolveStrandedOps selects
+          // status='submitted' AND user_op_hash IS NOT NULL, and inflight-reconcile
+          // only sweeps ops that succeeded — so an operation sent without it is
+          // one that no sweep can ever resolve. A skipped tick costs nothing; an
+          // unreconcilable spend costs the notional and the ability to find out.
           submittedRow = wrote;
-          if (!wrote) {
-            void addEvent(
-              agentId,
-              "err",
-              `couldn't record ${userOpHash} before broadcast — this op is in flight with no durable row`,
-            );
-          }
+          if (!wrote) throw new NotRecorded(userOpHash);
         },
       };
       const send = (calls: Call[]) => executor.execute(calls, submitHooks);
@@ -3793,6 +3797,37 @@ async function main() {
       // The rule string is a literal from gas-limits.ts, so it joins the
       // vocabulary the notifier and the dashboard already read rather than
       // becoming another free-form sentence in reject_rule.
+      // NOTHING WAS SENT, because nothing could have found it afterwards.
+      // The pre-broadcast row is what every reconciliation path keys on, so an
+      // operation whose row could not be written is one that no sweep can ever
+      // resolve. Refusing costs a tick; sending would have cost the notional
+      // with no way to learn what became of it.
+      //
+      // A sibling of GasRefused directly below: pre-broadcast, nothing signed,
+      // nothing spent, and a `rule` from a fixed vocabulary rather than free
+      // text — so it never reaches the generic branch that writes 'reverted'.
+      if (e instanceof NotRecorded) {
+        releaseBudget();
+        await addEvent(
+          agentId,
+          "err",
+          `refused to broadcast a ${intent.kind}: the ledger would not accept the row that has to exist ` +
+            `before an operation goes out, so it was not sent. Nothing was spent. This is a merrymen ` +
+            `fault, not a configuration one.`,
+        );
+        await recordTrade({
+          agent_id: agentId,
+          kind: intent.kind,
+          target: tradeTarget,
+          ...tokenLegs(intent),
+          amount_usdg: usdgNum(notional),
+          status: "rejected",
+          reject_rule: "not-recorded",
+          ...sim,
+        });
+        return;
+      }
+
       if (e instanceof GasRefused) {
         releaseBudget();
         await addEvent(agentId, "warn", `${intent.kind} refused before signing: ${msg.slice(0, 300)}`);
@@ -3878,10 +3913,43 @@ async function main() {
         return;
       }
 
-      // Roll back the optimistic reservation — the money didn't move. The
-      // 'reverted' row written below goes through recordTrade, which would
-      // release it anyway; doing it here keeps the counters honest for the
-      // window in between, and releaseBudget is idempotent.
+      // ── AN OPERATION THAT WENT OUT IS NOT A FAILED ONE ──────────────────
+      //
+      // `submittedRow` is set by the durable pre-broadcast write, which now
+      // happens BEFORE the send. So if it is set and this is not a typed
+      // on-chain revert, an operation reached the bundler — possibly landed —
+      // and something AFTER it threw: the receipt's fill read, the gas pricing,
+      // a ledger write, an addFlow.
+      //
+      // The old code booked that as `reverted`. Two things wrong with it, and
+      // the second is worse than the first. It asserts a chain outcome nobody
+      // observed; and with no hash to resolve on, `addTrade` INSERTS rather than
+      // resolving in place, so the same operation ends up as two rows — one
+      // 'submitted' that the resolver will later settle, and one 'reverted' that
+      // is simply false. A landed trade could be booked as a revert beside
+      // itself.
+      //
+      // Treated as unresolved instead, exactly like the receipt-read failure
+      // above: the pre-broadcast row stands, the charge stays counted, and the
+      // stranded-op resolver settles it from the chain. The budget must NOT be
+      // released here, which is why this sits above the rollback.
+      if (submittedRow) {
+        await refreshBudget(agentId);
+        releaseBudget();
+        await addEvent(
+          agentId,
+          "err",
+          `${intent.kind} was submitted, and then something after it failed: ${msg.slice(0, 200)}. ` +
+            `This is NOT a revert — the operation may have landed. It stays counted against today's ` +
+            `caps and the resolver will settle it from the chain.`,
+        );
+        return;
+      }
+
+      // Roll back the optimistic reservation — the money didn't move. The row
+      // written below goes through recordTrade, which would release it anyway;
+      // doing it here keeps the counters honest for the window in between, and
+      // releaseBudget is idempotent.
       releaseBudget();
       // A genuine on-chain revert vs a failure BEFORE submission (bundler, RPC,
       // gas), so the user isn't told "reverted on-chain" for something that
@@ -3950,7 +4018,15 @@ async function main() {
         // Resolves the pre-broadcast row in place when there is one — a revert
         // has a hash; a failure before submit does not, and inserts.
         ...(onChain ? { user_op_hash: e.userOpHash } : {}),
-        status: "reverted",
+        // REVERTED MEANS THE CHAIN REVERTED IT. Everything reaching this line
+        // without `onChain` never got there: no operation was submitted (the
+        // branch above returns when one was), so this is a build, an encode or a
+        // pre-flight that threw. Calling that 'reverted' put words in the
+        // chain's mouth, and the ledger is the one place in this product that
+        // must never do that — `rejected` is the vocabulary for "we did not
+        // send it", and it is what every other pre-broadcast refusal on this
+        // path already writes.
+        status: onChain ? "reverted" : "rejected",
         reject_rule: reason,
         // KEEP the simulation. This row is the single most informative one in
         // the ledger — the trade we quoted, sized and submitted, that the chain

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -308,6 +308,12 @@ interface ActiveAgent {
   ponsAdapterLive: boolean;
 }
 
+/**
+ * A token address as a person reads it. Only ever a LABEL — every comparison in
+ * this file is against the full address, so a collision here is cosmetic.
+ */
+const short = (a: string) => `${a.slice(0, 6)}…${a.slice(-4)}`;
+
 async function main() {
   await initStore();
   const selftest = process.argv.includes("--selftest");
@@ -3692,6 +3698,50 @@ async function main() {
       console.log(`[execute] ${intent.kind} landed: ${txHash}`);
       await addEvent(agentId, "ok", `${intent.kind} landed (${fmt(notional)} USDG): ${txHash}`);
 
+      // ── DID IT ACTUALLY ARRIVE? ──────────────────────────────────────────
+      //
+      // BEFORE the decode, and gated only on "did this operation acquire an
+      // ERC-20", because that is the only precondition the question has.
+      //
+      // It used to sit three gates deep — inside `if (fillPair)`, inside
+      // `if (measured)`, inside `if (side === "buy")` — and `fillPair` is
+      // assigned only in the Uniswap branch, under `sellIsUsdg !== buyIsUsdg`,
+      // under `if (symbol)`. So curve trades, Rialto swaps and stock-to-stock
+      // swaps got no delivery check at all. Curve is where honeypots live: it is
+      // the venue where a token is minted by whoever wants it minted, and it was
+      // the one lane with nothing watching.
+      //
+      // The other two gates were wrong for a subtler reason. `measured` is a
+      // RECEIPT DECODE, and this check exists precisely because receipt logs are
+      // contract-authored — a token that fabricates a Transfer log is exactly the
+      // token whose decode you should not be trusting to decide whether to look.
+      // Vex computes delivery before the decode for this reason.
+      //
+      // See delivery.ts for why it is exact-zero-only, why a failed read is
+      // 'unknown' rather than a zero, and why it can never fail the trade.
+      const acquired: { token: `0x${string}`; label: string } | null =
+        intent.kind === "swap" && intent.buyToken.toLowerCase() !== (CASH.USDG as string).toLowerCase()
+          ? { token: intent.buyToken, label: fillPair?.symbol ?? short(intent.buyToken) }
+          : intent.kind === "curve-trade" &&
+              intent.assetOut.toLowerCase() !== (CASH.USDG as string).toLowerCase()
+            ? { token: intent.assetOut, label: short(intent.assetOut) }
+            : null;
+      if (acquired) {
+        const delivery = await checkDelivery({
+          balanceOf: () =>
+            chainClient.readContract({
+              address: acquired.token,
+              abi: erc20Abi,
+              functionName: "balanceOf",
+              args: [executor.address],
+            }) as Promise<bigint>,
+        });
+        const note = describeDelivery(acquired.label, delivery);
+        // "delivered" says nothing, deliberately — a tape of non-events is
+        // noise, and this runs on every acquisition.
+        if (note) await addEvent(agentId, delivery.kind === "undelivered" ? "err" : "warn", note);
+      }
+
       // ── what the chain says actually moved ───────────────────────────────
       // Prefer the receipt over the quote. The quote is what we hoped for; the
       // receipt is what happened, and only the receipt's quantity matches the
@@ -3714,37 +3764,19 @@ async function main() {
           const receivedOut = measured.side === "buy" ? measured.qtyRaw : measured.cashUsdg;
           slippageBps = slippageBpsAgainst(fillPair.quotedOut, receivedOut);
 
-          // ── DID IT ACTUALLY ARRIVE? ────────────────────────────────────────
-          // Everything above this line was read from logs the token contract
-          // wrote. On a buy that is the whole basis, so ask the chain the one
-          // question a fabricated log cannot answer. See delivery.ts for why
-          // this is exact-zero-only, why a failed read is not a zero, and why
-          // it can never fail the trade.
+          // THE FLOOR IS A DIFFERENT QUESTION FROM DELIVERY, and it is the one
+          // that genuinely needs the decode: it compares the SETTLED output
+          // against the minOut this operation was signed with. A settled output
+          // below that floor cannot come from a well-behaved router — it would
+          // have reverted — so it is the signature of a token taking a cut on
+          // transfer. Delivery moved above, where it needs no decode.
           if (measured.side === "buy") {
-            const delivery = await checkDelivery({
-              balanceOf: () =>
-                chainClient.readContract({
-                  address: fillPair.stockToken,
-                  abi: erc20Abi,
-                  functionName: "balanceOf",
-                  args: [executor.address],
-                }) as Promise<bigint>,
-            });
-            const note = describeDelivery(fillPair.symbol, delivery);
-            // "delivered" says nothing, deliberately — a tape of non-events is
-            // noise, and this runs on every buy.
-            if (note) await addEvent(agentId, delivery.kind === "undelivered" ? "err" : "warn", note);
-
-            // And the floor, which is a different question from the quote. A
-            // settled output BELOW the minOut we signed cannot come from a
-            // well-behaved router — it would have reverted — so it is the
-            // signature of a token that takes a cut on transfer.
-            const short = belowFloorBps(fillPair.floorOut, receivedOut);
-            if (short !== null) {
+            const shortBps = belowFloorBps(fillPair.floorOut, receivedOut);
+            if (shortBps !== null) {
               await addEvent(
                 agentId,
                 "warn",
-                `${fillPair.symbol}: settled ${short} bps BELOW the minOut this op was signed with. A router cannot pay out less than the floor it accepted, so the shortfall happened on transfer — treat this as a fee-on-transfer token.`,
+                `${fillPair.symbol}: settled ${shortBps} bps BELOW the minOut this op was signed with. A router cannot pay out less than the floor it accepted, so the shortfall happened on transfer — treat this as a fee-on-transfer token.`,
               );
             }
           }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -60,6 +60,7 @@ import {
 } from "../../packages/core/src/index";
 import { fetchRialtoQuote, resolveRialtoRouter } from "./venues/rialto";
 import { impactBps, judgeImpact, probeAmountIn } from "./impact";
+import { checkV3SwapCalls } from "./final-fence";
 import { bestRoute, buildTradeCalls, minOutWithSlippage, requoteRoute } from "./venues/uniswap";
 import {
   NotRecorded,
@@ -3357,6 +3358,53 @@ async function main() {
           minAmountOut: minOut,
           deadline: Math.floor(Date.now() / 1000) + 300,
         });
+
+        // ── THE FINAL FENCE ─────────────────────────────────────────────
+        //
+        // Read the bytes about to be signed and check they say what this trade
+        // decided. Every other guard on this path judges the INTENT — the wall's
+        // mirror judges a notional, the impact guard judges a probe, the gas
+        // bounds judge an estimate — and none of them has ever looked at the
+        // calldata.
+        //
+        // The v3 lane only. A v4 quote goes through a different builder with a
+        // structurally pinned recipient, and a decoder returning "fine" for a
+        // shape it does not understand would be worse than no decoder: see the
+        // scope note in final-fence.ts. Reimplemented from Vex's final-request
+        // guard with its author's permission.
+        if (!quote.v4) {
+          const fence = checkV3SwapCalls(calls, {
+            router: UNISWAP.swapRouter02 as `0x${string}`,
+            tokenIn: intent.sellToken,
+            tokenOut: intent.buyToken,
+            recipient: executor.address,
+            amountIn: intent.sellAmountRaw,
+            minOut,
+          });
+          if (!fence.ok) {
+            // Pre-broadcast, so it books like a policy refusal rather than a
+            // revert: nothing signed, nothing spent, and the rule comes from a
+            // fixed vocabulary so the loop can suppress on it.
+            releaseBudget();
+            await addEvent(
+              agentId,
+              "err",
+              `refused to sign a ${intent.kind}: ${fence.detail}. Nothing was sent. This is a merrymen ` +
+                `fault — the calldata did not match the trade that was approved.`,
+            );
+            await recordTrade({
+              agent_id: agentId,
+              kind: intent.kind,
+              target: intent.target,
+              ...tokenLegs(intent),
+              amount_usdg: usdgNum(notional),
+              status: "rejected",
+              reject_rule: `fence-${fence.rule}`,
+              ...sim,
+            });
+            return;
+          }
+        }
         exec = await send(calls);
         const venue = quote.v4
           ? active.v4AdapterLive && grantV4Adapter(active.grant)

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -279,6 +279,23 @@ interface ActiveAgent {
    */
   orderExecutor: OrderExecutor | null;
   limits: AgentLimits;
+  /**
+   * This signature seals a policy contract with no bytecode on its chain.
+   *
+   * Read once at arm and carried, because it is a property of a frozen
+   * signature: it cannot change while this grant is active, and re-deriving it
+   * per-tick would parse the serialized permission set sixty times a minute to
+   * get the same answer.
+   */
+  deadPolicy: boolean;
+  /**
+   * Does the smart account have bytecode on the grant chain?
+   *
+   * `false` is the ordinary state of an account that has never operated, and
+   * `null` means the read did not land — which is not the same and must never
+   * be rendered as one.
+   */
+  accountDeployed: boolean | null;
   /** True only when breakerAddress has CODE on the grant chain — otherwise the
    * on-chain read would silently fail open (.catch → "not tripped"). */
   breakerLive: boolean;
@@ -363,6 +380,7 @@ async function main() {
       executor: !!active?.executor,
       chainId: active?.grant.chainId ?? 0,
       cashUsdg: lastCashUsdg,
+      deadPolicy: active?.deadPolicy ?? false,
       paperTradingEnabled: cfg.paperTradingEnabled,
     });
   const paperActive = () => execMode().mode === "paper";
@@ -2190,7 +2208,8 @@ async function main() {
     //
     // Said once per arm, as an err, because the alternative is an owner
     // watching every trade fail with a validation error that names nothing.
-    if (grantHasDeadRateLimit(grant.serialized)) {
+    const deadPolicy = grantHasDeadRateLimit(grant.serialized);
+    if (deadPolicy) {
       console.log(`[worker] grant predates the rate-limit removal — cannot transact until re-signed`);
       await addEvent(
         agentId,
@@ -2250,6 +2269,46 @@ async function main() {
         "warn",
         `couldn't check the wall's contracts this time (${uncheckedPolicyContracts.join(", ")}) — the chain did not answer. ` +
           `This says nothing about whether they are there; it retries on the next arm.`,
+      );
+    }
+
+    // HAS THIS ACCOUNT EVER EXISTED?
+    //
+    // Nothing in merrymen has ever asked. Every `getCode` in the repo is aimed
+    // at a policy contract, a breaker, an adapter or a token — never at the
+    // account itself — so "is the wall deployed" was answerable and "is the
+    // thing the wall protects deployed" was not.
+    //
+    // It matters more than it looks. A 4337 account is counterfactual until its
+    // first operation, so absence here is NORMAL and not an error. What absence
+    // means is that no EVM has ever evaluated this grant: every claim about what
+    // the wall enforces is, until this reads back bytecode, a claim about
+    // calldata that was built and signed and never submitted.
+    //
+    // Three-way, for the same reason as the loop above: a throw is not an
+    // absence. `null` is "could not look".
+    let accountDeployed: boolean | null = null;
+    try {
+      const code = await client.getCode({ address: grant.smartAccount as `0x${string}` });
+      accountDeployed = code !== undefined && code !== "0x";
+    } catch {
+      accountDeployed = null;
+    }
+    if (accountDeployed === false) {
+      console.log(`[worker] smart account ${grant.smartAccount} is not deployed yet — the first op deploys it`);
+      await addEvent(
+        agentId,
+        "warn",
+        `this account does not exist on chain ${chain.id} yet. That is normal — it deploys itself with ` +
+          `its first operation — but it means the first operation costs more than the ones after it, ` +
+          `and that no chain has yet checked the permissions this key was signed under.`,
+      );
+    } else if (accountDeployed === null) {
+      await addEvent(
+        agentId,
+        "warn",
+        `couldn't check whether this account is deployed — the chain did not answer. This says nothing ` +
+          `about whether it is; it retries on the next arm.`,
       );
     }
 
@@ -2340,6 +2399,10 @@ async function main() {
       // alongside every other grant-derived bound, so a curve the agent never
       // saw launch cannot be traded even though the wall cannot pin it.
       limits: limitsFromGrant(grant, watchTokens, (await knownCurves()) ?? undefined),
+      // Read once here, with every other grant-derived bound, because deciding
+      // it per-tick would re-parse a serialized signature that cannot change.
+      deadPolicy,
+      accountDeployed,
       breakerLive,
       v4AdapterLive,
       ponsAdapterLive,

--- a/worker/src/ledger-mirror.ts
+++ b/worker/src/ledger-mirror.ts
@@ -395,9 +395,11 @@ export async function mirrorTenant(args: {
   // is enough on its own. What it is NOT enough for is completeness: this used
   // to read `ORDER BY at DESC LIMIT 500` with no cursor, so a child that wrote
   // more than a batch between two passes lost the overflow PERMANENTLY. That
-  // was tolerable while a decision was only dashboard furniture. It stopped
-  // being tolerable when theses became the thing other agents read — a dropped
-  // decision is now a peer input that silently never arrives.
+  // was tolerable while a decision was only dashboard furniture, which is still
+  // all it is: no agent reads another's theses today. It stops being tolerable
+  // the moment one does, because a dropped decision is then a peer input that
+  // silently never arrives — and a cursor is much cheaper to add now than to
+  // debug later.
   //
   // Watermarked on `at` rather than on an id, because the id is a uuid and has
   // no order. `at` is not unique, so the cursor opens 300s BEHIND itself: ties

--- a/worker/src/mainnet-default.test.ts
+++ b/worker/src/mainnet-default.test.ts
@@ -42,6 +42,8 @@ function freshInstall(over: Partial<PreflightInput> = {}): PreflightInput {
     ethWei: 10n ** 16n,
     bundlerReachable: true,
     missingPolicyContracts: [],
+    deadPolicy: false,
+    accountDeployed: true,
     ...over,
   };
 }

--- a/worker/src/preflight-cli.ts
+++ b/worker/src/preflight-cli.ts
@@ -10,6 +10,7 @@
 import { readFileSync } from "node:fs";
 import { homePaths } from "./home";
 import { loadGrantFile } from "./grant";
+import { grantHasDeadRateLimit } from "./session-account";
 import { preflight, rank, verdict, type Check, type PreflightInput } from "./preflight";
 import { resolveConfig } from "./settings";
 import { CASH, WALL_POLICY_CONTRACTS, chainForId } from "../../packages/core/src/index";
@@ -84,6 +85,23 @@ async function missingPolicyContracts(url: string): Promise<string[] | null> {
 }
 
 /**
+ * Does the smart account have code on this chain?
+ *
+ * `null` on any read failure, like the probe above — "we could not look" and
+ * "it is not there" have different remedies, and for an account that is
+ * counterfactual by design the second is not even a fault.
+ */
+async function hasCode(url: string, account: string): Promise<boolean | null> {
+  try {
+    const code = (await rpc(url, "eth_getCode", [account, "latest"])) as string | null;
+    if (typeof code !== "string") return null;
+    return code !== "0x" && code !== "";
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Does the bundler answer?
  *
  * doctor probes only when a full `bundlerUrl` was pasted, so the common path —
@@ -142,11 +160,12 @@ async function main(): Promise<void> {
     (chainId === 46630 ? settings.rpcTestnet : settings.rpcMainnet) ??
     chain.rpcUrls.default.http[0]!;
 
-  const [usdg, ethWei, bundlerReachable, missingPolicy] = await Promise.all([
+  const [usdg, ethWei, bundlerReachable, missingPolicy, accountDeployed] = await Promise.all([
     grant ? usdgBalance(rpcUrl, grant.smartAccount) : Promise.resolve(null),
     grant ? ethBalance(rpcUrl, grant.smartAccount) : Promise.resolve(null),
     bundlerAnswers(settings, chainId),
     missingPolicyContracts(rpcUrl),
+    grant ? hasCode(rpcUrl, grant.smartAccount) : Promise.resolve(null),
   ]);
 
   // Resolved through the worker's OWN resolver rather than by re-reading the
@@ -167,6 +186,12 @@ async function main(): Promise<void> {
       ethWei,
       bundlerReachable,
       missingPolicyContracts: missingPolicy,
+      // Asked of the SIGNATURE, not of the chain — the probe above reads the
+      // addresses this code seals today and can never see what an older key
+      // sealed. Absent a grant there is nothing to judge, and the no-grant
+      // blocker above has already fired.
+      deadPolicy: grant ? grantHasDeadRateLimit(grant.serialized) : false,
+      accountDeployed,
     }),
   );
   for (const c of checks) render(c);

--- a/worker/src/preflight.test.ts
+++ b/worker/src/preflight.test.ts
@@ -21,6 +21,8 @@ function ready(over: Partial<PreflightInput> = {}): PreflightInput {
     ethWei: 10n ** 16n, // 0.01 ETH
     bundlerReachable: true,
     missingPolicyContracts: [],
+    deadPolicy: false,
+    accountDeployed: true,
     ...over,
   };
 }
@@ -55,6 +57,26 @@ describe("preflight — the things that stop a trade", () => {
     const chain = preflight(input).find((c) => c.id === "chain")!;
     assert.equal(chain.level, "blocker");
     assert.match(chain.detail!, /practice only/i);
+  });
+
+  it("A DEAD POLICY IS A BLOCKER, and it is not the same check as the contract probe", () => {
+    // The gap this closes. `missingPolicyContracts` probes the addresses this
+    // code seals TODAY, and every one of them is deployed — so a grant carrying
+    // the removed rate-limit policy passed preflight green while being unable to
+    // land a single UserOperation. Measured 2026-08-30: RATE_LIMIT_POLICY_CONTRACT
+    // has zero bytes on 4663 AND 46630.
+    //
+    // Both facts are asserted together on purpose: the contracts check must stay
+    // `ok` here, because that is exactly the shape that fooled the command.
+    const input = ready({ deadPolicy: true });
+    const checks = preflight(input);
+    const dead = checks.find((c) => c.id === "dead-policy")!;
+    assert.equal(dead.level, "blocker");
+    assert.equal(checks.find((c) => c.id === "policy-contracts")!.level, "ok");
+    assert.equal(verdict(checks).ready, false);
+    // The remedy is the whole value of the message: an owner who reads a
+    // funding instruction and acts on it has spent money on a dead account.
+    assert.match(dead.detail!, /re-sign/i);
   });
 
   it("an expired grant is a blocker", () => {

--- a/worker/src/preflight.ts
+++ b/worker/src/preflight.ts
@@ -89,6 +89,32 @@ export interface PreflightInput {
    * nothing about the contracts and must never read as "absent".
    */
   missingPolicyContracts: string[] | null;
+  /**
+   * Does THIS grant seal the dead rate-limit policy?
+   *
+   * A DIFFERENT QUESTION FROM THE ONE ABOVE, and the gap between them is why
+   * this command reported a healthy install for a grant that could never
+   * validate. `missingPolicyContracts` probes the three singletons this code
+   * seals TODAY. It cannot see what an OLDER signature sealed — and a signature
+   * is frozen, so the only grants that carry the dead policy are exactly the
+   * ones no probe of current addresses will ever look at.
+   *
+   * Passed as data rather than computed here, like the probe above:
+   * `grantHasDeadRateLimit` lives in `session-account.ts`, which imports the
+   * whole ZeroDev SDK, and this module's entire value is being pure enough to
+   * test without a chain.
+   */
+  deadPolicy: boolean;
+  /**
+   * Does the smart account have code on the grant chain? `null` = not probed.
+   *
+   * Not a blocker in either direction: an account with no code is the normal
+   * state of one that has never traded, and 4337 deploys it with the first
+   * operation. It is here because it changes what the FIRST operation costs and
+   * because it is the only observable that distinguishes "the wall is signed"
+   * from "the wall has been evaluated by a chain".
+   */
+  accountDeployed: boolean | null;
 }
 
 const ok = (id: string, title: string): Check => ({ id, level: "ok", title });
@@ -184,6 +210,40 @@ export function preflight(input: PreflightInput): Check[] {
     });
   } else {
     out.push(ok("policy-contracts", "the wall's validator contracts are deployed"));
+  }
+
+  // THE ONE CONDITION NO AMOUNT OF SETUP CAN CLEAR.
+  //
+  // Ahead of expiry, funding and sizing, because it invalidates every one of
+  // them: an owner who reads "fund 50 USDG" and does it has spent real money on
+  // an account whose every operation will still fail validation. Measured
+  // 2026-08-30 — RATE_LIMIT_POLICY_CONTRACT has zero bytes on 4663 AND 46630.
+  if (input.deadPolicy) {
+    out.push({
+      id: "dead-policy",
+      level: "blocker",
+      title: "this key was signed before a wall fix and CANNOT trade",
+      detail:
+        "It seals a rate-limit policy whose contract has no code on this chain, so Kernel has " +
+        "nothing to call and every operation fails validation. A signature is frozen: no deploy, " +
+        "no funding and no setting fixes it. Re-signing is free and instant — open the wallet page " +
+        "and use 're-sign this key'. Your funds are untouched, and practice mode still works.",
+    });
+  }
+
+  if (input.accountDeployed === false) {
+    out.push({
+      id: "account",
+      level: "warn",
+      title: "this account has never operated",
+      detail:
+        "A smart account is counterfactual until its first operation deploys it, so this is normal " +
+        "for a new install. Two consequences worth knowing before you fund it: the first operation " +
+        "costs meaningfully more than the ones after it, and no chain has yet evaluated the " +
+        "permissions this key was signed under.",
+    });
+  } else if (input.accountDeployed === true) {
+    out.push(ok("account", "the account is deployed"));
   }
 
   const secsLeft = g.expiresAt - input.nowSec;

--- a/worker/src/send-edge.test.ts
+++ b/worker/src/send-edge.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { NotRecorded, UserOpUnresolved } from "./executor";
+
+/**
+ * THE SEND EDGE, PINNED BY ORDER.
+ *
+ * `sendUserOperation` had no try/catch and `onSubmitted` fired after it
+ * returned. A throw at that edge therefore produced three wrong answers at once
+ * in index.ts's generic catch: the budget was released, the row was written
+ * `reverted` — a claim about a chain that never saw the operation — and no hash
+ * was stored at all. That last one is the trap: `resolveStrandedOps` selects on
+ * `status='submitted' AND user_op_hash IS NOT NULL`, so the operation was
+ * structurally invisible to the sweep built to find it.
+ *
+ * The failure that motivates it is not the tidy one. If the send reaches the
+ * bundler but the RESPONSE is lost — socket reset, proxy 502, a client timeout
+ * after acceptance — an operation is in flight, spending real money, with no
+ * record anywhere.
+ *
+ * These are ORDERING assertions, and ordering is the whole fix, so they are
+ * source scans rather than behavioural tests: a unit test would need a bundler,
+ * and the property under test is "which line comes first".
+ *
+ * COMMENTS ARE STRIPPED BEFORE MATCHING. The block being pinned explains itself
+ * at length and names every symbol below, so scanning raw source would let a
+ * deleted call keep passing on the strength of a comment about it.
+ */
+
+const strip = (s: string) =>
+  s
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .filter((l) => !l.trim().startsWith("//"))
+    .join("\n");
+
+const EXECUTOR = strip(readFileSync(new URL("./executor.ts", import.meta.url), "utf8"));
+const INDEX = strip(readFileSync(new URL("./index.ts", import.meta.url), "utf8"));
+
+test("the hash is computed locally, BEFORE anyone is asked to accept the operation", () => {
+  // A userOpHash is a pure function of the packed op, the EntryPoint and the
+  // chain id — so it is knowable before the network exists, exactly as Vex
+  // computes keccak256 of a signed transaction before sendRawTransaction.
+  assert.match(EXECUTOR, /getUserOperationHash\(\{/);
+  const hashAt = EXECUTOR.indexOf("getUserOperationHash({");
+  const sendAt = EXECUTOR.indexOf("client.sendUserOperation(signed");
+  assert.ok(hashAt > 0 && sendAt > 0, "both call sites must exist");
+  assert.ok(hashAt < sendAt, "the hash must be derived before the send, not from it");
+});
+
+test("THE DURABLE ROW IS WRITTEN BEFORE THE BROADCAST", () => {
+  // The property the whole change exists for. If this inverts again, a lost
+  // response is once more an operation with no record.
+  const hookAt = EXECUTOR.indexOf("hooks.onSubmitted(userOpHash)");
+  const sendAt = EXECUTOR.indexOf("client.sendUserOperation(signed");
+  assert.ok(hookAt > 0 && sendAt > 0, "both call sites must exist");
+  assert.ok(hookAt < sendAt, "onSubmitted must run before the send");
+});
+
+test("a throw at the send edge is UNRESOLVED, never a revert", () => {
+  // "We asked and do not know whether the ask arrived" is not "the chain
+  // refused". index.ts already handles UserOpUnresolved correctly — budget held,
+  // row left 'submitted', a warn naming the hash — and could not reach that
+  // branch from the send edge because nothing threw the type.
+  assert.match(EXECUTOR, /try \{\s*accepted = await client\.sendUserOperation/);
+  assert.match(EXECUTOR, /catch \(err\) \{\s*throw new UserOpUnresolved\(userOpHash/);
+});
+
+test("THE SEND IS NEVER REPEATED", () => {
+  // The one mistake this shape exists to make impossible: a re-send is a second
+  // operation and a second spend. The receipt read is the only thing retried,
+  // and the send sits outside that loop by construction.
+  const loopAt = EXECUTOR.indexOf("for (let attempt = 1; attempt <= RECEIPT_ATTEMPTS");
+  const sendAt = EXECUTOR.indexOf("client.sendUserOperation(signed");
+  assert.ok(loopAt > 0 && sendAt > 0);
+  assert.ok(sendAt < loopAt, "the send must sit outside the retry loop");
+  assert.equal(
+    (EXECUTOR.match(/client\.sendUserOperation\(/g) ?? []).length,
+    1,
+    "exactly one send call site — a second is a second spend",
+  );
+});
+
+test("REFUSING TO BROADCAST UNTRACKED", () => {
+  // Only possible because the hook moved ahead of the send. While it ran after,
+  // a failed write was noted and tolerated because the money was already
+  // committed; now nothing has gone out, so not sending is the cheaper answer.
+  assert.match(INDEX, /if \(!wrote\) throw new NotRecorded\(userOpHash\)/);
+  assert.match(INDEX, /e instanceof NotRecorded/);
+  // And it must be classified, not left to the generic branch that writes
+  // 'reverted' with free-form text.
+  assert.match(INDEX, /reject_rule: "not-recorded"/);
+  const notRecordedAt = INDEX.indexOf("e instanceof NotRecorded");
+  const genericAt = INDEX.indexOf('reason = "couldn\'t submit: "');
+  assert.ok(notRecordedAt > 0, "the branch must exist");
+  if (genericAt > 0) {
+    assert.ok(notRecordedAt < genericAt, "it must be caught before the generic fallback");
+  }
+});
+
+test("both refusals carry the hash, so nothing is thrown away nameless", () => {
+  // The classes are the contract; index.ts branches on TYPE rather than on a
+  // message regex, which is how a receipt-wait timeout used to be booked as a
+  // revert in the first place.
+  const unresolved = new UserOpUnresolved("0xabc", "socket hang up");
+  assert.equal(unresolved.userOpHash, "0xabc");
+  assert.equal(unresolved.name, "UserOpUnresolved");
+
+  const notRecorded = new NotRecorded("0xdef");
+  assert.equal(notRecorded.userOpHash, "0xdef");
+  assert.equal(notRecorded.name, "NotRecorded");
+  assert.match(notRecorded.message, /Nothing was sent/);
+});
+
+test("REVERTED MEANS THE CHAIN REVERTED IT", () => {
+  // The generic catch wrote `status: "reverted"` for everything that was not a
+  // typed revert — a bundler refusal, an RPC failure, a calldata build that
+  // threw. All of those are claims about a chain that never saw the operation,
+  // written into the one place in this product that must not put words in the
+  // chain's mouth.
+  assert.match(INDEX, /status: onChain \? "reverted" : "rejected"/);
+  // And `onChain` must still be a TYPE test, not a message match — matching on
+  // a string is how a receipt-wait timeout ended up in the revert branch in the
+  // first place.
+  assert.match(INDEX, /const onChain = e instanceof UserOpReverted/);
+});
+
+test("an operation that WENT OUT is never booked as a failure beside itself", () => {
+  // `submittedRow` is set by the pre-broadcast write. If it is set and the error
+  // is not a typed revert, an op reached the bundler and something after it
+  // threw — the fill read, the gas pricing, an addFlow. The old code wrote
+  // `reverted` with no hash, so addTrade INSERTED rather than resolving in
+  // place: the same operation became two rows, one 'submitted' that the resolver
+  // would later settle and one 'reverted' that was simply false.
+  // ANCHORED ON THE BRANCH'S OWN SENTENCE, which is the only thing that tells
+  // it apart. Two earlier attempts were vacuous: a `// Roll back` comment anchor
+  // could never match because strip() removes comment lines, and
+  // `lastIndexOf("if (submittedRow) {")` found the UserOpUnresolved branch's
+  // identical guard instead, so deleting this branch entirely still passed.
+  // Verified by mutation: removing the block now fails this test.
+  const classifierAt = INDEX.indexOf("const onChain = e instanceof UserOpReverted");
+  assert.ok(classifierAt > 0, "the classifier must exist");
+  const said = INDEX.indexOf("was submitted, and then something after it failed");
+  assert.ok(said > 0, "the submitted-then-threw branch must exist");
+  assert.ok(said < classifierAt, "and must be handled before the terminal classification");
+  const branchAt = INDEX.lastIndexOf("if (submittedRow) {", said);
+  assert.ok(branchAt > 0, "its guard must sit above its message");
+  // It must settle the charge and RETURN. Falling through would release the
+  // reservation for an operation that is in flight — under-counting the day's
+  // spend by exactly that notional — and then write a terminal row for it.
+  const body = INDEX.slice(branchAt, classifierAt);
+  assert.match(body, /refreshBudget\(agentId\)/, "the in-flight charge must be settled, not dropped");
+  assert.match(body, /return;/, "it must not fall through to the terminal write");
+});

--- a/worker/src/send-edge.test.ts
+++ b/worker/src/send-edge.test.ts
@@ -153,3 +153,28 @@ test("an operation that WENT OUT is never booked as a failure beside itself", ()
   assert.match(body, /refreshBudget\(agentId\)/, "the in-flight charge must be settled, not dropped");
   assert.match(body, /return;/, "it must not fall through to the terminal write");
 });
+
+test("DELIVERY IS CHECKED WHEREVER A TOKEN WAS ACQUIRED, not only where the decode worked", () => {
+  // It used to sit three gates deep: inside `if (fillPair)`, inside
+  // `if (measured)`, inside `if (side === "buy")`. `fillPair` is assigned only
+  // in the Uniswap branch, under `sellIsUsdg !== buyIsUsdg`, under `if (symbol)`
+  // — so curve trades, Rialto swaps and stock-to-stock swaps got no delivery
+  // check at all. Curve is the venue where a token is minted by whoever wants it
+  // minted, and it was the one lane with nothing watching.
+  const gate = INDEX.indexOf("const acquired: { token:");
+  assert.ok(gate > 0, "the acquisition gate must exist");
+  assert.match(INDEX.slice(gate, gate + 700), /intent\.kind === "curve-trade"/, "curve must be covered");
+
+  // And it must run BEFORE the decode. `measured` is a receipt decode, and this
+  // check exists precisely because receipt logs are contract-authored: a token
+  // that fabricates a Transfer log is exactly the token whose decode should not
+  // be deciding whether to look. Vex computes delivery before the decode for
+  // this reason.
+  const decodeAt = INDEX.indexOf("const deltas = netTokenDeltas(");
+  assert.ok(decodeAt > 0, "the decode must exist");
+  assert.ok(gate < decodeAt, "delivery must not depend on the decode succeeding");
+
+  // Exactly one call site — the old thrice-gated copy is gone, not merely
+  // shadowed by the new one.
+  assert.equal((INDEX.match(/await checkDelivery\(/g) ?? []).length, 1);
+});

--- a/worker/src/thesis-policy.ts
+++ b/worker/src/thesis-policy.ts
@@ -2,10 +2,18 @@
  * WHAT AN AGENT MAY SAY IN PUBLIC.
  *
  * WHY THIS LIVES UNDER worker/ AND NOT web/lib. It was in web/src/lib, which
- * was right while a browser was the only reader. The orchestrator is now a
- * second one: it materialises each child's followed theses into a file the
- * agent's desk reads, and what it writes must be EXACTLY what the public feed
- * publishes — same allowlist, same address backstop, same fail-closed default.
+ * was right while a browser was the only reader. The move anticipates a second:
+ * the orchestrator is to materialise each child's followed theses into a file
+ * the agent's desk reads, and what it writes must be EXACTLY what the public
+ * feed publishes — same allowlist, same address backstop, same fail-closed
+ * default.
+ *
+ * THAT SECOND READER DOES NOT EXIST YET. There is no follow store, no peers
+ * file and no read_peers tool in this repo; this paragraph described them in
+ * the present tense for three weeks, which is the failure mode the rest of this
+ * module exists to prevent, committed in a comment about it. The move stands on
+ * its own regardless — see below — but nothing here is load-bearing for a
+ * consumer that has not been written.
  * The worker cannot import from web/src (imports.test.ts forbids @merrymen/*
  * under worker/src, and web/src is not aliased inward at all), so the choice
  * was to move the module or keep a second copy. A second copy of a PUBLICATION

--- a/worker/src/venues/bitquery.ts
+++ b/worker/src/venues/bitquery.ts
@@ -27,6 +27,7 @@
  */
 
 import { MERRYMEN_GATEWAY_ORIGIN } from "../../../packages/core/src/index";
+import { readBoundedJson } from "../bounded-read";
 
 /** Bitquery's V2 (streaming) GraphQL endpoint — the one carrying EVM(network:). */
 export const BITQUERY_DEFAULT_ENDPOINT = "https://streaming.bitquery.io/graphql";
@@ -154,7 +155,11 @@ export async function bitqueryQuery<T = unknown>(
             : "";
       return { ok: false, error: `bitquery HTTP ${res.status}${hint}` };
     }
-    const json = (await res.json()) as { data?: T; errors?: { message?: string }[] };
+    // Bounded — see bounded-read.ts. An over-long answer is reported as an
+    // unusable response, which is what it is; it is never read as no data.
+    const read = await readBoundedJson<{ data?: T; errors?: { message?: string }[] }>(res);
+    if (!read.ok) return { ok: false, error: `bitquery: ${read.detail.slice(0, 200)}` };
+    const json = read.value;
     if (json.errors?.length) {
       return { ok: false, error: `bitquery: ${json.errors.map((e) => e.message ?? "?").join("; ").slice(0, 300)}` };
     }

--- a/worker/src/venues/geckoterminal.ts
+++ b/worker/src/venues/geckoterminal.ts
@@ -28,6 +28,8 @@
  * its own — never in the trading tick.
  */
 
+import { readBoundedJson } from "../bounded-read";
+
 const GECKO_BASE = "https://api.geckoterminal.com/api/v2";
 
 /** The network slug for Robinhood Chain (4663) in GeckoTerminal's namespace. */
@@ -273,7 +275,12 @@ export async function fetchGeckoPoolsResult(
       signal: controller.signal,
     });
     if (!res.ok) return { pools: [], failed: true };
-    const body = (await res.json()) as { data?: unknown[] };
+    // Bounded: an unbounded read hands a third party this worker's memory
+    // ceiling. A refusal reads as `failed`, which is already the "we could not
+    // learn anything" branch — never as an empty market.
+    const read = await readBoundedJson<{ data?: unknown[] }>(res);
+    if (!read.ok) return { pools: [], failed: true };
+    const body = read.value;
     // A body with no `data` array is a shape we do not understand, not an empty
     // market. An empty `data` array IS an empty market, and reads as one.
     if (!Array.isArray(body?.data)) return { pools: [], failed: true };

--- a/worker/src/venues/research.ts
+++ b/worker/src/venues/research.ts
@@ -26,6 +26,7 @@
  */
 
 import { safeFetchUrl } from "../../../packages/core/src/index";
+import { readBoundedJson } from "../bounded-read";
 import { sanitizeMeta } from "./pons-meta";
 
 export interface PageRead {
@@ -88,8 +89,15 @@ export async function readPage(cfg: BrowserConfig | null, rawUrl: string): Promi
       const detail = await r.text().catch(() => "");
       return { ok: false, url, failure: "browser-error", detail: detail.slice(0, 200) };
     }
-    const page = (await r.json()) as PageRead;
-    return { ok: true, url, page };
+    // THE ADVERSARIAL LANE. `read_link` fetches a page an attacker chose, so
+    // this is the one read where an enormous body is a plausible act rather than
+    // a broken server. Bounded like the rest, and reported as a browser failure
+    // rather than as a page with no content.
+    const read = await readBoundedJson<PageRead>(r);
+    if (!read.ok) {
+      return { ok: false, url, failure: "browser-error", detail: read.detail.slice(0, 200) };
+    }
+    return { ok: true, url, page: read.value };
   } catch (e) {
     return { ok: false, url, failure: "unreachable", detail: String((e as Error)?.message ?? e).slice(0, 200) };
   } finally {

--- a/worker/src/venues/rialto.test.ts
+++ b/worker/src/venues/rialto.test.ts
@@ -53,7 +53,14 @@ describe("fetchRialtoQuote", () => {
     const f: FetchLike & { lastUrl?: string; lastHeaders?: Record<string, string> } = async (url, init) => {
       f.lastUrl = url;
       f.lastHeaders = init?.headers;
-      return { ok: status < 400, status, json: async () => body };
+      const text = JSON.stringify(body);
+      return {
+        ok: status < 400,
+        status,
+        headers: { get: () => null },
+        json: async () => body,
+        text: async () => text,
+      };
     };
     return f;
   }

--- a/worker/src/venues/rialto.ts
+++ b/worker/src/venues/rialto.ts
@@ -15,6 +15,7 @@
 
 import { isAddress, isHex, parseAbi, type PublicClient } from "viem";
 import { RIALTO } from "../../../packages/core/src/index";
+import { readBoundedJson } from "../bounded-read";
 
 const REGISTRY_ABI = parseAbi(["function ownerOf(uint256 id) view returns (address)"]);
 
@@ -93,10 +94,20 @@ export function parseRialtoQuote(
   return { quote: { to: to as `0x${string}`, data: data as `0x${string}`, value, buyAmountRaw } };
 }
 
+/**
+ * Widened to what a Response actually is, because the body is now read through
+ * bounded-read.ts rather than by calling `json()` — which needs the headers to
+ * consult content-length and `text()` for the no-stream fallback. A narrower
+ * double than the real thing would have let this compile while the production
+ * path took a branch no test could reach.
+ */
 export type FetchLike = (url: string, init?: { headers?: Record<string, string> }) => Promise<{
   ok: boolean;
   status: number;
+  headers: { get(name: string): string | null };
+  body?: unknown;
   json(): Promise<unknown>;
+  text(): Promise<string>;
 }>;
 
 export interface RialtoClientOpts {
@@ -139,11 +150,11 @@ export async function fetchRialtoQuote(
   }
   if (!res.ok) return { quote: null, reason: `quote API returned ${res.status}` };
 
-  let body: unknown;
-  try {
-    body = await res.json();
-  } catch {
-    return { quote: null, reason: "quote response is not JSON" };
-  }
+  // Bounded — see bounded-read.ts. Both failure modes read the same way to
+  // this caller: no quote, and a reason saying why rather than a null pretending
+  // the venue had nothing.
+  const read = await readBoundedJson<unknown>(res);
+  if (!read.ok) return { quote: null, reason: `quote response unusable: ${read.detail.slice(0, 160)}` };
+  const body: unknown = read.value;
   return parseRialtoQuote(body, args.expectedRouter);
 }


### PR DESCRIPTION
Vex's author asked how merrymen could be better than Vex. We traced both execution paths in full. **Vex has no ERC-4337 anywhere** — zero hits for `sendUserOperation`, any EntryPoint address, or any AA package; every signer is `privateKeyToAccount` and the broadcast is one `sendRawTransaction`. Their rail carries real transactions because nothing privileged is in the path.

That architecture isn't portable to us — the on-chain wall is the whole differentiator and it stays. Their **engineering** is, and this PR ports it.

Three facts came back from the chain, not from reasoning:

- **No Kernel account has ever been deployed.** `eth_getCode` is `0x` for all three known account addresses on 4663 *and* 46630. The wall this project is built around has never been evaluated by an EVM.
- **The live grant seals a RateLimitPolicy at a codeless address.** Kernel calls `checkUserOpPolicy`; a call to a codeless address returns empty and validation fails. That grant can never land a UserOp no matter what is funded. `index.ts` detected this and only *warned* — the agent armed anyway — and `preflight` never checked it at all.
- **We do not have Vex's re-quote bug.** Our quote is threaded `bestRoute` → `buildTradeCalls`, deliberately. Vex added quote-binding after a confirmed fill **263× worse than quoted**.

## Stage 1 — say what the rail is doing

Detected-and-ignored becomes detected-and-refused: a fifth `RefuseRule`, named ahead of `no-executor`/`wrong-chain`/`no-cash` because it is the only one funding, a bundler key and a chain switch all fail to fix. `preflight` now asks what *this signature* sealed, not just whether today's singletons are deployed — the test pins that the new blocker fires **while `policy-contracts` stays `ok`**, which is the shape that fooled the command. Something finally asks whether the account exists.

And the `warn` events nobody has ever seen are rendered on `/you`. Chief among them: *"no bundler key — this agent CANNOT trade live"*, raised under a comment reading `SAY IT WHERE THE OWNER WILL LOOK`, written and stored and filtered out of the only page that reads events. That is why 1,311 intents and zero fills read as a broken execution path when execution had simply never been configured.

The wire copy stopped lying too — four comments asserted a peer pipeline that does not exist, and the site-wide OG sold "wire them into your own agent's thinking".

## Stage 2 — the first operation is not the operation the ceiling was chosen for

`absoluteMax: 3M` reasons openly about "an approve plus an `exactInputSingle`". The first op also carries the factory `initCode`, the plugin-enable (~960 bytes of `ONE_OF` lists alone) and the enable-signature verification — and `boundGas` **refuses rather than clamps**, so that ceiling would have flatly refused your deploy with the words *"the operation is not the one it is meant to be."*

## Stage 4 — the fences

- **4.1 The hash exists before the network does.** Prepare, sign, hash, persist, *then* send. A send-edge throw is now `UserOpUnresolved` instead of three simultaneous wrong answers (budget released, `reverted` written about a chain that never saw it, no hash — leaving `resolveStrandedOps` structurally unable to find it). Verified against viem 2.55.0 rather than assumed. Also: **refusing to broadcast untracked**, which only became possible once the hook moved ahead of the send.
- **4.2 Read the bytes before signing them.** Byte-provenance *and* a decode that reads `amountOutMinimum` back out — equality, not "at least". Tests are fed from `buildTradeCalls`'s own output so an encoder change fails a test rather than turning the fence into a wall or an escape hatch.
- **4.3 Ask the token, on every lane that acquires one.** Delivery sat three gates deep, so curve trades, Rialto and stock→stock got no check at all — and curve is where honeypots live. It also ran *after* the receipt decode, which is backwards: this check exists because receipt logs are contract-authored.
- **4.4 Bound what a stranger can make this worker hold.** Enforced while reading, not measured afterwards.

## Verification

- **1845 tests pass**, typecheck clean. `wall.test.ts` and `paymaster.test.ts` untouched.
- Every source-scan assertion was **mutation-checked**. Two were vacuous on the first attempt — one anchored on a comment that the comment-stripper removes, one matching a guard the `UserOpUnresolved` branch has an identical copy of — and both now fail when the code is removed.
- `/you` verified in the browser.

## Stated gaps

`packages/core/src/mcp.ts` still reads unbounded: `packages/core` cannot import from `worker/src`, so it needs either a copy or a move, and neither belonged in this change. The v4 adapter and legacy Permit2 lanes are deliberately **not** fenced by 4.2 — scope is stated in the module rather than quietly exceeded.

Nothing here can make an agent trade. That still needs a bundler key, a grant re-signed on 4663, and funding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)