### PR TITLE
Stage A: stop the loop that was killing the fleet, and make it measurable

### DIFF
--- a/worker/src/circle.ts
+++ b/worker/src/circle.ts
@@ -9,6 +9,7 @@
  */
 
 import { createPublicClient, erc20Abi, http, type PublicClient } from "viem";
+import { metered } from "./rpc-meter";
 import {
   CIRCLE_TIERS,
   MERRYMEN_TOKEN,
@@ -37,7 +38,7 @@ export async function readHolderStatus(
   try {
     const client: PublicClient = createPublicClient({
       chain: robinhoodChain,
-      transport: http(rpcMainnet),
+      transport: metered(http(rpcMainnet), "read"),
     });
     const raw = (await client.readContract({
       address: MERRYMEN_TOKEN.address,

--- a/worker/src/deposit-log.ts
+++ b/worker/src/deposit-log.ts
@@ -110,13 +110,42 @@ export async function findTransferFlows(opts: {
   const span = opts.maxSpan ?? 10_000n;
   const me = addressTopic(smartAccount);
 
+  // A SHORT SCAN MUST NOT LOOK LIKE AN EMPTY ONE.
+  //
+  // getLogsAdaptive no longer loops forever on a rate limit; it returns what it
+  // covered and says so. That is better, but it moves a decision here: this
+  // caller advances a deposit cursor, and treating a half-scanned window as
+  // "no deposits found" would step the cursor past money that arrived.
+  //
+  // So incomplete coverage is raised, because the ONE caller
+  // (index.ts scanChainFlows) already catches and does exactly the right thing
+  // with it: "An RPC that will not answer is not evidence of no deposits. Leave
+  // the cursor where it is so the same window is retried."
+  const scanOrRefuse = async (
+    c: typeof chain,
+    address: `0x${string}`,
+    topics: (Hex | Hex[] | null)[],
+    lo: bigint,
+    hi: bigint,
+    sp: bigint,
+    log?: (m: string) => void,
+  ): Promise<RawLog[]> => {
+    const r = await getLogsAdaptive(c, { address, topics }, lo, hi, sp, log);
+    if (!r.complete) {
+      throw new Error(
+        `deposit scan covered only ${lo}..${r.scannedTo} of ${lo}..${hi} — refusing to advance the cursor past blocks nobody read`,
+      );
+    }
+    return r.logs;
+  };
+
   const raw: RawLog[] = [];
   for (const topics of [
     [TRANSFER_TOPIC, null, me], // inbound: to = us
     [TRANSFER_TOPIC, me, null], // outbound: from = us
   ] as (Hex | Hex[] | null)[][]) {
     raw.push(
-      ...(await getLogsAdaptive(chain, { address: usdgToken, topics }, fromBlock, toBlock, span, opts.log)),
+      ...(await scanOrRefuse(chain, usdgToken, topics, fromBlock, toBlock, span, opts.log)),
     );
   }
 

--- a/worker/src/executor.ts
+++ b/worker/src/executor.ts
@@ -14,6 +14,7 @@
  */
 
 import { http, createPublicClient, type Chain, type Hex } from "viem";
+import { metered } from "./rpc-meter";
 import { createKernelAccountClient } from "@zerodev/sdk";
 import { SponsorRefused, assertBoundsHeld, type Sponsor } from "./paymaster";
 import { KERNEL_V3_3, getEntryPoint } from "@zerodev/sdk/constants";
@@ -21,7 +22,7 @@ import { deserializeFlaggedPermissionAccount } from "./session-account";
 import { WALL_POLICY_FLAG } from "../../packages/core/src/index";
 import { userOpGasConfig } from "./gas";
 import { getUserOperationHash } from "viem/account-abstraction";
-import { boundGas, DEPLOY_GAS_BOUNDS, GAS_BOUNDS, type UserOpGas } from "./gas-limits";
+import { boundGas, DEPLOY_GAS_BOUNDS, GAS_BOUNDS, totalGas, type UserOpGas } from "./gas-limits";
 
 export interface Call {
   to: `0x${string}`;
@@ -172,7 +173,7 @@ export async function createAgentExecutor(opts: {
    */
   sponsor?: Sponsor;
 }): Promise<AgentExecutor> {
-  const publicClient = createPublicClient({ chain: opts.chain, transport: http(opts.rpcUrl) });
+  const publicClient = createPublicClient({ chain: opts.chain, transport: metered(http(opts.rpcUrl), "read") });
   const entryPoint = getEntryPoint("0.7");
 
   // NOT deserializePermissionAccount. That function silently drops the policy
@@ -194,7 +195,12 @@ export async function createAgentExecutor(opts: {
   const client = createKernelAccountClient({
     account,
     chain: opts.chain,
-    bundlerTransport: http(opts.bundlerUrl),
+    // METERED, NEVER MANAGED. This transport carries eth_sendUserOperation. It
+    // is counted so the bundler quota stays visible separately from the chain
+    // RPC, and it must never gain retry, queueing or dedupe: the send-edge
+    // rules — persist the hash, send once, never re-send — are the whole reason
+    // a lost operation is recoverable.
+    bundlerTransport: metered(http(opts.bundlerUrl), "bundler"),
     ...(opts.sponsor
       ? { paymaster: opts.sponsor.paymaster, paymasterContext: opts.sponsor.paymasterContext }
       : {}),
@@ -300,7 +306,31 @@ export async function createAgentExecutor(opts: {
       // WHICH CEILING APPLIES DEPENDS ON WHETHER THIS ACCOUNT EXISTS YET.
       // See DEPLOY_GAS_BOUNDS: the first op also deploys the account and enables
       // the permission validator, and the steady-state ceiling would refuse it.
-      const bounded = boundGas(first, second, (await isDeployed()) ? GAS_BOUNDS : DEPLOY_GAS_BOUNDS);
+      const accountLive = await isDeployed();
+      const bounds = accountLive ? GAS_BOUNDS : DEPLOY_GAS_BOUNDS;
+      const bounded = boundGas(first, second, bounds);
+
+      // SAY WHAT THE NUMBERS WERE.
+      //
+      // Twenty-four consecutive live attempts died on this path and left no gas
+      // figure anywhere, because `GasRefused.detail` only carries one on the
+      // absurd/unstable branches — a `gas-unreadable` refusal, which is what all
+      // twenty-four were, prints nothing at all. Diagnosing it meant decoding
+      // handleOps calldata from two unrelated landed transactions.
+      //
+      // One line, on every execution. `null` is printed as "unreadable" rather
+      // than as a zero: an estimate the bundler refused to give is not an
+      // estimate of nothing.
+      const fmt = (g: UserOpGas | null) =>
+        g === null
+          ? "unreadable"
+          : `call ${g.callGasLimit} + verif ${g.verificationGasLimit} + preVerif ${g.preVerificationGas} = ${totalGas(g)}`;
+      console.log(
+        `[gas] account ${accountLive ? "deployed" : "NOT deployed"} · ceiling ${bounds.absoluteMax} · ` +
+          `estimate1 ${fmt(first)} · estimate2 ${fmt(second)} · ` +
+          `signed ${bounded.ok ? totalGas(bounded.gas) : "refused"}` +
+          `${bounded.ok ? "" : ` (${bounded.rule})`}`,
+      );
       if (!bounded.ok) {
         // BEFORE the send, so nothing is spent and no 'submitted' row exists.
         // This is a pre-broadcast rejection in the same shape as a policy one.

--- a/worker/src/gas-limits.test.ts
+++ b/worker/src/gas-limits.test.ts
@@ -191,6 +191,15 @@ test("THE CALL SITE: the executor picks the ceiling by whether the account exist
   // consequence. Pin that the wide ceiling is reached only when the account has
   // no code, and that it stops applying once an op has been accepted.
   const src = readFileSync(new URL("./executor.ts", import.meta.url), "utf8");
-  assert.match(src, /await isDeployed\(\)\) \? GAS_BOUNDS : DEPLOY_GAS_BOUNDS/);
+  // Pinned on the PROPERTY, not the phrasing. This asserted one exact
+  // expression and broke when the same logic was split across two lines so the
+  // gas numbers could be logged — a test that fails on a rename while the
+  // behaviour is intact teaches the next person to stop reading it.
+  assert.match(src, /await isDeployed\(\)/, "the deploy state must be consulted");
+  assert.match(
+    src,
+    /\? GAS_BOUNDS : DEPLOY_GAS_BOUNDS/,
+    "deployed picks the steady-state ceiling, undeployed the wider one",
+  );
   assert.match(src, /deployed = true;/, "a landed send must retire the deploy ceiling");
 });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -22,6 +22,7 @@
  */
 
 import { rmSync, writeFileSync } from "node:fs";
+import { metered, resetRpcMeters, rpcSummaryLines } from "./rpc-meter";
 import {
   createPublicClient,
   encodeFunctionData,
@@ -2224,7 +2225,7 @@ async function main() {
       );
     }
 
-    const client = createPublicClient({ chain, transport: http(rpc) });
+    const client = createPublicClient({ chain, transport: metered(http(rpc), "read") });
 
     // ── THE WALL'S OWN CONTRACTS MUST EXIST ──────────────────────────────
     // Same discipline as the breaker below, applied to the singletons the
@@ -4163,7 +4164,21 @@ async function main() {
     }
   }
 
-  function heartbeat(blockNumber: bigint) {
+  /**
+   * LIVENESS, WHICH IS NOT THE SAME QUESTION AS "DID THE CHAIN ANSWER".
+   *
+   * The block number is optional now, and that is the whole fix. This used to
+   * be called once per tick, AFTER `readMarketSafety()` — so a rate-limited
+   * `eth_getBlockByNumber` threw out of the tick one line before the beat, the
+   * file went stale, and the orchestrator SIGKILLed a process that was working
+   * perfectly. 14.6% of ticks died that way, and each death fed the restart
+   * loop that caused the rate limiting in the first place.
+   *
+   * A heartbeat answers "is this process alive". That is true whether or not a
+   * third party answered an HTTP request, and conflating the two let a provider
+   * outage read as a dead worker.
+   */
+  function heartbeat(blockNumber?: bigint) {
     const at = Math.floor(Date.now() / 1000);
     const mode = paperActive() ? "paper" : active?.executor ? "live" : "idle";
     // WHO PAYS, reported rather than guessed. Only this process resolves it
@@ -4175,7 +4190,10 @@ async function main() {
       ensureHome();
       writeFileSync(
         homePaths.heartbeat(),
-        JSON.stringify({ at, block: blockNumber.toString(), mode, sponsorGas }),
+        // `block` is omitted rather than zeroed when the chain was not read:
+        // a zero here would be a claim about chain height, and the dashboard
+        // would render it. Absent means absent.
+        JSON.stringify({ at, ...(blockNumber === undefined ? {} : { block: blockNumber.toString() }), mode, sponsorGas }),
         "utf8",
       );
     } catch {
@@ -4193,16 +4211,61 @@ async function main() {
     if (active) void setAgentMode(active.agentId, mode, at, sponsorGas);
   }
 
+  /**
+   * One line per RPC provider, per tick, then the counters reset.
+   *
+   * Printed at the END of the tick and in a `finally`, so a tick that returns
+   * early — an unreadable market, an unread book, a disarmed agent — still
+   * reports what it spent. A measurement that only appears on the happy path
+   * would miss exactly the ticks worth measuring.
+   */
+  function reportRpc() {
+    for (const line of rpcSummaryLines()) console.log(line);
+    resetRpcMeters();
+  }
+
   async function tick() {
+    // BEAT FIRST, BEFORE ANY NETWORK CALL. See heartbeat() for why this line
+    // moved: everything below can fail on somebody else’s rate limit, and none
+    // of it changes whether this process is alive.
+    heartbeat();
+
     await refreshConfig();
     const armed = await syncGrant();
 
     const market = await readMarketSafety();
-    heartbeat(market.blockNumber);
+    // Beat again WITH the height once the chain has answered, so the file still
+    // carries block number whenever it is genuinely known.
+    heartbeat(market.blockNumber ?? undefined);
     console.log(
-      `[tick] mainnet block ${market.blockNumber} · sequencer ${market.sequencerUp ? "up" : "DOWN"} · ` +
-        `${market.pausedTokens.size} paused · ${market.staleFeeds.size} stale feeds`,
+      `[tick] mainnet block ${market.blockNumber ?? "unread"} · sequencer ${market.sequencerUp ? "up" : "DOWN"} · ` +
+        `${market.pausedTokens.size} paused · ${market.staleFeeds.size} stale · ${market.unread.length} unread`,
     );
+
+    // ── FAIL CLOSED ON AN UNKNOWN MARKET ────────────────────────────────
+    //
+    // This tick used to end here by THROWING, which is why the heartbeat above
+    // never got written and the orchestrator killed the process. It ends by
+    // RETURNING now, with the beat already recorded and the reason named.
+    //
+    // No trading decision changes: an unreadable market produced no trade
+    // before and produces no trade now. What changes is that the worker stays
+    // alive and says which reads failed, instead of dying and saying nothing.
+    if (market.unreadable) {
+      console.log(
+        `[tick] market unreadable (${market.unread.slice(0, 6).join(", ")}${market.unread.length > 6 ? "…" : ""}) — ` +
+          `no trading this tick. A fact about our reads, not about the market.`,
+      );
+      if (active) {
+        await addEvent(
+          active.agentId,
+          "warn",
+          `the market could not be read this tick (${market.unread.length} read(s) failed) — nothing was traded. ` +
+            `This says nothing about prices or liquidity; it retries on the next tick.`,
+        );
+      }
+      return;
+    }
 
     if (active && market.sequencerUp !== lastSequencerUp) {
       await addEvent(
@@ -4679,7 +4742,8 @@ async function main() {
           stale: p.priceStale,
         })),
         // The block the balances were read at — where an auditor re-reads from.
-        blockNumber: market.blockNumber,
+        // Non-null by construction: an unreadable market returned above.
+        blockNumber: market.blockNumber ?? undefined,
       });
     }
     await setPositions(
@@ -5339,7 +5403,12 @@ async function main() {
   const runLoop = () => {
     tick()
       .catch((e) => console.error("[tick]", e))
-      .finally(() => setTimeout(runLoop, cfg.tickSeconds * 1000));
+      // In the finally so a tick that threw still reports what it spent — the
+      // ticks that fail are exactly the ones whose RPC cost matters most.
+      .finally(() => {
+        reportRpc();
+        setTimeout(runLoop, cfg.tickSeconds * 1000);
+      });
   };
   runLoop();
 }

--- a/worker/src/inflight-reconcile.ts
+++ b/worker/src/inflight-reconcile.ts
@@ -37,6 +37,7 @@
  * like the Postgres store: this file is correct by test, proven by that run.
  */
 import { decodeEventLog, parseAbi, type Hex } from "viem";
+import { backoffMs, classifyRpcError } from "./rpc-error";
 import { netTokenDeltas, type ReceiptLog } from "./fills";
 import { ENTRYPOINT } from "../../packages/core/src/index";
 
@@ -105,9 +106,25 @@ export function addressTopic(addr: string): Hex {
  *
  * EXPORTED AND ADDRESS-AGNOSTIC because the deposit scanner needs exactly this
  * behaviour against the USDG token rather than the EntryPoint. Writing a second
- * halving loop is how the two drift: this one already knows that a failure at
- * span 1 is a bad block to step over rather than a range error to halve again.
+ * halving loop is how the two drift.
+ *
+ * RETURNS COVERAGE, NOT JUST LOGS. `complete: false` means the window was not
+ * fully scanned and the caller must not treat the absence of a log as evidence
+ * that no such log exists.
  */
+export interface AdaptiveLogs {
+  logs: RawLog[];
+  /** Did the scan actually cover fromBlock..toBlock? */
+  complete: boolean;
+  /** The last block genuinely scanned. Equals toBlock when complete. */
+  scannedTo: bigint;
+}
+
+/** Retries of one span before the sweep gives up and reports short coverage. */
+const MAX_RETRIES_PER_SPAN = 4;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 export async function getLogsAdaptive(
   chain: ReconcileChain,
   filter: { address: `0x${string}`; topics: (Hex | Hex[] | null)[] },
@@ -115,10 +132,11 @@ export async function getLogsAdaptive(
   toBlock: bigint,
   maxSpan: bigint,
   log?: (m: string) => void,
-): Promise<RawLog[]> {
+): Promise<AdaptiveLogs> {
   const out: RawLog[] = [];
   let cursor = fromBlock;
   let span = maxSpan;
+  let attempt = 0;
   while (cursor <= toBlock) {
     const end = cursor + span - 1n < toBlock ? cursor + span - 1n : toBlock;
     try {
@@ -130,18 +148,48 @@ export async function getLogsAdaptive(
       });
       out.push(...logs);
       cursor = end + 1n;
+      // A clean pass earns the retry budget back, so one blip mid-sweep does
+      // not doom the rest of a long window.
+      attempt = 0;
     } catch (e) {
-      // Almost always "block range too large" — halve and retry the same start.
-      if (span <= 1n) {
-        log?.(`getLogs failed on a single block ${cursor}, skipping it: ${e instanceof Error ? e.message : String(e)}`);
-        cursor += 1n;
-        span = maxSpan;
+      // A RATE LIMIT IS NOT A RANGE ERROR, and reading it as one was a fault
+      // that could not terminate. The old code halved the span on EVERY
+      // failure: under a sustained 429 it walked 10,000 -> 1 in fourteen
+      // requests (times four again, because viem retries 429 by default),
+      // advanced the cursor by ONE BLOCK, reset the span, and did it again.
+      // Traversing 200,000 blocks that way is millions of requests, and the
+      // requests were themselves the reason for the rate limit.
+      //
+      // Worse than the cost: at span 1 it STEPPED OVER the block. This sweep
+      // exists so a landed operation cannot go unreconciled and under-count the
+      // day’s spend, so silently skipping blocks broke the one property it is
+      // for.
+      const v = classifyRpcError(e);
+
+      if (v.kind === "range-too-large" && span > 1n) {
+        span = span / 2n;
         continue;
       }
-      span = span / 2n;
+
+      if (v.retryable && attempt < MAX_RETRIES_PER_SPAN) {
+        // Same span, same cursor. Nothing about the question was wrong.
+        const wait = v.retryAfterMs ?? backoffMs(attempt);
+        attempt += 1;
+        log?.(`getLogs ${v.kind} at ${cursor}..${end} — retrying the same span in ${wait}ms (${v.detail})`);
+        await sleep(wait);
+        continue;
+      }
+
+      // Out of retries, or a failure retrying cannot fix. STOP, and say the
+      // coverage is short. A caller that believes it saw every log in a window
+      // it did not actually cover is the failure mode; an explicit gap is not.
+      log?.(
+        `getLogs gave up at ${cursor} (${v.kind}: ${v.detail}) — scanned ${fromBlock}..${cursor - 1n} of ${fromBlock}..${toBlock}`,
+      );
+      return { logs: out, complete: false, scannedTo: cursor - 1n };
     }
   }
-  return out;
+  return { logs: out, complete: true, scannedTo: toBlock };
 }
 
 /**
@@ -176,9 +224,18 @@ export async function findOrphanOps(opts: {
     opts.log,
   );
 
+  // INCOMPLETE COVERAGE IS SAID OUT LOUD. An orphan sweep that scanned half
+  // its window and found nothing has not established that there are no orphans.
+  if (!logs.complete) {
+    opts.log?.(
+      `findOrphanOps covered only ${from}..${logs.scannedTo} of ${from}..${head} — ` +
+        `any op outside that range is still unreconciled`,
+    );
+  }
+
   const orphans: OrphanOp[] = [];
   const seen = new Set<string>(); // guard against the same op appearing twice in a window
-  for (const raw of logs) {
+  for (const raw of logs.logs) {
     let userOpHash: string;
     let success: boolean;
     try {
@@ -273,11 +330,13 @@ export async function resolveSubmittedOps(opts: {
       opts.maxSpan ?? 10_000n,
       opts.log,
     );
-    if (logs.length === 0) continue; // not found is NOT "reverted" — leave it be
+    // NOT FOUND IS NOT "REVERTED" — and a scan that did not finish has not even
+    // established "not found". Both leave the op exactly as it was.
+    if (!logs.complete || logs.logs.length === 0) continue;
 
     let decoded: { success: boolean } | null = null;
     let txHash = "";
-    for (const raw of logs) {
+    for (const raw of logs.logs) {
       try {
         const d = decodeEventLog({
           abi: ENTRYPOINT_ABI,

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -56,8 +56,25 @@ import { drainCommandResults, writeCommand } from "./command-files";
 
 /** How often to re-read the store for tenants added or killed. */
 const RECONCILE_MS = 15_000;
-/** A child with no fresh heartbeat for this many seconds is wedged → SIGKILL. */
-const WATCHDOG_STALE_SEC = 180;
+/**
+ * FLOOR for the staleness threshold. The real one is DERIVED per child — see
+ * `staleThresholdSec`.
+ *
+ * A CONSTANT HERE WAS A BUG, AND IT WAS ARITHMETIC RATHER THAN A RACE. The
+ * heartbeat is written once per tick, so the minimum possible gap between two
+ * beats is the tick period. With `MERRYMEN_TICK_SECONDS=240` on the hosted
+ * fleet and this fixed at 180, every child was SIGKILLed at ~185s — before its
+ * SECOND TICK EVER RAN. Measured: all 71 observed `heartbeat stale` events
+ * landed in a 181-196s band, which is exactly 180 plus one 15s poll interval.
+ *
+ * That killed the fleet in a loop: kill → re-arm → a 200,000-block getLogs
+ * sweep → rate limits → a tick that dies before writing its beat → kill again.
+ * Nothing about it required a slow RPC; the numbers alone guaranteed it.
+ *
+ * So the threshold is now computed from the tick this child actually runs, and
+ * this value is only the lower bound for a fast one.
+ */
+const WATCHDOG_STALE_FLOOR_SEC = 180;
 /** Don't watchdog a child until it's had a chance to write its first beat. */
 const WATCHDOG_GRACE_SEC = 90;
 /** Cap a child's heap well below the container so an OOM kills the offender, not the box. */
@@ -129,6 +146,30 @@ interface Child {
   tenant: `0x${string}`;
   startedAt: number;
   restarts: number;
+  /**
+   * Seconds without a heartbeat before this child is considered wedged.
+   *
+   * Per child rather than global, because `tickSeconds` is per tenant: the
+   * settings file the orchestrator writes for a child can override the fleet
+   * env var (settings.ts resolves file BEFORE env), so one global number cannot
+   * be correct for every child at once.
+   */
+  staleSec: number;
+}
+
+/**
+ * How long to wait for a beat from a child whose tick is `tickSeconds`.
+ *
+ * TWO TICKS PLUS THE GRACE PERIOD. One tick is the floor by definition — a beat
+ * cannot arrive sooner — so one tick of margin allows a single slow or failed
+ * pass without declaring the process dead, and the grace absorbs the watchdog's
+ * own 15s polling granularity. Below that, a healthy agent on a slow RPC is
+ * indistinguishable from a wedged one.
+ *
+ * Exported for the test that pins the invariant this replaced.
+ */
+export function staleThresholdSec(tickSeconds: number): number {
+  return Math.max(WATCHDOG_STALE_FLOOR_SEC, Math.ceil(tickSeconds) * 2 + WATCHDOG_GRACE_SEC);
 }
 
 const children = new Map<string, Child>();
@@ -213,18 +254,25 @@ async function writeGrantForChild(tenant: `0x${string}`): Promise<boolean> {
  * tick, and mergeSettings strips house keys + forces the RCE flags off, so what
  * the tenant stored can only ever be their own legitimate configuration.
  */
-async function writeSettingsForChild(tenant: `0x${string}`, seenBotTokens?: Set<string>): Promise<void> {
+async function writeSettingsForChild(
+  tenant: `0x${string}`,
+  seenBotTokens?: Set<string>,
+): Promise<MerrymenSettings | null> {
   try {
     const settings = await getSettingsStore().get(tenant);
-    if (!settings) return;
+    if (!settings) return null;
     if (seenBotTokens && settings.telegramBotToken && dedupeBotToken(settings, seenBotTokens)) {
       log(`${tenant}: telegram bot token already claimed by another tenant — telegram disabled for this child`);
     }
     const home = childHome(tenant);
     mkdirSync(home, { recursive: true });
     writeFileSync(path.join(home, "settings.json"), JSON.stringify(settings, null, 2), { encoding: "utf8", mode: 0o600 });
+    // Returned so the caller can size the watchdog to the tick THIS child will
+    // read. Nothing else about the write changes.
+    return settings;
   } catch {
     /* best-effort — the child falls back to defaults */
+    return null;
   }
 }
 
@@ -244,13 +292,18 @@ async function spawnChild(tenant: `0x${string}`, restarts = 0): Promise<void> {
     log(`${tenant}: no grant in the store — not spawning`);
     return;
   }
-  await writeSettingsForChild(tenant);
+  // The settings the child will actually read, so the watchdog can size its
+  // patience to the tick that child will actually run. `tickSeconds` resolves
+  // file-before-env (settings.ts), and the file is what we just wrote.
+  const settings = await writeSettingsForChild(tenant);
+  const tickSeconds = typeof settings?.tickSeconds === "number" ? settings.tickSeconds : envTickSeconds();
+  const staleSec = staleThresholdSec(tickSeconds);
   const proc = spawn(
     process.execPath,
     [`--max-old-space-size=${CHILD_MAX_OLD_SPACE_MB}`, "--import", "tsx", WORKER_ENTRY],
     { cwd: ROOT, env: childEnv(tenant), stdio: ["ignore", "pipe", "pipe"] },
   );
-  const child: Child = { proc, tenant, startedAt: Date.now(), restarts };
+  const child: Child = { proc, tenant, startedAt: Date.now(), restarts, staleSec };
   children.set(tenant, child);
   const tag = `[${tenant.slice(0, 8)}]`;
   const pipe = (stream: NodeJS.ReadableStream | null, sink: NodeJS.WriteStream) =>
@@ -264,7 +317,17 @@ async function spawnChild(tenant: `0x${string}`, restarts = 0): Promise<void> {
   pipe(proc.stderr, process.stderr);
 
   proc.on("exit", (code) => {
-    children.delete(tenant);
+    // ONLY IF THIS ENTRY IS STILL OURS.
+    //
+    // `children.delete(tenant)` unconditionally was a double-spawn generator.
+    // The watchdog deletes, SIGKILLs, and spawns a replacement which installs a
+    // NEW entry under the same key — and then this handler, running for the
+    // corpse, deleted the replacement. A second later the `!children.has`
+    // guard below was true and a SECOND child spawned. The first replacement
+    // was orphaned: still ticking, still hitting the RPC, invisible to the
+    // watchdog, never mirrored, sharing one home and one sqlite file with its
+    // own replacement. Measured: 105 spawns against 61 exits in one window.
+    if (children.get(tenant) === child) children.delete(tenant);
     if (stopping) return;
     log(`${tenant} exited (${code})`);
     // A long healthy run that then dies is a fresh incident, not a crash loop.
@@ -280,10 +343,25 @@ async function spawnChild(tenant: `0x${string}`, restarts = 0): Promise<void> {
       if (!stopping && !children.has(tenant)) void spawnChild(tenant, freshRestarts);
     }, delay);
   });
-  log(`${tenant} spawned (pid ${proc.pid})`);
+  log(`${tenant} spawned (pid ${proc.pid}) — tick ${tickSeconds}s, watchdog ${staleSec}s`);
 }
 
-/** Stop a child hard. SIGTERM first for a clean exit, then SIGKILL — a wedged tick only the OS can reclaim. */
+/** The fleet-wide tick, for a tenant whose own settings do not name one. */
+function envTickSeconds(): number {
+  const raw = Number(process.env.MERRYMEN_TICK_SECONDS);
+  return Number.isFinite(raw) && raw > 0 ? raw : 60;
+}
+
+/**
+ * Stop a child hard. SIGTERM first for a clean exit, then SIGKILL — a wedged
+ * tick only the OS can reclaim.
+ *
+ * The delete below is now load-bearing in the way this function always claimed:
+ * the exit handler compares identity, so removing our entry first genuinely
+ * does mark the exit as intentional. Before that comparison existed, this
+ * survived only because `releaseLease` happened to win a race against the
+ * handler's 1s respawn timer.
+ */
 function killChild(tenant: string): void {
   const child = children.get(tenant);
   if (!child) return;
@@ -609,9 +687,11 @@ export function watchdog(nowSec = Math.floor(Date.now() / 1000)): void {
     const ageSec = (Date.now() - child.startedAt) / 1000;
     if (ageSec < WATCHDOG_GRACE_SEC) continue; // give it time to write its first beat
     const beat = heartbeatAt(tenant);
-    const stale = beat === null || nowSec - beat > WATCHDOG_STALE_SEC;
+    const stale = beat === null || nowSec - beat > child.staleSec;
     if (stale) {
-      log(`${tenant} heartbeat stale (${beat === null ? "never beat" : `${nowSec - beat}s`}) — SIGKILL + restart`);
+      log(
+        `${tenant} heartbeat stale (${beat === null ? "never beat" : `${nowSec - beat}s`} > ${child.staleSec}s) — SIGKILL + restart`,
+      );
       const restarts = child.restarts;
       children.delete(tenant);
       try {

--- a/worker/src/rpc-error.test.ts
+++ b/worker/src/rpc-error.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { backoffMs, classifyRpcError } from "./rpc-error";
+
+/**
+ * The shapes below are the ones this chain actually produces, not invented
+ * ones. The decisive case is the first: what arrives from Robinhood's RPC is a
+ * viem `RpcRequestError` whose JSON-RPC body says "Rate Limit Hit" and which
+ * carries NO HTTP status at all — so a status-only classifier would miss every
+ * real rate limit and the whole module would be decorative.
+ */
+
+/** As viem constructs it: name, message, details, and a numeric `code`. */
+const rateLimited = () =>
+  Object.assign(new Error("RPC Request failed.\nDetails: Rate Limit Hit, limit will reset in 60 seconds"), {
+    name: "RpcRequestError",
+    details: "Rate Limit Hit, limit will reset in 60 seconds",
+    shortMessage: "RPC Request failed.",
+    code: 429,
+  });
+
+describe("classifyRpcError", () => {
+  it("recognises the rate limit THIS chain actually sends", () => {
+    const v = classifyRpcError(rateLimited());
+    assert.equal(v.kind, "rate-limited");
+    assert.equal(v.retryable, true);
+  });
+
+  it("recognises a rate limit with no status code at all", () => {
+    // The form that broke getLogsAdaptive: an RpcRequestError whose only signal
+    // is the body text. viem does not attach an HTTP status to these.
+    const bare = Object.assign(new Error("Rate Limit Hit, limit will reset in 60 seconds"), {
+      name: "RpcRequestError",
+    });
+    assert.equal(classifyRpcError(bare).kind, "rate-limited");
+  });
+
+  it("A RATE LIMIT IS NOT A RANGE ERROR, even when it says 'limit'", () => {
+    // The whole bug in one assertion. "limit will reset in 60 seconds" contains
+    // the word `limit`, and a looser matcher ordered the other way would call it
+    // range-too-large and start halving the span.
+    assert.equal(classifyRpcError(rateLimited()).kind, "rate-limited");
+    assert.notEqual(classifyRpcError(rateLimited()).kind, "range-too-large");
+  });
+
+  it("recognises a genuine range error, which IS a hint about the question", () => {
+    for (const msg of [
+      "query returned more than 10000 results",
+      "block range is too large",
+      "eth_getLogs: too many blocks requested",
+      "log response size exceeded",
+    ]) {
+      const v = classifyRpcError(new Error(msg));
+      assert.equal(v.kind, "range-too-large", msg);
+      // NOT retryable unchanged — the caller must narrow, not wait.
+      assert.equal(v.retryable, false, msg);
+    }
+  });
+
+  it("honours Retry-After, from a Headers object or a plain record", () => {
+    const withHeaders = Object.assign(new Error("Too Many Requests"), {
+      name: "HttpRequestError",
+      status: 429,
+      headers: new Headers({ "retry-after": "42" }),
+    });
+    assert.equal(classifyRpcError(withHeaders).retryAfterMs, 42_000);
+
+    const withRecord = Object.assign(new Error("Too Many Requests"), {
+      status: 429,
+      headers: { "Retry-After": "7" },
+    });
+    assert.equal(classifyRpcError(withRecord).retryAfterMs, 7_000);
+  });
+
+  it("a revert is an ANSWER, and retrying gets the same one", () => {
+    const v = classifyRpcError(new Error("execution reverted: STF"));
+    assert.equal(v.kind, "reverted");
+    assert.equal(v.retryable, false);
+  });
+
+  it("timeouts and transport failures are retryable; they say nothing about the answer", () => {
+    assert.equal(classifyRpcError(new Error("The request timed out.")).kind, "timeout");
+    assert.equal(classifyRpcError(new Error("fetch failed")).kind, "transport");
+    assert.equal(classifyRpcError(Object.assign(new Error("bad gateway"), { status: 502 })).kind, "transport");
+    for (const e of ["The request timed out.", "fetch failed", "socket hang up"]) {
+      assert.equal(classifyRpcError(new Error(e)).retryable, true, e);
+    }
+  });
+
+  it("AN UNRECOGNISED FAILURE IS NOT RETRYABLE", () => {
+    // When in doubt, stop. An unrecognised failure retried forever is how one
+    // rate limit became millions of requests; surfaced once, it is a bug report.
+    const v = classifyRpcError(new Error("something nobody has seen before"));
+    assert.equal(v.kind, "other");
+    assert.equal(v.retryable, false);
+  });
+
+  it("never throws, whatever it is handed", () => {
+    for (const junk of [null, undefined, 42, "a string", {}, [], new Error("")]) {
+      const v = classifyRpcError(junk);
+      assert.ok(typeof v.kind === "string" && typeof v.retryable === "boolean", String(junk));
+      assert.ok(v.detail.length > 0);
+    }
+  });
+});
+
+describe("backoffMs", () => {
+  it("grows exponentially and stays under the cap", () => {
+    for (let a = 0; a < 12; a++) {
+      const ms = backoffMs(a, 500, 30_000);
+      assert.ok(ms >= 0 && ms <= 30_000, `attempt ${a} gave ${ms}`);
+    }
+  });
+
+  it("IS FULLY JITTERED, because the callers were rate-limited in step", () => {
+    // A fleet of agents throttled by the same provider at the same instant must
+    // not come back at the same instant either. Full jitter, not a ±10% wobble:
+    // the whole distribution has to spread, so the samples must differ.
+    const samples = new Set(Array.from({ length: 40 }, () => backoffMs(6, 500, 30_000)));
+    assert.ok(samples.size > 20, `expected a spread, got ${samples.size} distinct values`);
+  });
+});

--- a/worker/src/rpc-error.ts
+++ b/worker/src/rpc-error.ts
@@ -1,0 +1,177 @@
+/**
+ * WHAT WENT WRONG, AND WHOSE FAULT IT IS.
+ *
+ * merrymen's whole doctrine is that "we could not read" must never render as
+ * "there is nothing there". Every module that gets this right — `delivery.ts`
+ * on a balance, `read-candles.ts` on a chart, `recover.ts` on a token, the
+ * three-way policy-contract probe in `index.ts` — reaches the same shape: a
+ * closed union with a distinct arm for the failure to ask, never a sentinel.
+ *
+ * On the RPC path that shape was missing, and the cost was measured. Every
+ * quote helper catches and returns `null`, so an HTTP 429 and a pool that does
+ * not exist produce the identical value; the worker then books `no-route` and
+ * the public feed publishes "no route to trade it" — a claim about the chain,
+ * manufactured out of our own rate limit. And `getLogsAdaptive` read every
+ * failure as "block range too large", halving its span on a 429 until it was
+ * asking one block at a time, then STEPPING OVER that block.
+ *
+ * This is the classifier those paths need. It is pure, it does not throw, and
+ * it mirrors the vocabulary the repo already uses everywhere else — a `kind`
+ * from a closed union of string literals plus the one bit callers actually
+ * branch on, `retryable`, which `revert.ts` established.
+ *
+ * STAGE A USES IT IN EXACTLY ONE PLACE: `getLogsAdaptive`. Rewiring the quote
+ * helpers onto it is deliberately a separate change, because altering what a
+ * 429 MEANS at the same time as altering how often we make requests would make
+ * the fleet measurement that follows uninterpretable.
+ */
+
+export type RpcErrorKind =
+  /** The provider refused because we asked too often. Ours to fix, not the chain's. */
+  | "rate-limited"
+  /** The request timed out or the socket died. Says nothing about the answer. */
+  | "timeout"
+  /** DNS, TLS, connection refused — the provider was not reachable at all. */
+  | "transport"
+  /** The provider will answer, but not for a window this wide. A real hint. */
+  | "range-too-large"
+  /** The contract itself reverted. This IS an answer, and usually a business one. */
+  | "reverted"
+  /** Classified as nothing. Treated as NOT retryable — see below. */
+  | "other";
+
+export interface RpcErrorVerdict {
+  kind: RpcErrorKind;
+  /**
+   * Is asking again, unchanged, a reasonable thing to do?
+   *
+   * FALSE FOR `other`, deliberately. An unrecognised failure retried forever is
+   * how a rate limit became eleven million requests; an unrecognised failure
+   * surfaced once is a bug report. When in doubt, stop.
+   */
+  retryable: boolean;
+  /** Milliseconds the provider asked us to wait, when it said so. */
+  retryAfterMs?: number;
+  /** The original text, bounded, for a log line a person will read. */
+  detail: string;
+}
+
+/** `Retry-After` is seconds, or an HTTP date. Returns ms, or undefined. */
+function retryAfterMs(raw: unknown): number | undefined {
+  if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) return raw * 1000;
+  if (typeof raw !== "string") return undefined;
+  const secs = Number(raw.trim());
+  if (Number.isFinite(secs) && secs >= 0) return secs * 1000;
+  const at = Date.parse(raw);
+  if (Number.isFinite(at)) return Math.max(0, at - Date.now());
+  return undefined;
+}
+
+/** Pull a `Retry-After` out of whatever shape the error carries it in. */
+function headerRetryAfter(e: unknown): number | undefined {
+  const o = e as { headers?: unknown; response?: { headers?: unknown } } | null;
+  for (const h of [o?.headers, o?.response?.headers]) {
+    if (!h) continue;
+    // A real Headers object, or a plain record.
+    const get = (h as { get?: (k: string) => string | null }).get;
+    if (typeof get === "function") {
+      const v = get.call(h, "retry-after");
+      const ms = retryAfterMs(v);
+      if (ms !== undefined) return ms;
+      continue;
+    }
+    const rec = h as Record<string, unknown>;
+    const ms = retryAfterMs(rec["retry-after"] ?? rec["Retry-After"]);
+    if (ms !== undefined) return ms;
+  }
+  return undefined;
+}
+
+/**
+ * Classify a caught RPC failure.
+ *
+ * Matches on TEXT as well as on codes, because the shape that actually arrives
+ * from this chain is a viem `RpcRequestError` whose JSON-RPC body says
+ * `Rate Limit Hit, limit will reset in 60 seconds` — there is no HTTP status on
+ * it at all, so a status-only classifier would miss every real case.
+ */
+export function classifyRpcError(e: unknown): RpcErrorVerdict {
+  const err = e as { name?: string; message?: string; details?: string; shortMessage?: string; code?: unknown; status?: unknown; cause?: unknown } | null;
+  const text = [err?.message, err?.details, err?.shortMessage, err?.name]
+    .filter((v): v is string => typeof v === "string")
+    .join(" ");
+  const lower = text.toLowerCase();
+  const detail = text.replace(/\s+/g, " ").trim().slice(0, 200) || "no message";
+
+  const codes: unknown[] = [err?.code, err?.status, (err?.cause as { code?: unknown } | null)?.code, (err?.cause as { status?: unknown } | null)?.status];
+  const is = (n: number) => codes.some((c) => c === n || c === String(n));
+
+  // ── rate limited ──────────────────────────────────────────────────────
+  // Checked FIRST. A 429 can also mention "limit", and reading it as a range
+  // hint is the exact bug this module was written to end.
+  if (is(429) || lower.includes("rate limit") || lower.includes("too many requests")) {
+    return { kind: "rate-limited", retryable: true, retryAfterMs: headerRetryAfter(e), detail };
+  }
+
+  // ── range too large ───────────────────────────────────────────────────
+  // A genuine hint about the QUESTION, not about our rate. Narrowing helps.
+  if (
+    lower.includes("block range") ||
+    lower.includes("range too large") ||
+    lower.includes("too many blocks") ||
+    lower.includes("query returned more than") ||
+    lower.includes("log response size exceeded") ||
+    lower.includes("exceeds the limit")
+  ) {
+    return { kind: "range-too-large", retryable: false, detail };
+  }
+
+  // ── reverted ──────────────────────────────────────────────────────────
+  // The chain answered. Retrying an identical call gets an identical revert.
+  if (
+    lower.includes("execution reverted") ||
+    lower.includes("reverted with") ||
+    err?.name === "ContractFunctionRevertedError" ||
+    err?.name === "CallExecutionError"
+  ) {
+    return { kind: "reverted", retryable: false, detail };
+  }
+
+  // ── timeout ───────────────────────────────────────────────────────────
+  if (
+    lower.includes("timed out") ||
+    lower.includes("timeout") ||
+    err?.name === "TimeoutError" ||
+    err?.name === "AbortError" ||
+    is(408)
+  ) {
+    return { kind: "timeout", retryable: true, retryAfterMs: headerRetryAfter(e), detail };
+  }
+
+  // ── transport ─────────────────────────────────────────────────────────
+  if (
+    lower.includes("fetch failed") ||
+    lower.includes("econnrefused") ||
+    lower.includes("econnreset") ||
+    lower.includes("enotfound") ||
+    lower.includes("socket hang up") ||
+    lower.includes("network") ||
+    err?.name === "HttpRequestError" ||
+    is(502) ||
+    is(503) ||
+    is(504)
+  ) {
+    return { kind: "transport", retryable: true, retryAfterMs: headerRetryAfter(e), detail };
+  }
+
+  return { kind: "other", retryable: false, detail };
+}
+
+/** Base delay for the nth retry (0-indexed), exponential and jittered. */
+export function backoffMs(attempt: number, baseMs = 500, capMs = 30_000): number {
+  const exp = Math.min(capMs, baseMs * 2 ** Math.max(0, attempt));
+  // FULL jitter, not a ±10% wobble. The failure being spread here is a fleet of
+  // agents that were rate-limited by the same provider at the same instant, so
+  // they must not come back in step either.
+  return Math.floor(Math.random() * exp);
+}

--- a/worker/src/rpc-meter.ts
+++ b/worker/src/rpc-meter.ts
@@ -1,0 +1,161 @@
+/**
+ * WHAT WE ACTUALLY ASK THE CHAIN FOR, COUNTED.
+ *
+ * Nothing in the worker has ever known. Every transport is `http()` with no
+ * options, built at five separate sites, so there is no chokepoint — nowhere to
+ * count, and nowhere to put a limiter later.
+ *
+ * The gap this leaves is not academic. In the logs no `eth_call` has EVER
+ * appeared in a rate-limit line, because every quote helper catches and returns
+ * `null`; the only 429s that get seen are the handful that escape a catch. So
+ * roughly 95% of the traffic by count is invisible, and any limiter sized
+ * against what the logs show would be sized against the wrong number.
+ *
+ * THIS CHANGES NO BEHAVIOUR. It does not queue, delay, retry, batch, dedupe or
+ * refuse. It forwards every request untouched and records what happened. That
+ * is deliberate: the fleet is currently in a restart storm of its own making,
+ * and the whole point of measuring first is to size the limiter against a
+ * healthy fleet rather than against the storm.
+ *
+ * It is also the seam. When the limiter arrives it goes here, and no call site
+ * changes.
+ */
+import type { Transport } from "viem";
+import { classifyRpcError, type RpcErrorKind } from "./rpc-error";
+
+interface MethodStat {
+  calls: number;
+  errors: number;
+  totalMs: number;
+  maxMs: number;
+  byKind: Partial<Record<RpcErrorKind, number>>;
+}
+
+interface Meter {
+  label: string;
+  since: number;
+  calls: number;
+  errors: number;
+  inFlight: number;
+  peakInFlight: number;
+  byMethod: Map<string, MethodStat>;
+}
+
+const meters = new Map<string, Meter>();
+
+function meterFor(label: string): Meter {
+  let m = meters.get(label);
+  if (!m) {
+    m = { label, since: Date.now(), calls: 0, errors: 0, inFlight: 0, peakInFlight: 0, byMethod: new Map() };
+    meters.set(label, m);
+  }
+  return m;
+}
+
+function statFor(m: Meter, method: string): MethodStat {
+  let s = m.byMethod.get(method);
+  if (!s) {
+    s = { calls: 0, errors: 0, totalMs: 0, maxMs: 0, byKind: {} };
+    m.byMethod.set(method, s);
+  }
+  return s;
+}
+
+/**
+ * Wrap a viem transport so every request is counted.
+ *
+ * `label` separates the read RPC from the bundler, because they are different
+ * providers with different quotas and conflating them would hide which one is
+ * under pressure.
+ */
+export function metered(transport: Transport, label: string): Transport {
+  return ((opts) => {
+    const inner = transport(opts);
+    const m = meterFor(label);
+    return {
+      ...inner,
+      async request(args: { method: string; params?: unknown }, reqOpts?: unknown) {
+        const method = typeof args?.method === "string" ? args.method : "unknown";
+        const s = statFor(m, method);
+        const started = Date.now();
+        m.calls += 1;
+        s.calls += 1;
+        m.inFlight += 1;
+        if (m.inFlight > m.peakInFlight) m.peakInFlight = m.inFlight;
+        try {
+          // FORWARDED UNTOUCHED. No retry, no queue, no transformation of the
+          // result or of the error — a meter that changed an outcome would be
+          // measuring itself.
+          return await (inner.request as (a: unknown, o?: unknown) => Promise<unknown>)(args, reqOpts);
+        } catch (e) {
+          m.errors += 1;
+          s.errors += 1;
+          const kind = classifyRpcError(e).kind;
+          s.byKind[kind] = (s.byKind[kind] ?? 0) + 1;
+          throw e;
+        } finally {
+          m.inFlight -= 1;
+          const ms = Date.now() - started;
+          s.totalMs += ms;
+          if (ms > s.maxMs) s.maxMs = ms;
+        }
+      },
+    };
+  }) as Transport;
+}
+
+/** One line per meter: totals, peak concurrency, and the busiest methods. */
+export function rpcSummaryLines(): string[] {
+  const out: string[] = [];
+  for (const m of meters.values()) {
+    if (m.calls === 0) continue;
+    const secs = Math.max(1, Math.round((Date.now() - m.since) / 1000));
+    const top = [...m.byMethod.entries()]
+      .sort((a, b) => b[1].calls - a[1].calls)
+      .slice(0, 6)
+      .map(([method, s]) => {
+        const avg = Math.round(s.totalMs / Math.max(1, s.calls));
+        const kinds = Object.entries(s.byKind)
+          .map(([k, n]) => `${k}:${n}`)
+          .join(",");
+        return `${method} ${s.calls}${s.errors ? `/${s.errors}err` : ""} avg${avg}ms${kinds ? ` [${kinds}]` : ""}`;
+      })
+      .join(" · ");
+    const rateLimited = [...m.byMethod.values()].reduce((n, s) => n + (s.byKind["rate-limited"] ?? 0), 0);
+    out.push(
+      `[rpc:${m.label}] ${m.calls} calls in ${secs}s (${(m.calls / secs).toFixed(2)}/s) · ` +
+        `${m.errors} err · ${rateLimited} rate-limited · peak concurrency ${m.peakInFlight} · ${top}`,
+    );
+  }
+  return out;
+}
+
+/**
+ * Reset the counters after a summary so each line covers one window rather than
+ * all of history. `peakInFlight` resets too — a high-water mark from an hour ago
+ * says nothing about what a limiter needs to bound now.
+ */
+export function resetRpcMeters(): void {
+  for (const m of meters.values()) {
+    m.since = Date.now();
+    m.calls = 0;
+    m.errors = 0;
+    m.peakInFlight = m.inFlight;
+    m.byMethod.clear();
+  }
+}
+
+/** Test seam. */
+export function rpcMeterSnapshot(): { label: string; calls: number; errors: number; peakInFlight: number }[] {
+  return [...meters.values()].map((m) => ({
+    label: m.label,
+    calls: m.calls,
+    errors: m.errors,
+    peakInFlight: m.peakInFlight,
+  }));
+}
+
+/** Test seam: forget every meter. */
+export function resetRpcMetersForTest(): void {
+  meters.clear();
+}

--- a/worker/src/snapshot.ts
+++ b/worker/src/snapshot.ts
@@ -7,6 +7,7 @@
  */
 
 import { createPublicClient, http, parseAbi, type PublicClient } from "viem";
+import { metered } from "./rpc-meter";
 import {
   CASH,
   CHAINLINK_ABI,
@@ -25,11 +26,11 @@ const VAULT_READS = parseAbi([
   "function convertToAssets(uint256 shares) view returns (uint256)",
 ]);
 
-let mainnet = createPublicClient({ chain: robinhoodChain, transport: http() });
+let mainnet = createPublicClient({ chain: robinhoodChain, transport: metered(http(), "read") });
 
 /** Point safety reads at a custom mainnet RPC (settings/env); undefined = chain default. */
 export function setMainnetRpc(url?: string): void {
-  mainnet = createPublicClient({ chain: robinhoodChain, transport: http(url) });
+  mainnet = createPublicClient({ chain: robinhoodChain, transport: metered(http(url), "read") });
 }
 
 /**
@@ -53,41 +54,90 @@ export interface MarketSafety {
    */
   prices: Map<string, PriceQuote>;
   sequencerUp: boolean;
-  blockNumber: bigint;
+  /** Chain height, or null when the block could not be read. Null is not zero. */
+  blockNumber: bigint | null;
+  /**
+   * Symbols whose feed we COULD NOT READ, as distinct from feeds that answered
+   * and were old.
+   *
+   * THE ASYMMETRY THIS FIXES WAS IN THIS FILE. Twenty lines below,
+   * `readAccountBalances` already carries `unread: string[]` and explains why;
+   * this function put an unreadable feed into `staleFeeds` instead — and
+   * `staleFeeds` is a claim about the ORACLE. Attributing our own rate limit to
+   * Chainlink is exactly the mistake delivery.ts, read-candles.ts and the
+   * three-way policy probe were each written to prevent.
+   */
+  unread: string[];
+  /**
+   * True when the market could not be read well enough to trade on.
+   *
+   * The tick fails CLOSED on this, the same way it already does for
+   * `unreadBook`. Nothing about which trades are allowed changes: an
+   * unreadable market already produced no trade, by throwing the whole tick.
+   * The difference is that it now produces no trade AND a heartbeat AND a
+   * reason with a name.
+   */
+  unreadable: boolean;
 }
 
 export async function readMarketSafety(): Promise<MarketSafety> {
   const withFeed = STOCK_TOKENS.filter((t) => t.chainlinkFeed !== null);
 
+  // GUARDED PER LEG, like readAccountBalances below and unlike this function
+  // before it. An unguarded Promise.all here threw the whole tick on a single
+  // rate-limited eth_getBlockByNumber — one line before the heartbeat was
+  // written — so a busy provider read as a dead worker and the orchestrator
+  // SIGKILLed a process that was working. 14.6% of ticks died that way, and
+  // every death fed the restart loop that caused the rate limiting.
   const [block, pausedResults, feedResults] = await Promise.all([
-    mainnet.getBlock({ blockTag: "latest" }),
-    mainnet.multicall({
-      contracts: STOCK_TOKENS.map(
-        (t) => ({ address: t.address, abi: STOCK_ABI, functionName: "tokenPaused" }) as const,
-      ),
-    }),
-    mainnet.multicall({
-      contracts: withFeed.map(
-        (t) =>
-          ({ address: t.chainlinkFeed!, abi: CHAINLINK_ABI, functionName: "latestRoundData" }) as const,
-      ),
-    }),
+    mainnet.getBlock({ blockTag: "latest" }).catch(() => null),
+    mainnet
+      .multicall({
+        contracts: STOCK_TOKENS.map(
+          (t) => ({ address: t.address, abi: STOCK_ABI, functionName: "tokenPaused" }) as const,
+        ),
+      })
+      .catch(() => null),
+    mainnet
+      .multicall({
+        contracts: withFeed.map(
+          (t) =>
+            ({ address: t.chainlinkFeed!, abi: CHAINLINK_ABI, functionName: "latestRoundData" }) as const,
+        ),
+      })
+      .catch(() => null),
   ]);
 
   const now = Math.floor(Date.now() / 1000);
 
+  const unread: string[] = [];
+
+  // A PAUSE WE COULD NOT READ IS NOT AN UNPAUSED TOKEN. The whole multicall
+  // failing means we know nothing about any of them, which is a reason to
+  // refuse the tick rather than to trade as though every token were live.
   const pausedTokens = new Set<string>();
-  STOCK_TOKENS.forEach((t, i) => {
-    const r = pausedResults[i];
-    if (r?.status === "success" && (r.result as boolean)) pausedTokens.add(t.address.toLowerCase());
-  });
+  if (pausedResults === null) {
+    unread.push("token-pause-state");
+  } else {
+    STOCK_TOKENS.forEach((t, i) => {
+      const r = pausedResults[i];
+      if (r?.status === "success" && (r.result as boolean)) pausedTokens.add(t.address.toLowerCase());
+      else if (r?.status !== "success") unread.push(t.symbol);
+    });
+  }
 
   const staleFeeds = new Set<string>();
   const prices = new Map<string, PriceQuote>();
+  if (feedResults === null) {
+    withFeed.forEach((t) => unread.push(t.symbol));
+  } else
   withFeed.forEach((t, i) => {
     const r = feedResults[i];
     if (r?.status !== "success") {
-      staleFeeds.add(t.symbol);
+      // UNREAD, not stale. See the note on `unread` above: "the feed is old" and
+      // "we could not ask the feed" have different causes and different
+      // remedies, and only one of them is Chainlink's.
+      unread.push(t.symbol);
       return;
     }
     const [, answer, , updatedAt] = r.result as readonly [bigint, bigint, bigint, bigint, bigint];
@@ -100,9 +150,26 @@ export async function readMarketSafety(): Promise<MarketSafety> {
 
   // Sequencer heuristic until the Chainlink sequencer-uptime feed address is
   // confirmed for 4663: a healthy sequencer produces blocks continuously.
-  const sequencerUp = now - Number(block.timestamp) < 120;
+  //
+  // AN UNREAD BLOCK IS NOT A DOWN SEQUENCER. Reporting `false` here would have
+  // the tick announce "sequencer DOWN — all trading paused" to every owner on
+  // the strength of our own 429, so the unreadable flag carries it instead.
+  const sequencerUp = block === null ? false : now - Number(block.timestamp) < 120;
 
-  return { pausedTokens, staleFeeds, prices, sequencerUp, blockNumber: block.number };
+  // Unreadable when the block did not answer, or when the pause state is
+  // entirely unknown, or when NO feed answered at all. A handful of missing
+  // feeds is ordinary and stays a per-symbol fact.
+  const unreadable = block === null || pausedResults === null || (withFeed.length > 0 && prices.size === 0);
+
+  return {
+    pausedTokens,
+    staleFeeds,
+    prices,
+    sequencerUp,
+    blockNumber: block === null ? null : block.number,
+    unread,
+    unreadable,
+  };
 }
 
 export interface AccountBalances {

--- a/worker/src/stop-the-loop.test.ts
+++ b/worker/src/stop-the-loop.test.ts
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { getLogsAdaptive } from "./inflight-reconcile";
+import { staleThresholdSec } from "./orchestrator";
+
+/**
+ * THE LOOP THAT KILLED THE FLEET, PINNED SO IT CANNOT COME BACK.
+ *
+ * None of this was a race. `MERRYMEN_TICK_SECONDS=240` against
+ * `WATCHDOG_STALE_SEC=180`, with the heartbeat written once per tick, means the
+ * minimum gap between two beats exceeds the kill threshold — so every child was
+ * SIGKILLed at ~185s, before its second tick ever ran. All 71 observed
+ * `heartbeat stale` events landed in a 181-196s band, which is 180 plus one 15s
+ * poll and nothing else.
+ *
+ * The kill fed a re-arm, the re-arm fed a 200,000-block getLogs sweep, the
+ * sweep fed the rate limiting, the rate limiting killed the tick one line
+ * before the heartbeat, and that fed the kill.
+ */
+
+const strip = (s: string) =>
+  s
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .filter((l) => !l.trim().startsWith("//") && !l.trim().startsWith("*"))
+    .join("\n");
+
+const at = (p: string) => readFileSync(new URL(p, import.meta.url), "utf8");
+
+describe("A1 — the watchdog cannot be shorter than the tick", () => {
+  it("a 240s tick gets a threshold well above 240s", () => {
+    // The exact configuration that was killing the hosted fleet.
+    const t = staleThresholdSec(240);
+    assert.ok(t > 240, `240s tick must not be killed at ${t}s`);
+    assert.equal(t, 240 * 2 + 90);
+  });
+
+  it("keeps a floor for fast ticks", () => {
+    // A 15s tick must not get a 120s watchdog — the floor is what stops a fast
+    // agent being declared dead over one slow pass.
+    assert.equal(staleThresholdSec(15), 180);
+    // The floor binds up to a 45s tick (45*2+90 = 180); above that the derived
+    // value takes over, which is the point.
+    assert.equal(staleThresholdSec(45), 180);
+    assert.equal(staleThresholdSec(60), 210);
+  });
+
+  it("is monotonic, so a slower tick is never treated more harshly", () => {
+    let prev = 0;
+    for (const tick of [15, 30, 60, 120, 240, 600, 3600]) {
+      const t = staleThresholdSec(tick);
+      assert.ok(t >= prev, `tick ${tick} gave ${t} after ${prev}`);
+      assert.ok(t > tick, `tick ${tick} must not be killed at ${t}`);
+      prev = t;
+    }
+  });
+
+  it("THE HEARTBEAT IS WRITTEN BEFORE ANY NETWORK CALL", () => {
+    // The other half. Deriving the threshold does not help if the beat is
+    // downstream of a read that a rate limit can kill — which is exactly where
+    // it was, one line after `readMarketSafety()`.
+    const src = strip(at("./index.ts"));
+    const tickAt = src.indexOf("async function tick() {");
+    assert.ok(tickAt > 0, "tick() must exist");
+    const beatAt = src.indexOf("heartbeat()", tickAt);
+    const marketAt = src.indexOf("await readMarketSafety()", tickAt);
+    assert.ok(beatAt > 0 && marketAt > 0, "both calls must exist in tick()");
+    assert.ok(beatAt < marketAt, "the beat must precede the first network read");
+  });
+});
+
+describe("A2 — the exit handler only cleans up its own child", () => {
+  it("compares identity rather than deleting by key", () => {
+    // `children.delete(tenant)` unconditionally meant the watchdog's
+    // replacement was evicted by the corpse of the child it replaced, and the
+    // respawn guard then spawned a SECOND one. The first was orphaned: still
+    // ticking, still hitting the RPC, invisible to the watchdog.
+    // Measured: 105 spawns against 61 exits in one window.
+    const src = strip(at("./orchestrator.ts"));
+    assert.match(src, /if \(children\.get\(tenant\) === child\) children\.delete\(tenant\);/);
+    // And the unconditional form must be gone from the exit path.
+    const exitAt = src.indexOf('proc.on("exit"');
+    const guardAt = src.indexOf("if (children.get(tenant) === child)", exitAt);
+    const respawnAt = src.indexOf("!children.has(tenant)", exitAt);
+    assert.ok(exitAt > 0 && guardAt > exitAt, "the guard must be inside the exit handler");
+    assert.ok(guardAt < respawnAt, "and must run before the respawn check");
+  });
+
+  it("the watchdog logs the threshold it actually applied", () => {
+    // A number that cannot be read from a log is a number nobody can debug.
+    const src = strip(at("./orchestrator.ts"));
+    assert.match(src, /child\.staleSec/);
+    assert.match(src, /watchdog \$\{staleSec\}s/);
+  });
+});
+
+describe("A3 — a rate limit is not a block-range error", () => {
+  const filter = { address: "0x00000000000000000000000000000000000000e7" as const, topics: [] };
+
+  /** A chain seam that fails the first `fail` calls with `err`, then succeeds. */
+  const chainThatFails = (err: () => Error, fail: number) => {
+    let calls = 0;
+    const spans: bigint[] = [];
+    return {
+      calls: () => calls,
+      spans: () => spans,
+      chain: {
+        getLogs: async (a: { fromBlock: bigint; toBlock: bigint }) => {
+          calls += 1;
+          spans.push(a.toBlock - a.fromBlock + 1n);
+          if (calls <= fail) throw err();
+          return [];
+        },
+      },
+    };
+  };
+
+  const rateLimit = () =>
+    Object.assign(new Error("RPC Request failed."), {
+      name: "RpcRequestError",
+      details: "Rate Limit Hit, limit will reset in 60 seconds",
+      code: 429,
+    });
+  const rangeErr = () => new Error("query returned more than 10000 results");
+
+  it("RETRIES THE SAME SPAN on a rate limit — never halves, never advances", () => {
+    // The old loop halved on every failure, walked 10,000 -> 1 in fourteen
+    // requests, advanced the cursor by ONE BLOCK, reset, and did it again.
+    return (async () => {
+      const t = chainThatFails(rateLimit, 2);
+      const r = await getLogsAdaptive(t.chain as never, filter, 0n, 999n, 1000n);
+      assert.equal(r.complete, true);
+      // Every attempt asked for the SAME window.
+      assert.deepEqual([...new Set(t.spans().map(String))], ["1000"], "the span must not change");
+      assert.equal(t.calls(), 3, "two failures then one success");
+    })();
+  });
+
+  it("halves on a GENUINE range error, which is a hint about the question", () => {
+    return (async () => {
+      const t = chainThatFails(rangeErr, 2);
+      const r = await getLogsAdaptive(t.chain as never, filter, 0n, 999n, 1000n);
+      assert.equal(r.complete, true);
+      // Only the NARROWING PREFIX is asserted. Once a chunk succeeds the loop
+      // keeps that span and walks the rest of the window with it, so the tail is
+      // 250s repeating — correct, and not what this test is about.
+      assert.deepEqual(t.spans().slice(0, 3).map(String), ["1000", "500", "250"], "the span must narrow");
+    })();
+  });
+
+  it("NEVER SKIPS A BLOCK — it reports short coverage instead", () => {
+    // The worst of the old behaviour: at span 1 it stepped over the block. This
+    // sweep exists so a landed operation cannot go unreconciled and under-count
+    // the day's spend, so silently skipping blocks broke the one property it is
+    // for.
+    return (async () => {
+      const t = chainThatFails(rateLimit, 1000);
+      const r = await getLogsAdaptive(t.chain as never, filter, 100n, 999n, 1000n);
+      assert.equal(r.complete, false, "coverage must be reported as short");
+      assert.equal(r.scannedTo, 99n, "nothing was scanned, so scannedTo is before the start");
+      assert.equal(r.logs.length, 0);
+      // Bounded: it gives up rather than spinning.
+      assert.ok(t.calls() <= 6, `expected a bounded number of attempts, got ${t.calls()}`);
+    })();
+  });
+
+  it("a clean pass restores the retry budget", () => {
+    return (async () => {
+      // Fail once, succeed, and the next chunk still has its full allowance.
+      let calls = 0;
+      const chain = {
+        getLogs: async () => {
+          calls += 1;
+          if (calls === 1 || calls === 3) throw rateLimit();
+          return [];
+        },
+      };
+      const r = await getLogsAdaptive(chain as never, filter, 0n, 1999n, 1000n);
+      assert.equal(r.complete, true, "one blip per chunk must not doom the sweep");
+    })();
+  });
+});
+
+describe("A4 — an unreadable market is not a stale feed", () => {
+  it("carries `unread` beside `staleFeeds`, mirroring readAccountBalances", () => {
+    // The asymmetry was inside one file: readAccountBalances already carried
+    // `unread: string[]` and explained why, while readMarketSafety put an
+    // unreadable feed into `staleFeeds` — a claim about Chainlink, manufactured
+    // out of our own rate limit.
+    const src = at("./snapshot.ts");
+    assert.match(src, /unread: string\[\]/);
+    assert.match(src, /unreadable: boolean/);
+    const code = strip(src);
+    // The guarded legs: a throw must not escape readMarketSafety any more.
+    assert.match(code, /\.catch\(\(\) => null\)/);
+  });
+
+  it("the tick FAILS CLOSED on an unreadable market, and returns rather than throws", () => {
+    const code = strip(at("./index.ts"));
+    assert.match(code, /if \(market\.unreadable\) \{/);
+    const guardAt = code.indexOf("if (market.unreadable) {");
+    const returnAt = code.indexOf("return;", guardAt);
+    const armedAt = code.indexOf("if (!armed || !active) return;");
+    assert.ok(guardAt > 0 && returnAt > guardAt, "it must return");
+    assert.ok(guardAt < armedAt, "and must do so before any trading work");
+  });
+
+  it("an unread block is not a DOWN sequencer claim in the ledger", () => {
+    // "sequencer DOWN — all trading paused" is an event every owner reads.
+    // Emitting it on the strength of our own 429 would be the same error one
+    // level up.
+    const code = strip(at("./snapshot.ts"));
+    assert.match(code, /block === null \? false :/);
+    assert.match(code, /blockNumber: block === null \? null : block\.number/);
+  });
+});
+
+describe("A5 — the meter is a seam, not a policy", () => {
+  it("every transport goes through it", () => {
+    for (const [file, n] of [
+      ["./snapshot.ts", 2],
+      ["./index.ts", 1],
+      ["./executor.ts", 2],
+      ["./circle.ts", 1],
+    ] as const) {
+      const code = strip(at(file));
+      assert.equal(
+        (code.match(/metered\(http\(/g) ?? []).length,
+        n,
+        `${file} must route all ${n} transport(s) through the meter`,
+      );
+      assert.doesNotMatch(code, /transport: http\(/, `${file} still has a bare transport`);
+    }
+  });
+
+  it("THE BUNDLER IS METERED BUT NEVER MANAGED", () => {
+    // It carries eth_sendUserOperation. The send-edge rules — persist the hash,
+    // send once, never re-send — are why a lost operation is recoverable, and a
+    // retrying transport underneath them would silently undo that.
+    const code = strip(at("./executor.ts"));
+    assert.match(code, /bundlerTransport: metered\(http\(opts\.bundlerUrl\), "bundler"\)/);
+    assert.doesNotMatch(code, /retryCount/, "no retry may be configured on any transport here");
+  });
+
+  it("changes no behaviour: it forwards, counts, and rethrows", () => {
+    const code = strip(at("./rpc-meter.ts"));
+    assert.match(code, /return await \(inner\.request/, "the result must be forwarded untouched");
+    assert.match(code, /throw e;/, "the error must be rethrown, not swallowed");
+    assert.doesNotMatch(code, /setTimeout|sleep|await new Promise/, "a meter must not delay anything");
+  });
+});
+
+describe("A6 — the gas numbers reach a log", () => {
+  it("prints all three limits, the ceiling, and the deploy state", () => {
+    // Twenty-four consecutive live attempts died leaving no gas figure anywhere,
+    // because GasRefused.detail only carries one on the absurd/unstable
+    // branches — and all twenty-four were `gas-unreadable`.
+    const code = strip(at("./executor.ts"));
+    assert.match(code, /\[gas\] account/);
+    assert.match(code, /callGasLimit/);
+    assert.match(code, /verificationGasLimit/);
+    assert.match(code, /preVerificationGas/);
+    assert.match(code, /ceiling \$\{bounds\.absoluteMax\}/);
+    // null must print as "unreadable", never as a zero.
+    assert.match(code, /"unreadable"/);
+  });
+});


### PR DESCRIPTION
The hosted fleet has never landed an agent trade. The reason is not gas ceilings and not funding — it is **arithmetic**.

`MERRYMEN_TICK_SECONDS` is **240**. `WATCHDOG_STALE_SEC` was **180**. The heartbeat is written once per tick, and `index.ts:4201` was its only writer in the repo. So the minimum possible gap between two beats was 240s against a 180s kill threshold: **every child was SIGKILLed at ~185s, before its second tick ever ran.** Not a race — all 71 observed `heartbeat stale` events land in a 181–196s band, which is 180 plus one 15s poll and nothing else.

```
tick 240s > watchdog 180s ─► SIGKILL every ~185s
  └─► re-arm ─► 20 sequential eth_getLogs over 200k blocks
        └─► 429 ─► getLogsAdaptive misreads it as "range too large", halves the span
              └─► 10,000→1 in 14 steps, ×4 viem retries ≈ 56 requests to advance ONE block
                    └─► more 429 ─► snapshot.ts:63 throws UNCAUGHT ─► no heartbeat
                          └─► SIGKILL again, and the exit handler double-spawns an orphan
```

## The six changes

**A1 — the watchdog derives from the tick.** A constant that silently contradicts a configurable period is a bug waiting for someone to change the period. It is now `max(180, tick*2 + grace)`, computed per child from the settings the orchestrator itself just wrote, and logged on every spawn. **The Railway variable is untouched** — fixing the class beats tuning the instance.

The heartbeat also moved to the *top* of the tick, before any network call. It answers "is this process alive", which is true whether or not a third party answered an HTTP request.

**A2 — the exit handler only cleans up its own child.** `children.delete(tenant)` unconditionally meant the watchdog's replacement was evicted by the corpse of the child it replaced; a second later the respawn guard saw an empty slot and spawned a **second** one. The first was orphaned — still ticking, still hitting the RPC, invisible to the watchdog, sharing one home and one sqlite file with its own replacement. **105 spawns against 61 exits** in one window.

**A3 — a rate limit is not a block-range error.** New `rpc-error.ts` classifies failures into a closed union with `retryable`, mirroring `RefuseRule` / `ImpactVerdict` / `GasVerdict` / `classifyRevert`. It matches on **text** as well as codes, because what this chain sends is an `RpcRequestError` with *no HTTP status* whose body says `Rate Limit Hit` — a status-only classifier would miss every real case. And rate-limited is checked *before* range-too-large, because "limit will reset in 60 seconds" contains the word "limit".

`getLogsAdaptive` now retries the same span on a rate limit, halves only on a genuine range error, and **never skips a block**. The old code stepped over the block at span 1 — silent data loss on the one sweep that exists so a landed operation cannot go unreconciled and under-count the day's spend.

**A4 — an unreadable market is not a stale feed.** `readMarketSafety`'s `Promise.all` was unguarded while `readAccountBalances` twenty lines below already caught per call and carried `unread: string[]`. That asymmetry, in one file, was the bug: a rate-limited feed went into `staleFeeds`, which is a claim about *Chainlink*. The tick now fails closed by **returning** rather than throwing. No trading decision changes — an unreadable market produced no trade before and produces none now; it just no longer takes the process down on the way.

**A5 — `rpc-meter.ts`.** A transport wrapper that changes no behaviour and counts everything: method, provider, latency, outcome, peak concurrency. Applied at all six transport sites, which were `http()` with no options. **This is what makes the next stage possible** — no `eth_call` has ever appeared in a rate-limit log line, because every quote helper catches and returns `null`, so ~95% of the traffic is invisible and a limiter sized against the logs would be sized against the wrong number. The bundler transport is metered but **never managed**.

**A6 — the gas numbers reach a log.** Twenty-four consecutive live attempts died leaving no figure anywhere; diagnosing it meant decoding `handleOps` calldata from two unrelated landed transactions.

## Deliberately not done

`DEPLOY_GAS_BOUNDS` **does not move.** `boundGas` never received a number on any of the 24 attempts, `gas-absurd` occurs **0 times** across all 14 deployments, and the 8M ceiling was never reached. The 18.6M figure quoted earlier could not have been produced by this code path.

The quote paths keep `catch → null` until it is replaced deliberately — changing what a 429 *means* at the same time as changing how often we ask would make the measurement uninterpretable.

No policy wall, gas bound, quote simulation, in-flight accounting or UserOperation durability was touched.

## Verification

- **1901 tests pass**, typecheck clean. `wall.test.ts` and `paymaster.test.ts` untouched.
- Every new guard is **mutation-checked**: restoring the unconditional delete, pinning the watchdog back to a constant, halving on any failure, and moving the heartbeat back after the network each fail the suite. (The heartbeat mutation passed on my first attempt because my mutation string used `\n` against a CRLF file — a no-op, not a passing test. Redone correctly.)
- One pre-existing test of mine was re-pinned: it asserted an exact expression that this change splits across two lines, while the property it cares about is intact.

## After merge

Deploy, then **measure one full fleet cycle before sizing anything**. Targets: `heartbeat stale` → 0, spawned == exited, tick death rate 14.6% → 0%, `getLogs failed on a single block` → 0, and — recorded for the first time — peak RPC concurrency, requests by method, and the true 429 count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)