### PR TITLE
The "SECOND, INDEPENDENT CHECK" compared a value with itself

### DIFF
--- a/worker/src/session-account-address.test.ts
+++ b/worker/src/session-account-address.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createPublicClient, custom, encodeErrorResult, type Address } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { getEntryPoint, KERNEL_V3_3 } from "@zerodev/sdk/constants";
+import { createKernelAccount } from "@zerodev/sdk";
+import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
+import { serializePermissionAccount, toPermissionValidator } from "@zerodev/permissions";
+import { toECDSASigner } from "@zerodev/permissions/signers";
+import { toTimestampPolicy } from "@zerodev/permissions/policies";
+import { robinhoodChain, WALL_POLICY_FLAG } from "../../packages/core/src/index";
+import { AccountAddressMismatch, deserializeFlaggedPermissionAccount } from "./session-account";
+
+/**
+ * THE CHECK THAT COMPARED A VALUE WITH ITSELF.
+ *
+ * session-account.ts has always carried two checks. The first rebuilds the
+ * permission id WITHOUT passing the stored one, with a comment explaining that
+ * passing it would make getIdentifier() echo the input and the comparison
+ * tautological. The second — "SECOND, INDEPENDENT CHECK" — then built the
+ * account WITH `address: params.accountParams.accountAddress` and compared
+ * `account.address` against that same value.
+ *
+ * createKernelAccount.ts:263 is `accountAddress = address ?? (…derive…)`, so
+ * supplying the address skips derivation entirely and the comparison could
+ * never fail. A guard that reads as one and is not one is worse than no guard,
+ * because it stops anyone writing the real one.
+ *
+ * These tests drive the REAL function over a REAL serialized grant. The only
+ * thing stubbed is the chain, and it is stubbed precisely so the derived
+ * address can be made to disagree with the signed one — which is the case that
+ * cannot be constructed at all if the derivation never runs.
+ */
+
+const entryPoint = getEntryPoint("0.7");
+
+/** `SenderAddressResult(address)` — how the EntryPoint answers getSenderAddress. */
+const SENDER_ADDRESS_RESULT = [
+  { inputs: [{ name: "sender", type: "address" }], name: "SenderAddressResult", type: "error" },
+] as const;
+
+/**
+ * A chain that deploys exactly where we say it does.
+ *
+ * getSenderAddress works by CALLING EntryPoint.getSenderAddress and reading the
+ * address back out of the revert, so a stub that reverts with
+ * SenderAddressResult(x) IS a chain whose factory deploys to x. Nothing else is
+ * faked: the validators, the plugin manager, the enable signature and the
+ * serialized blob are all built by the real packages.
+ */
+function chainThatDeploysTo(where: Address) {
+  const seen: string[] = [];
+  const client = createPublicClient({
+    chain: robinhoodChain,
+    transport: custom({
+      async request({ method }: { method: string }) {
+        seen.push(method);
+        if (method === "eth_chainId") return `0x${robinhoodChain.id.toString(16)}`;
+        if (method === "eth_call") {
+          throw Object.assign(new Error("execution reverted"), {
+            code: 3,
+            data: encodeErrorResult({
+              abi: SENDER_ADDRESS_RESULT,
+              errorName: "SenderAddressResult",
+              args: [where],
+            }),
+          });
+        }
+        if (method === "eth_getCode") return "0x";
+        throw new Error(`the stub was asked for ${method}, which this test did not anticipate`);
+      },
+    }),
+  });
+  return { client, seen };
+}
+
+/** A grant, built the way the browser builds one. */
+async function signedGrant(deployedTo: Address) {
+  const { client } = chainThatDeploysTo(deployedTo);
+  const owner = privateKeyToAccount(generatePrivateKey());
+  const sessionKey = generatePrivateKey();
+
+  const sudo = await signerToEcdsaValidator(client, {
+    signer: owner,
+    entryPoint,
+    kernelVersion: KERNEL_V3_3,
+  });
+  const regular = await toPermissionValidator(client, {
+    signer: await toECDSASigner({ signer: privateKeyToAccount(sessionKey) }),
+    policies: [toTimestampPolicy({ validAfter: 1_800_000_000, validUntil: 1_800_086_400 })],
+    entryPoint,
+    kernelVersion: KERNEL_V3_3,
+    flag: WALL_POLICY_FLAG,
+  } as never);
+
+  // No `address` — the account's address is DERIVED, which is what makes the
+  // stub's answer the account's real identity rather than a decoration.
+  const account = await createKernelAccount(client, {
+    entryPoint,
+    kernelVersion: KERNEL_V3_3,
+    plugins: { sudo, regular },
+  });
+  assert.equal(account.address.toLowerCase(), deployedTo.toLowerCase(), "the fixture is what it claims");
+
+  return { blob: await serializePermissionAccount(account, sessionKey), sessionKey };
+}
+
+/** Rewrite one field of a serialized grant, leaving everything else signed. */
+function withAccountAddress(blob: string, address: Address): string {
+  const params = JSON.parse(new TextDecoder().decode(Uint8Array.from(atob(blob), (c) => c.codePointAt(0)!)));
+  params.accountParams.accountAddress = address;
+  const json = JSON.stringify(params);
+  return btoa(String.fromCodePoint(...new TextEncoder().encode(json)));
+}
+
+const REAL = "0x1111111111111111111111111111111111111111" as Address;
+const IMPOSTOR = "0x2222222222222222222222222222222222222222" as Address;
+
+test("an honest grant arms", async () => {
+  const { blob } = await signedGrant(REAL);
+  const { client } = chainThatDeploysTo(REAL);
+  const account = await deserializeFlaggedPermissionAccount(
+    client as never,
+    entryPoint,
+    KERNEL_V3_3,
+    blob,
+    WALL_POLICY_FLAG,
+  );
+  assert.equal(account.address.toLowerCase(), REAL.toLowerCase());
+});
+
+test("REGRESSION: a grant whose address does not match its own initCode is REFUSED", async () => {
+  // This is the case the old check could not see. Everything else about the
+  // blob is genuinely signed; only the address claim is wrong — which is
+  // exactly the shape of "a correct validator attached to the wrong address"
+  // that the old comment claimed to catch.
+  const { blob } = await signedGrant(REAL);
+  const tampered = withAccountAddress(blob, IMPOSTOR);
+  const { client } = chainThatDeploysTo(REAL);
+
+  await assert.rejects(
+    () =>
+      deserializeFlaggedPermissionAccount(client as never, entryPoint, KERNEL_V3_3, tampered, WALL_POLICY_FLAG),
+    (e: unknown) => {
+      assert.ok(e instanceof AccountAddressMismatch, `expected AccountAddressMismatch, got ${String(e)}`);
+      assert.equal(e.signed.toLowerCase(), IMPOSTOR.toLowerCase());
+      assert.equal(e.derived.toLowerCase(), REAL.toLowerCase());
+      assert.match(e.message, /Refusing to arm/);
+      return true;
+    },
+  );
+});
+
+test("THE DERIVATION ACTUALLY RUNS — the address is never handed to the deriver", async () => {
+  // The whole defect was that the answer was supplied, so the work was skipped.
+  // A behavioural test cannot see a call that does not happen, so watch the
+  // chain: an eth_call to the EntryPoint is the derivation, and its absence is
+  // the bug.
+  const { blob } = await signedGrant(REAL);
+  const { client, seen } = chainThatDeploysTo(REAL);
+  await deserializeFlaggedPermissionAccount(client as never, entryPoint, KERNEL_V3_3, blob, WALL_POLICY_FLAG);
+  assert.ok(seen.includes("eth_call"), "the account address must be derived, not accepted");
+});

--- a/worker/src/session-account.ts
+++ b/worker/src/session-account.ts
@@ -169,6 +169,28 @@ export class PermissionIdMismatch extends Error {
 }
 
 /**
+ * The grant's own initCode does not deploy the address the grant claims.
+ *
+ * Named, like PermissionIdMismatch, because "refusing to arm" with a bare
+ * Error is what an owner sees, and the two failures mean different things: a
+ * mismatched id is a wall we rebuilt wrongly, a mismatched address is a grant
+ * whose two halves disagree about which account they are for.
+ */
+export class AccountAddressMismatch extends Error {
+  constructor(
+    readonly signed: `0x${string}`,
+    readonly derived: `0x${string}`,
+  ) {
+    super(
+      `this grant says it is for account ${signed}, but its own factory data deploys ${derived}. ` +
+        "The two halves of the blob disagree about which account they belong to, so nothing here " +
+        "can be trusted to sign for either. Refusing to arm — nothing was signed.",
+    );
+    this.name = "AccountAddressMismatch";
+  }
+}
+
+/**
  * `deserializePermissionAccount`, plus the flag.
  *
  * Signature deliberately mirrors the package's so the two can be read side by
@@ -235,7 +257,48 @@ export async function deserializeFlaggedPermissionAccount(
     ...params.validityData,
   } as never);
 
-  const account = await createKernelAccount(client as never, {
+  // SECOND, INDEPENDENT CHECK — AND, AGAIN, WITHOUT THE ANSWER.
+  //
+  // This check used to run against an account built WITH
+  // `address: params.accountParams.accountAddress`, and createKernelAccount is
+  // `accountAddress = address ?? (…derive…)` (createKernelAccount.ts:263): hand
+  // it the address and the derivation is skipped entirely, so the comparison
+  // below compared the signed address with itself and could not fail. The same
+  // trap the id check twenty lines up was deliberately written to avoid, walked
+  // into by the check that claimed to be independent of it.
+  //
+  // So derive it. Omitting `address` sends createKernelAccount down the CREATE2
+  // path — getFactoryArgs() over the grant's own initCode-derived
+  // validatorInitData, index and useMetaFactory, then getSenderAddress against
+  // the EntryPoint — which is the address this grant's factory data actually
+  // deploys, computed from the grant rather than read off it.
+  //
+  // WHAT IT COSTS: one eth_call at ARM time, and this function is no longer
+  // offline. That is the price of the check being real; it was free before
+  // because it was doing nothing.
+  //
+  // WHAT IT CATCHES: an accountAddress that does not match the initCode sitting
+  // beside it in the same blob. Kernel's own enable-signature check would also
+  // refuse such a grant on chain (measured on 4663: AA23 reverted 0xc48cf8ee),
+  // but only after arming, mirroring, showing the owner a live agent, and
+  // spending a signature — and it would present as an opaque bundler code.
+  const derived = await createKernelAccount(client as never, {
+    entryPoint,
+    kernelVersion,
+    plugins,
+    index,
+    useMetaFactory,
+    eip7702Auth: params.eip7702Auth,
+  } as never);
+
+  if (derived.address.toLowerCase() !== params.accountParams.accountAddress.toLowerCase()) {
+    throw new AccountAddressMismatch(params.accountParams.accountAddress, derived.address);
+  }
+
+  // Now pass it, matching the package — same shape as the id above, and for the
+  // same reason: the stored value is authoritative, we have just proved ours
+  // equals it.
+  return createKernelAccount(client as never, {
     entryPoint,
     kernelVersion,
     plugins,
@@ -244,16 +307,4 @@ export async function deserializeFlaggedPermissionAccount(
     useMetaFactory,
     eip7702Auth: params.eip7702Auth,
   } as never);
-
-  // SECOND, INDEPENDENT CHECK. The id proves the validator; this proves the
-  // account it was installed into. They can fail separately — a correct
-  // validator attached to the wrong address would sign operations for an
-  // account the owner never funded.
-  if (account.address.toLowerCase() !== params.accountParams.accountAddress.toLowerCase()) {
-    throw new Error(
-      `rebuilt account ${account.address} is not the signed account ${params.accountParams.accountAddress} — refusing to arm`,
-    );
-  }
-
-  return account;
 }


### PR DESCRIPTION
`session-account.ts` carries two checks on a grant it rebuilds. The first computes the permission id **without** passing the stored one, and says why:

> Passing `permissionId` makes `getIdentifier()` return it verbatim … which would make the check below tautological — it would compare the stored id with itself and pass however wrong the rebuild was. So compute it fresh and compare.

The second then built the account **with** `address: params.accountParams.accountAddress` and compared `account.address` against that same value. `createKernelAccount.ts:263` is `accountAddress = address ?? (…derive…)` — supply the address and the CREATE2 derivation is skipped entirely — so the check could never fail. The exact trap the check above it was written to avoid, walked into by the one that called itself independent.

## What it was meant to prove

From its own comment: *"a correct validator attached to the wrong address would sign operations for an account the owner never funded."* That question now gets asked. Omitting `address` sends `createKernelAccount` down the CREATE2 path — `getFactoryArgs()` over the grant's own initCode-derived `validatorInitData`, `index` and `useMetaFactory`, then `getSenderAddress` against the EntryPoint — so the address is computed **from** the grant rather than read **off** it, then compared to what the grant claims. Same shape as the id check: derive without the answer, then build with it.

Mismatches get a name, `AccountAddressMismatch`, beside `PermissionIdMismatch` — the two mean different things. A mismatched id is a wall we rebuilt wrongly; a mismatched address is a grant whose two halves disagree about which account they are for.

**Cost:** one `eth_call` at arm time, and this function is no longer offline. That is the price of the check being real — it was free before because it was doing nothing.

## Not a closed hole, a restored assurance

Kernel's own enable-signature check already refuses a grant pointed at an account the tenant does not own (measured on 4663: `AA23 reverted 0xc48cf8ee`). But only after arming, mirroring, showing the owner a live agent and spending a signature — and it arrives as an opaque bundler code. A guard that reads as one and is not one is worse than no guard, because it stops anyone writing the real one.

## The test drives the real function over a real grant

The validators, plugin manager, enable signature and serialized blob are all built by the actual packages. The only thing stubbed is the chain — and it is stubbed precisely so the derived address can be made to disagree with the claimed one, which is the case that cannot be constructed at all while the derivation never runs. `getSenderAddress` works by calling the EntryPoint and reading the address out of the revert, so a stub that reverts with `SenderAddressResult(x)` **is** a chain whose factory deploys to `x`.

**Mutation-checked.** Restoring `address:` to the deriver turns 3 passing tests into 1 pass / 2 failures — the regression case, and the pin that the derivation runs at all:

```
ok 1 - an honest grant arms
not ok 2 - REGRESSION: a grant whose address does not match its own initCode is REFUSED
not ok 3 - THE DERIVATION ACTUALLY RUNS — the address is never handed to the deriver
```

Test 1 passes either way, which is correct, and is why it is not the regression test.

**1904 tests, 0 failures.** Typecheck clean. Branched off `main`, independent of #56.

Found while proving the first-enable gas ceiling gate in #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)