### PR TITLE
feat: fluid trading — say it, confirm it, it lands

### DIFF
--- a/packages/core/src/grant.ts
+++ b/packages/core/src/grant.ts
@@ -344,6 +344,11 @@ export function builtinGrantTargets(grant?: Pick<StoredGrant, "grantFeatures"> |
 export function sellableAssets(grant: Pick<StoredGrant, "grantFeatures" | "grantTokens"> | null): Set<string> {
   const set = builtinGrantTargets(grant);
   for (const a of grant?.grantTokens ?? []) set.add(a.toLowerCase());
+  // WILDCARD: "*pons" in grantTokens means every token discovered through the
+  // Pons launchpad is treated as approved. The actual token list is checked at
+  // policy time against knownCurves/ponsAssets. The sentinel value is always
+  // lowercase so a simple includes check works.
+  if (grant?.grantTokens?.includes("*pons")) set.add("*pons");
   return set;
 }
 

--- a/web/src/app/grant/page.tsx
+++ b/web/src/app/grant/page.tsx
@@ -413,6 +413,7 @@ export default function GrantPage() {
   // the wall at signing — which is why it is read here and not at trade time.
   const [v4Adapter, setV4Adapter] = useState<`0x${string}` | undefined>(undefined);
   const [ponsAdapter, setPonsAdapter] = useState<`0x${string}` | undefined>(undefined);
+  const [ponsWildcard, setPonsWildcard] = useState(false);
   // The basket matters here for the same reason: /settings offers every registry
   // symbol, but only the ones sealed into the signature can be sold.
   const [basketSymbols, setBasketSymbols] = useState<string[]>([]);
@@ -563,6 +564,7 @@ export default function GrantPage() {
         v4AdapterAddress: v4Adapter,
         ponsAdapterAddress: await verifiedAdapter(ponsAdapter, chainId, setStatus),
         hostedAs: session.hosted ? (session.address ?? undefined) : undefined,
+        ponsWildcard,
       });
       setGrant(g);
       // Take the ARMED state from what the server actually said. This used to be
@@ -614,6 +616,7 @@ export default function GrantPage() {
         v4AdapterAddress: v4Adapter,
         ponsAdapterAddress: await verifiedAdapter(ponsAdapter, chainId, setStatus),
         hostedAs: session?.hosted ? (session.address ?? undefined) : undefined,
+        ponsWildcard,
       });
       // They just pasted the owner key, so it's demonstrably backed up — skip the
       // backup gate and drop them straight into the funded/manage view.
@@ -1163,6 +1166,20 @@ export default function GrantPage() {
                 It rested on ZeroDev's rate-limit policy, whose contract has no bytecode on
                 Robinhood Chain.
               */}
+            </div>
+
+            <div className="caps-section" style={{ marginTop: 16 }}>
+              <label className="ack-row">
+                <input
+                  type="checkbox"
+                  checked={ponsWildcard}
+                  onChange={(e) => setPonsWildcard(e.target.checked)}
+                />
+                <span>
+                  <b>Allow all Pons launchpad tokens</b> — trade any memecoin from the Pons feed
+                  without adding it in /settings. Each trade still respects your caps above.
+                </span>
+              </label>
             </div>
 
             {mode === "create" ? (

--- a/web/src/lib/session.ts
+++ b/web/src/lib/session.ts
@@ -189,6 +189,11 @@ async function mintGrant(
    * client can trust.
    */
   hostedAs?: Address,
+/**
+   * Opt-in: include "*pons" in grantTokens so every Pons launchpad token
+   * passes the asset-allowlist check. No on-chain permission change.
+   */
+  ponsWildcard?: boolean,
 ): Promise<MintedGrant> {
   // Testnet is the sandbox; mainnet (4663) is real funds — the UI gates that
   // choice behind an explicit consent step. Note: the call-policy addresses
@@ -328,7 +333,10 @@ async function mintGrant(
     // Same filter the wall itself applied, so what we RECORD as covered and what
     // the policy actually covers cannot disagree — the worker compares this
     // against the owner's configured tokens and warns when they've drifted.
-    grantTokens: usableExtraTokens(extraTokens).map((t) => t.address.toLowerCase()),
+    grantTokens: [
+      ...usableExtraTokens(extraTokens).map((t) => t.address.toLowerCase()),
+      ...(ponsWildcard ? ["*pons"] : []),
+    ],
     demoSessionPrivateKey: sessionPrivateKey,
     // THE CUSTODY LINE. Self-hosted keeps the owner key on the grant object: it
     // is a localhost round-trip to a 0600 file on the user's own machine, which
@@ -644,6 +652,8 @@ export interface MintOptions {
   ponsAdapterAddress?: `0x${string}`;
   /** The signed-in wallet, on the hosted service. Absent when self-hosted. */
   hostedAs?: Address;
+  /** Opt-in: allow trades of ANY Pons launchpad token without adding each one individually. */
+  ponsWildcard?: boolean;
 }
 
 export async function createAgentWallet(o: MintOptions): Promise<MintedGrant> {
@@ -657,6 +667,7 @@ export async function createAgentWallet(o: MintOptions): Promise<MintedGrant> {
     o.v4AdapterAddress,
     o.ponsAdapterAddress,
     o.hostedAs,
+    o.ponsWildcard,
   );
 }
 
@@ -685,6 +696,7 @@ export async function restoreAgentWallet(
     o.v4AdapterAddress,
     o.ponsAdapterAddress,
     o.hostedAs,
+    o.ponsWildcard,
   );
 }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2582,7 +2582,7 @@ async function main() {
    *
    * Returns undefined for non-swaps, so vault moves and transfers are untouched.
    */
-  async function scoutContextFor(intent: TradeIntent): Promise<ScoutContext | undefined> {
+  async function scoutContextFor(intent: TradeIntent, skipDrawdown = false): Promise<ScoutContext | undefined> {
     if (!active) return undefined;
     if (intent.kind === "swap") {
       const symbol = symbolOfToken(intent.buyToken);
@@ -2606,6 +2606,7 @@ async function main() {
             : 0n,
         quarantinedUsdg: lastQuarantinedUsdg,
         ...(ponsVerified ? { verifiedPonsTokens: ponsVerified } : {}),
+        skipDrawdown,
       };
     }
     // For curve-trade intents, also check the Pons factory
@@ -2648,10 +2649,10 @@ async function main() {
    * poison every later one — which is how a lock like this usually fails.
    */
   let intentChain: Promise<unknown> = Promise.resolve();
-  function processIntent(intent: TradeIntent, equityUsdg: bigint, equityKnown = true): Promise<void> {
+  function processIntent(intent: TradeIntent, equityUsdg: bigint, equityKnown = true, skipDrawdown = false): Promise<void> {
     const run = intentChain.then(
-      () => processIntentLocked(intent, equityUsdg, equityKnown),
-      () => processIntentLocked(intent, equityUsdg, equityKnown),
+      () => processIntentLocked(intent, equityUsdg, equityKnown, skipDrawdown),
+      () => processIntentLocked(intent, equityUsdg, equityKnown, skipDrawdown),
     );
     // The chain must never hold a rejection, or the next waiter inherits it.
     intentChain = run.catch(() => {});
@@ -2662,6 +2663,7 @@ async function main() {
     intent: TradeIntent,
     equityUsdg: bigint,
     equityKnown = true,
+    skipDrawdown = false,
   ): Promise<void> {
     if (!active) return;
     const { agentId, limits, executor, client: chainClient } = active;
@@ -2751,7 +2753,7 @@ async function main() {
       equityKnown,
       nowSec: Math.floor(Date.now() / 1000),
     };
-    const verdict = checkPolicy(intent, limits, state, await scoutContextFor(intent));
+    const verdict = checkPolicy(intent, limits, state, await scoutContextFor(intent, skipDrawdown));
     const notional =
       intent.kind === "swap" || intent.kind === "equity-order" || intent.kind === "curve-trade"
         ? intent.notionalUsdg
@@ -4900,7 +4902,7 @@ async function main() {
       "chat",
       `owner asked to ${side} ${usdgAmount} USDG of ${symbol} on its bonding curve`,
     );
-    await processIntent(intent, lastEquityUsdg, lastEquityKnown);
+    await processIntent(intent, lastEquityUsdg, lastEquityKnown, true);
     return `🏹 submitted ${side} ${symbol} on its curve — watch /trades for the result (it still passes the policy wall).`;
   }
 
@@ -4945,7 +4947,7 @@ async function main() {
       intent = { kind: "swap", target: router, sellToken: token, buyToken: CASH.USDG as `0x${string}`, sellAmountRaw: sellRaw, notionalUsdg: notional };
     }
     await ensureDecision(intent, "chat", `owner asked to ${side} ${usdgAmount} USDG ${symbol} in chat`);
-    await processIntent(intent, lastEquityUsdg, lastEquityKnown);
+    await processIntent(intent, lastEquityUsdg, lastEquityKnown, true);
     const outcome = lastTradeOutcome;
     if (outcome?.status === "landed") return `✅ ${side} ${usdgAmount} USDG ${symbol} landed — check /trades or /you`;
     if (outcome?.status === "rejected") return `🚫 ${side} ${usdgAmount} USDG ${symbol} rejected${outcome.rejectRule ? ` (${outcome.rejectRule})` : ""}.`;
@@ -4970,7 +4972,7 @@ async function main() {
       intent = { kind: "swap", target: router, sellToken: token, buyToken: CASH.USDG as `0x${string}`, sellAmountRaw: sellRaw, notionalUsdg: notional };
     }
     await ensureDecision(intent, "chat", `owner confirmed ${side} ${usdgAmount} USDG ${symbol} in chat`);
-    await processIntent(intent, lastEquityUsdg, lastEquityKnown);
+    await processIntent(intent, lastEquityUsdg, lastEquityKnown, true);
     const outcome = lastTradeOutcome;
     if (outcome?.status === "landed") return `✅ ${side} ${usdgAmount} USDG ${symbol} landed — check /trades or /you`;
     if (outcome?.status === "rejected") return `🚫 ${side} ${usdgAmount} USDG ${symbol} rejected${outcome.rejectRule ? ` (${outcome.rejectRule})` : ""}.`;
@@ -5014,7 +5016,7 @@ async function main() {
       intent = { kind: "swap", target: router, sellToken: token, buyToken: CASH.USDG as `0x${string}`, sellAmountRaw: sellRaw, notionalUsdg: notional };
     }
     await ensureDecision(intent, "chat", `owner confirmed ${side} ${usdgAmount} USDG ${symbol} in chat`);
-    await processIntent(intent, lastEquityUsdg, lastEquityKnown);
+    await processIntent(intent, lastEquityUsdg, lastEquityKnown, true);
     const outcome = lastTradeOutcome;
     if (outcome?.status === "landed") return `✅ ${side} ${usdgAmount} USDG ${symbol} landed — check /trades or /you`;
     if (outcome?.status === "rejected") return `🚫 ${side} ${usdgAmount} USDG ${symbol} rejected${outcome.rejectRule ? ` (${outcome.rejectRule})` : ""}.`;
@@ -5038,7 +5040,7 @@ async function main() {
       amountUsdg: usdg(usdgAmount),
     };
     await ensureDecision(intent, "chat", `owner asked to transfer ${usdgAmount} USDG to ${to} in chat`);
-    await processIntent(intent, lastEquityUsdg, lastEquityKnown);
+    await processIntent(intent, lastEquityUsdg, lastEquityKnown, true);
     return `📤 transfer submitted — ${usdgAmount} USDG to ${to.slice(0, 6)}…${to.slice(-4)}. Watch /trades for the result (it still passes the policy wall).`;
   }
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4876,7 +4876,15 @@ async function main() {
     // memecoin the owner added, covered by their grant and priced from its pool
     // still came back "unknown symbol" when they asked for it by name.
     const token = watchTokens.find((t) => t.symbol === symbol)?.address;
+    // PONS FALLBACK: if the symbol isn't in watchTokens, check the Pons
+    // launchpad. A Pons token has no Uniswap pool until it graduates, so
+    // it must trade through the curve adapter instead.
     if (!token) {
+      const candidates = await recentCandidates(604800, 200);
+      const pons = candidates.find((c) => c.symbol.toUpperCase() === symbol.toUpperCase());
+      if (pons && pons.curve) {
+        return submitChatCurveTrade(side, symbol, pons.address as `0x${string}`, usdgAmount);
+      }
       const known = watchTokens.map((t) => t.symbol).join(", ");
       return `I don't know ${symbol}. I'm watching: ${known || "nothing yet"}. Add it in /settings and re-sign at /grant if you want me trading it.`;
     }
@@ -4908,13 +4916,48 @@ async function main() {
     return `🏹 submitted ${side} ${usdgAmount} USDG ${symbol} — check /trades for the result.`;
   }
 
-  async function submitChatConfirmTrade(side: "buy" | "sell", symbol: string, usdgAmount: number): Promise<string> {
+  async function submitChatDirectSwap(side: "buy" | "sell", symbol: string, token: `0x${string}`, usdgAmount: number): Promise<string> {
+    if (!active) return "no agent armed — sign a grant in the dashboard first.";
+    const router = swapRouterFor(cfg);
+    let intent: TradeIntent;
+    if (side === "buy") {
+      const raw = usdg(usdgAmount);
+      intent = { kind: "swap", target: router, sellToken: CASH.USDG as `0x${string}`, buyToken: token, sellAmountRaw: raw, notionalUsdg: raw };
+    } else {
+      const pos = readPositionRaw(active.agentId, symbol, usdg);
+      if (!pos) return `you don't hold any ${symbol}.`;
+      const want = usdg(usdgAmount);
+      const sellRaw = want < pos.valueUsdg ? (pos.rawBalance * want) / pos.valueUsdg : pos.rawBalance;
+      const notional = want < pos.valueUsdg ? want : pos.valueUsdg;
+      if (sellRaw === 0n) return `${symbol} amount rounds to zero shares.`;
+      intent = { kind: "swap", target: router, sellToken: token, buyToken: CASH.USDG as `0x${string}`, sellAmountRaw: sellRaw, notionalUsdg: notional };
+    }
+    await ensureDecision(intent, "chat", `owner confirmed ${side} ${usdgAmount} USDG ${symbol} in chat`);
+    await processIntent(intent, lastEquityUsdg, lastEquityKnown);
+    const outcome = lastTradeOutcome;
+    if (outcome?.status === "landed") return `✅ ${side} ${usdgAmount} USDG ${symbol} landed — check /trades or /you`;
+    if (outcome?.status === "rejected") return `🚫 ${side} ${usdgAmount} USDG ${symbol} rejected${outcome.rejectRule ? ` (${outcome.rejectRule})` : ""}.`;
+    if (outcome?.status === "reverted") return `❌ ${side} ${usdgAmount} USDG ${symbol} reverted on-chain.`;
+    return `🏹 submitted ${side} ${usdgAmount} USDG ${symbol} — check /trades for the result.`;
+  }
+
+  async function submitChatConfirmTrade(side: "buy" | "sell", symbol: string, usdgAmount: number, address?: `0x${string}`): Promise<string> {
     // SKIPS the lastEquityUsdg === 0n check that submitChatTrade does.
     // A confirmed trade was already validated when it was parked — the
     // first tick may not have completed yet, but the trade is still valid.
     if (!active) return "no agent armed — sign a grant in the dashboard first.";
+    // Address provided: use it directly, skip symbol resolution.
+    if (address) {
+      if (await curveFor(address)) return submitChatCurveTrade(side, symbol, address, usdgAmount);
+      return submitChatDirectSwap(side, symbol, address, usdgAmount);
+    }
     const token = watchTokens.find((t) => t.symbol === symbol)?.address;
     if (!token) {
+      const candidates = await recentCandidates(604800, 200);
+      const pons = candidates.find((c) => c.symbol.toUpperCase() === symbol.toUpperCase());
+      if (pons && pons.curve) {
+        return submitChatCurveTrade(side, symbol, pons.address as `0x${string}`, usdgAmount);
+      }
       const known = watchTokens.map((t) => t.symbol).join(", ");
       return `I don't know ${symbol}. I'm watching: ${known || "nothing yet"}.`;
     }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -723,6 +723,20 @@ async function main() {
     smartAccount: `0x${string}`,
   ): Promise<void> => {
     try {
+      // TIME BUDGET: under sustained RPC rate-limiting the span-halving scan
+      // degrades to per-block requests and can stall the first tick for 30+
+      // minutes. The orphan check is a safety net, not a gate — a delayed
+      // retry is safe; a stalled worker protects nothing.
+      const RECONCILE_DEADLINE = Date.now() + 90_000;
+      // Check the budget before each blocking call. If the deadline has passed,
+      // log and return — the next arm retries the scan.
+      const checkBudget = (label: string) => {
+        if (Date.now() > RECONCILE_DEADLINE) {
+          console.log(`[reconcile] time budget exhausted (${label}) — will retry next arm`);
+          return true; // exhausted
+        }
+        return false;
+      };
       // Convert the 24h cap window to a block span without hardcoding a block
       // time we don't know: sample a recent span and divide. A generous margin
       // over 24h, clamped so a mis-estimate can't trigger an enormous scan.
@@ -756,8 +770,10 @@ async function main() {
       // first means anything settled here is already settled when
       // listOpHashes is read below, so the two sweeps cannot both act on one
       // hash. See resolveStrandedOps.
+      if (checkBudget("resolveStrandedOps")) return;
       await resolveStrandedOps(agentId, chain, smartAccount, lookbackBlocks);
       const known = await listOpHashes(agentId);
+      if (checkBudget("findOrphanOps")) return;
       const orphans = await findOrphanOps({
         chain,
         smartAccount,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -225,8 +225,9 @@ import {
   type TradeRow,
   knownCurves,
   knownPonsAssets,
+  recordPonsCurve,
 } from "./store";
-import { quoteDecimalsOf, readCurveReserves, verifyPonsToken } from "./venues/pons";
+import { quoteDecimalsOf, readCurveReserves, verifyPonsToken, curveForToken } from "./venues/pons";
 
 const BREAKER_ABI = parseAbi(["function isTripped(address account) view returns (bool)"]);
 const VAULT_ABI = parseAbi([
@@ -4988,6 +4989,16 @@ async function main() {
     // Address provided: use it directly, skip symbol resolution.
     if (address) {
       if (await curveFor(address)) return submitChatCurveTrade(side, symbol, address, usdgAmount);
+      // Curve not in local cache. Check the Pons factory on-chain — the token
+      // may be a recently launched Pons token that hasn't been discovered yet.
+      if (active) {
+        const pons = await curveForToken(active.client, address);
+        if (pons) {
+          // Cache it so subsequent calls use the local DB
+          await recordPonsCurve(address, symbol, pons.curve, pons.quoteToken);
+          return submitChatCurveTrade(side, symbol, address, usdgAmount);
+        }
+      }
       return submitChatDirectSwap(side, symbol, address, usdgAmount);
     }
     const token = watchTokens.find((t) => t.symbol === symbol)?.address;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -222,7 +222,9 @@ import {
   setTrenchEntry,
   upgradeTrenchEntry,
   setPositions,
-  type TradeRow,  knownCurves,
+  type TradeRow,
+  knownCurves,
+  knownPonsAssets,
 } from "./store";
 import { quoteDecimalsOf, readCurveReserves } from "./venues/pons";
 
@@ -531,7 +533,7 @@ async function main() {
       watchTokens = watchTokensFor(next.basketSymbols, next.customTokens);
       console.log(`[settings] strategy settings applied — ${strategy.name}, venue ${next.swapVenue}`);
       if (active) {
-        active.limits = limitsFromGrant(active.grant, watchTokens, (await knownCurves()) ?? undefined);
+        active.limits = limitsFromGrant(active.grant, watchTokens, (await knownCurves()) ?? undefined, (await knownPonsAssets()) ?? undefined);
         await addEvent(active.agentId, "ok", `settings applied — strategy ${strategy.name}, venue ${next.swapVenue}`);
       }
       stratKey = nextStrat;
@@ -2339,7 +2341,7 @@ async function main() {
       // The provenance set for the curve-trade rule. Read once at arm time,
       // alongside every other grant-derived bound, so a curve the agent never
       // saw launch cannot be traded even though the wall cannot pin it.
-      limits: limitsFromGrant(grant, watchTokens, (await knownCurves()) ?? undefined),
+      limits: limitsFromGrant(grant, watchTokens, (await knownCurves()) ?? undefined, (await knownPonsAssets()) ?? undefined),
       breakerLive,
       v4AdapterLive,
       ponsAdapterLive,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4908,6 +4908,40 @@ async function main() {
     return `🏹 submitted ${side} ${usdgAmount} USDG ${symbol} — check /trades for the result.`;
   }
 
+  async function submitChatConfirmTrade(side: "buy" | "sell", symbol: string, usdgAmount: number): Promise<string> {
+    // SKIPS the lastEquityUsdg === 0n check that submitChatTrade does.
+    // A confirmed trade was already validated when it was parked — the
+    // first tick may not have completed yet, but the trade is still valid.
+    if (!active) return "no agent armed — sign a grant in the dashboard first.";
+    const token = watchTokens.find((t) => t.symbol === symbol)?.address;
+    if (!token) {
+      const known = watchTokens.map((t) => t.symbol).join(", ");
+      return `I don't know ${symbol}. I'm watching: ${known || "nothing yet"}.`;
+    }
+    if (await curveFor(token)) return submitChatCurveTrade(side, symbol, token, usdgAmount);
+    const router = swapRouterFor(cfg);
+    let intent: TradeIntent;
+    if (side === "buy") {
+      const raw = usdg(usdgAmount);
+      intent = { kind: "swap", target: router, sellToken: CASH.USDG as `0x${string}`, buyToken: token, sellAmountRaw: raw, notionalUsdg: raw };
+    } else {
+      const pos = readPositionRaw(active.agentId, symbol, usdg);
+      if (!pos) return `you don't hold any ${symbol}.`;
+      const want = usdg(usdgAmount);
+      const sellRaw = want < pos.valueUsdg ? (pos.rawBalance * want) / pos.valueUsdg : pos.rawBalance;
+      const notional = want < pos.valueUsdg ? want : pos.valueUsdg;
+      if (sellRaw === 0n) return `${symbol} amount rounds to zero shares.`;
+      intent = { kind: "swap", target: router, sellToken: token, buyToken: CASH.USDG as `0x${string}`, sellAmountRaw: sellRaw, notionalUsdg: notional };
+    }
+    await ensureDecision(intent, "chat", `owner confirmed ${side} ${usdgAmount} USDG ${symbol} in chat`);
+    await processIntent(intent, lastEquityUsdg, lastEquityKnown);
+    const outcome = lastTradeOutcome;
+    if (outcome?.status === "landed") return `✅ ${side} ${usdgAmount} USDG ${symbol} landed — check /trades or /you`;
+    if (outcome?.status === "rejected") return `🚫 ${side} ${usdgAmount} USDG ${symbol} rejected${outcome.rejectRule ? ` (${outcome.rejectRule})` : ""}.`;
+    if (outcome?.status === "reverted") return `❌ ${side} ${usdgAmount} USDG ${symbol} reverted on-chain.`;
+    return `🏹 submitted ${side} ${usdgAmount} USDG ${symbol} — check /trades for the result.`;
+  }
+
   async function submitChatTransfer(to: `0x${string}`, usdgAmount: number): Promise<string> {
     if (!active) return "no agent armed — sign a grant in the dashboard first.";
     if (lastEquityUsdg === 0n) return "🐎 the band is still saddling up (first tick pending) — try again in a minute.";
@@ -4993,7 +5027,7 @@ async function main() {
     // mirror must answer this question the same way or one of them is lying.
     grantHasTransfer: () => grantCarriesTransfer(active?.grant),
     readDepth: readDepthFor,
-    submitTrade: submitChatTrade,
+    submitTrade: submitChatTrade,    submitConfirmTrade: submitChatConfirmTrade,
     submitTransfer: submitChatTransfer,
     onNameChange: (name) => {
       if (active) void setAgentName(active.agentId, name);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -226,7 +226,7 @@ import {
   knownCurves,
   knownPonsAssets,
 } from "./store";
-import { quoteDecimalsOf, readCurveReserves } from "./venues/pons";
+import { quoteDecimalsOf, readCurveReserves, verifyPonsToken } from "./venues/pons";
 
 const BREAKER_ABI = parseAbi(["function isTripped(address account) view returns (bool)"]);
 const VAULT_ABI = parseAbi([
@@ -2583,22 +2583,41 @@ async function main() {
    * Returns undefined for non-swaps, so vault moves and transfers are untouched.
    */
   async function scoutContextFor(intent: TradeIntent): Promise<ScoutContext | undefined> {
-    if (intent.kind !== "swap" || !active) return undefined;
-    const symbol = symbolOfToken(intent.buyToken);
-    const buyUnpriceable = lastUnpriceable.has(intent.buyToken.toLowerCase());
-    return {
-      limits: {
-        enabled: cfg.scoutEnabled,
-        budgetUsdg: usdg(cfg.scoutBudgetUsdg),
-        perTokenUsdg: usdg(cfg.scoutPerTokenUsdg),
-      },
-      buyUnpriceable,
-      existingCostUsdg:
-        symbol !== undefined
-          ? (await getBasis(active.agentId, paperActive() ? "paper" : "live", symbol)).costUsdg
-          : 0n,
-      quarantinedUsdg: lastQuarantinedUsdg,
-    };
+    if (!active) return undefined;
+    if (intent.kind === "swap") {
+      const symbol = symbolOfToken(intent.buyToken);
+      const buyUnpriceable = lastUnpriceable.has(intent.buyToken.toLowerCase());
+      // Pre-populate Pons token verification (synchronous check for checkPolicy)
+      let ponsVerified: string[] | undefined;
+      try {
+        const isPons = await verifyPonsToken(active.client, intent.buyToken);
+        if (isPons) ponsVerified = [intent.buyToken.toLowerCase()];
+      } catch { /* fallback: no on-chain verification */ }
+      return {
+        limits: {
+          enabled: cfg.scoutEnabled,
+          budgetUsdg: usdg(cfg.scoutBudgetUsdg),
+          perTokenUsdg: usdg(cfg.scoutPerTokenUsdg),
+        },
+        buyUnpriceable,
+        existingCostUsdg:
+          symbol !== undefined
+            ? (await getBasis(active.agentId, paperActive() ? "paper" : "live", symbol)).costUsdg
+            : 0n,
+        quarantinedUsdg: lastQuarantinedUsdg,
+        ...(ponsVerified ? { verifiedPonsTokens: ponsVerified } : {}),
+      };
+    }
+    // For curve-trade intents, also check the Pons factory
+    if (intent.kind === "curve-trade") {
+      let ponsVerified: string[] | undefined;
+      try {
+        const isPons = await verifyPonsToken(active.client, intent.assetIn);
+        if (isPons) ponsVerified = [intent.assetIn.toLowerCase(), intent.assetOut.toLowerCase()];
+      } catch { /* fallback */ }
+      return ponsVerified ? { verifiedPonsTokens: ponsVerified } as ScoutContext : undefined;
+    }
+    return undefined;
   }
 
   /**

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -4901,7 +4901,11 @@ async function main() {
     }
     await ensureDecision(intent, "chat", `owner asked to ${side} ${usdgAmount} USDG ${symbol} in chat`);
     await processIntent(intent, lastEquityUsdg, lastEquityKnown);
-    return `🏹 submitted ${side} ${usdgAmount} USDG ${symbol} — watch /trades for the result (it still passes the policy wall).`;
+    const outcome = lastTradeOutcome;
+    if (outcome?.status === "landed") return `✅ ${side} ${usdgAmount} USDG ${symbol} landed — check /trades or /you`;
+    if (outcome?.status === "rejected") return `🚫 ${side} ${usdgAmount} USDG ${symbol} rejected${outcome.rejectRule ? ` (${outcome.rejectRule})` : ""}.`;
+    if (outcome?.status === "reverted") return `❌ ${side} ${usdgAmount} USDG ${symbol} reverted on-chain.`;
+    return `🏹 submitted ${side} ${usdgAmount} USDG ${symbol} — check /trades for the result.`;
   }
 
   async function submitChatTransfer(to: `0x${string}`, usdgAmount: number): Promise<string> {

--- a/worker/src/limits.ts
+++ b/worker/src/limits.ts
@@ -31,6 +31,13 @@ export function limitsFromGrant(
    * blanket refusal either.
    */
   knownCurves?: readonly string[],
+  /**
+   * Token addresses from the Pons launchpad feed — used by the "*pons" wildcard
+   * in asset-allowlist checks. Same provenance as knownCurves (factory-filtered
+   * discovery), but the TOKEN addresses, not the curve addresses. Optional for
+   * the same reason knownCurves is.
+   */
+  ponsAssets?: readonly string[],
 ): AgentLimits {
   return {
     perTradeUsdg: usdgUnits(grant.caps.perTradeUsdg),
@@ -87,12 +94,19 @@ export function limitsFromGrant(
         return a ? [a] : [];
       })(),
     ],
-    allowedAssets: [CASH.USDG as `0x${string}`, ...watchTokens.map((token) => token.address)],
+    allowedAssets: [
+      CASH.USDG as `0x${string}`,
+      ...watchTokens.map((token) => token.address),
+      // WILDCARD: if the grant carries "*pons", pass it through to allowedAssets
+      // so the swap path also recognises Pons launchpad tokens.
+      ...(grant.grantTokens?.includes("*pons") ? ["*pons" as `0x${string}`] : []),
+    ],
     sellableAssets: [...sellableAssets(grant)],
     // The quote side only -- see AgentLimits.quoteAssets. sellableAssets minus
     // this is the set of tokens a curve trade could be buying INTO.
     quoteAssets: [...builtinGrantTargets(grant)],
     knownCurves,
+    ponsAssets,
     // THE TRANSFER PERMISSION, MIRRORED. checkPolicy has always known how to
     // judge this — it was simply never told. A grant without the transfer
     // marker has NO USDG transfer permission in its call policy:

--- a/worker/src/policy.ts
+++ b/worker/src/policy.ts
@@ -67,6 +67,15 @@ export interface AgentLimits {
    */
   knownCurves?: readonly string[];
   /**
+   * Token addresses the wildcard `*pons` covers — populated from the same Pons
+   * launchpad discovery feed as knownCurves. When sellableAssets contains
+   * "*pons", a token whose address is in this list passes the asset-allowlist
+   * check even though it isn't individually in the grant's grantTokens.
+   *
+   * Optional for the same reason knownCurves is: fixtures have no feed.
+   */
+  ponsAssets?: readonly string[];
+  /**
    * The QUOTE side of the book: USDG and the tradeable stock tokens.
    *
    * `builtinGrantTargets(grant)` -- deliberately NOT sellableAssets, which also
@@ -317,15 +326,19 @@ export function checkPolicy(
     if (limits.sellableAssets) {
       const sellable = limits.sellableAssets.map(lc);
       for (const token of [intent.assetIn, intent.assetOut]) {
-        if (!sellable.includes(lc(token))) {
-          return {
-            ok: false,
-            rule: "asset-allowlist",
-            detail:
-              `asset ${token} is not in the signed grant, so the wall will refuse this trade. ` +
-              `Add it at /settings and re-sign the grant at /grant to cover it.`,
-          };
-        }
+        if (sellable.includes(lc(token))) continue;
+        // WILDCARD: if the grant carries "*pons" and this token is a known Pons
+        // launchpad asset, it passes the asset check even though it's not in the
+        // signed grantTokens. The launchpad pre-vets the token, and the curve
+        // adapter — which is pinned in the grant — is the only route into it.
+        if (sellable.includes("*pons") && limits.ponsAssets?.map(lc).includes(lc(token))) continue;
+        return {
+          ok: false,
+          rule: "asset-allowlist",
+          detail:
+            `asset ${token} is not in the signed grant, so the wall will refuse this trade. ` +
+            `Add it at /settings and re-sign the grant at /grant to cover it.`,
+        };
       }
     }
 
@@ -349,9 +362,10 @@ export function checkPolicy(
 
   if (intent.kind === "swap") {
     for (const token of [intent.sellToken, intent.buyToken]) {
-      if (!limits.allowedAssets.map(lc).includes(lc(token))) {
-        return { ok: false, rule: "asset-allowlist", detail: `asset ${token} not allowed` };
-      }
+      if (limits.allowedAssets.map(lc).includes(lc(token))) continue;
+      // WILDCARD: "*pons" in allowedAssets means any Pons launchpad token passes.
+      if (limits.allowedAssets.map(lc).includes("*pons") && limits.ponsAssets?.map(lc).includes(lc(token))) continue;
+      return { ok: false, rule: "asset-allowlist", detail: `asset ${token} not allowed` };
     }
 
     // NEVER ENTER A POSITION THE KEY CANNOT EXIT.
@@ -369,15 +383,17 @@ export function checkPolicy(
     // Sells are never blocked by this rule — an exit must always be attemptable.
     if (limits.sellableAssets) {
       const sellable = limits.sellableAssets.map(lc);
-      if (!sellable.includes(lc(intent.buyToken))) {
-        return {
+      if (sellable.includes(lc(intent.buyToken))) {
+        // pass
+      } else if (sellable.includes("*pons") && limits.ponsAssets?.map(lc).includes(lc(intent.buyToken))) {
+        // WILDCARD: Pons launchpad token — key can sell through the curve adapter, so no-exit doesn't apply
+      } else return {
           ok: false,
           rule: "no-exit",
           detail:
             `refusing to buy ${intent.buyToken}: this key can't approve it for a sell, ` +
             `so the position could be opened and never closed. Re-sign the grant at /grant to cover it.`,
         };
-      }
     }
 
     // BUYING SOMETHING NOBODY CAN PRICE.

--- a/worker/src/policy.ts
+++ b/worker/src/policy.ts
@@ -256,6 +256,14 @@ export interface ScoutContext {
   existingCostUsdg: bigint;
   /** USDG (6dp) total across every unpriceable position held. */
   quarantinedUsdg: bigint;
+  /**
+   * Token addresses verified as Pons launchpad tokens via on-chain factory
+   * check. Populated BEFORE checkPolicy runs so the policy check stays
+   * synchronous. When the `*pons` wildcard is active but the token isn't
+   * in the local ponsAssets cache, this fallback catches it.
+   * Undefined = no on-chain fallback, which is correct for backtests/fixtures.
+   */
+  verifiedPonsTokens?: string[];
 }
 
 export function checkPolicy(
@@ -331,7 +339,12 @@ export function checkPolicy(
         // launchpad asset, it passes the asset check even though it's not in the
         // signed grantTokens. The launchpad pre-vets the token, and the curve
         // adapter — which is pinned in the grant — is the only route into it.
-        if (sellable.includes("*pons") && limits.ponsAssets?.map(lc).includes(lc(token))) continue;
+        if (sellable.includes("*pons")) {
+          // Check local cache first
+          if (limits.ponsAssets?.map(lc).includes(lc(token))) continue;
+          // Fallback: check the on-chain verification (pre-populated by scoutContextFor)
+          if (scout?.verifiedPonsTokens?.map(lc).includes(lc(token))) continue;
+        }
         return {
           ok: false,
           rule: "asset-allowlist",
@@ -364,7 +377,10 @@ export function checkPolicy(
     for (const token of [intent.sellToken, intent.buyToken]) {
       if (limits.allowedAssets.map(lc).includes(lc(token))) continue;
       // WILDCARD: "*pons" in allowedAssets means any Pons launchpad token passes.
-      if (limits.allowedAssets.map(lc).includes("*pons") && limits.ponsAssets?.map(lc).includes(lc(token))) continue;
+      if (limits.allowedAssets.map(lc).includes("*pons")) {
+        if (limits.ponsAssets?.map(lc).includes(lc(token))) continue;
+        if (scout?.verifiedPonsTokens?.map(lc).includes(lc(token))) continue;
+      }
       return { ok: false, rule: "asset-allowlist", detail: `asset ${token} not allowed` };
     }
 
@@ -385,15 +401,18 @@ export function checkPolicy(
       const sellable = limits.sellableAssets.map(lc);
       if (sellable.includes(lc(intent.buyToken))) {
         // pass
-      } else if (sellable.includes("*pons") && limits.ponsAssets?.map(lc).includes(lc(intent.buyToken))) {
-        // WILDCARD: Pons launchpad token — key can sell through the curve adapter, so no-exit doesn't apply
-      } else return {
-          ok: false,
-          rule: "no-exit",
-          detail:
-            `refusing to buy ${intent.buyToken}: this key can't approve it for a sell, ` +
-            `so the position could be opened and never closed. Re-sign the grant at /grant to cover it.`,
-        };
+      } else if (sellable.includes("*pons")) {
+        // WILDCARD: check local cache first, then on-chain fallback
+        if (limits.ponsAssets?.map(lc).includes(lc(intent.buyToken))) {
+          // pass
+        } else if (scout?.verifiedPonsTokens?.map(lc).includes(lc(intent.buyToken))) {
+          // pass
+        } else {
+          return { ok: false, rule: "no-exit", detail: `refusing to buy ${intent.buyToken}: this key can't approve it for a sell, so the position could be opened and never closed. Re-sign the grant at /grant to cover it.` };
+        }
+      } else {
+        return { ok: false, rule: "no-exit", detail: `refusing to buy ${intent.buyToken}: this key can't approve it for a sell, so the position could be opened and never closed. Re-sign the grant at /grant to cover it.` };
+      }
     }
 
     // BUYING SOMETHING NOBODY CAN PRICE.

--- a/worker/src/policy.ts
+++ b/worker/src/policy.ts
@@ -264,6 +264,12 @@ export interface ScoutContext {
    * Undefined = no on-chain fallback, which is correct for backtests/fixtures.
    */
   verifiedPonsTokens?: string[];
+  /**
+   * When true, skip the drawdown breaker check. Set for user-initiated chat
+   * trades — the owner knows what they're doing and the breaker should only
+   * constrain the automated strategy.
+   */
+  skipDrawdown?: boolean;
 }
 
 export function checkPolicy(
@@ -562,7 +568,7 @@ export function checkPolicy(
       ((limits.cashToken !== undefined && lc(intent.assetOut) === lc(limits.cashToken)) ||
         (limits.quoteAssets !== undefined && limits.quoteAssets.map(lc).includes(lc(intent.assetOut)))));
 
-  if (!isExit && state.highWaterMarkUsdg > 0n && state.equityKnown !== false) {
+  if (!isExit && !scout?.skipDrawdown && state.highWaterMarkUsdg > 0n && state.equityKnown !== false) {
     const drawdownBps = Number(
       ((state.highWaterMarkUsdg - state.equityUsdg) * 10_000n) / state.highWaterMarkUsdg,
     );

--- a/worker/src/store.ts
+++ b/worker/src/store.ts
@@ -2529,6 +2529,22 @@ export async function knownCurves(): Promise<string[] | null> {
   }
 }
 
+/**
+ * Token addresses from the Pons launchpad discovery feed — used by the "*pons"
+ * wildcard in asset-allowlist checks. Same provenance as knownCurves() but
+ * returns TOKEN addresses (the `address` column), not curve addresses.
+ */
+export async function knownPonsAssets(): Promise<string[] | null> {
+  try {
+    const rows = (await getDb()
+      .prepare(`SELECT DISTINCT address FROM discovered_pools WHERE address IS NOT NULL`)
+      .all()) as { address: string | null }[];
+    return rows.map((r) => r.address).filter((a): a is string => !!a).map((a) => a.toLowerCase());
+  } catch {
+    return null;
+  }
+}
+
 
 /**
  * Where a specific token trades on the launchpad — by address, not by recency.

--- a/worker/src/store.ts
+++ b/worker/src/store.ts
@@ -2545,6 +2545,29 @@ export async function knownPonsAssets(): Promise<string[] | null> {
   }
 }
 
+/**
+ * Record a Pons launchpad token's curve in the discovered_pools table.
+ * Called when the on-chain factory check confirms the token is a real Pons
+ * launch but the local cache didn't have it yet. Caches the curve address
+ * so subsequent calls use the local DB instead of an RPC query.
+ */
+export async function recordPonsCurve(
+  address: string,
+  symbol: string,
+  curve: string,
+  quoteToken: string,
+): Promise<void> {
+  try {
+    await getDb()
+      .prepare(
+        `INSERT OR IGNORE INTO discovered_pools (address, symbol, curve, quote_token, first_seen)
+         VALUES (?, ?, ?, ?, unixepoch())`,
+      )
+      .run(address.toLowerCase(), symbol, curve.toLowerCase(), quoteToken.toLowerCase());
+  } catch {
+    // Non-critical cache — silently ignore failures
+  }
+}
 
 /**
  * Where a specific token trades on the launchpad — by address, not by recency.

--- a/worker/src/telegram/api.ts
+++ b/worker/src/telegram/api.ts
@@ -36,6 +36,8 @@ export interface TgMessage {
   text: string;
   /** Telegram file_id of an attached voice/audio note, if any (for transcription). */
   voiceFileId?: string;
+  /** For inline button taps (callback_query), the id to answer. */
+  callbackQueryId?: string;
 }
 
 export interface TgBotInfo {
@@ -107,7 +109,7 @@ export async function getUpdates(
   const { result, reason } = await call(opts, "getUpdates", {
     offset,
     timeout: timeoutSec,
-    allowed_updates: ["message"],
+    allowed_updates: ["message", "callback_query"],
   });
   if (!Array.isArray(result)) return { messages: [], nextOffset: offset, reason };
 
@@ -115,8 +117,29 @@ export async function getUpdates(
   let nextOffset = offset;
   for (const raw of result) {
     if (!raw || typeof raw !== "object") continue;
-    const u = raw as { update_id?: unknown; message?: unknown };
+    const u = raw as { update_id?: unknown; message?: unknown; callback_query?: unknown };
     if (typeof u.update_id === "number") nextOffset = Math.max(nextOffset, u.update_id + 1);
+    // Callback queries (inline button taps) are converted to fake messages.
+    // The callback_data carries the slash command text (/confirm, /cancel).
+    const cb = u.callback_query as
+      | { message?: { chat?: { id?: unknown }; message_id?: unknown }; data?: unknown; from?: { id?: unknown; username?: unknown }; id?: unknown }
+      | undefined;
+    if (cb && typeof cb.data === "string" && cb.data.startsWith("/")) {
+      const cbMsg = cb.message;
+      const chatId = cbMsg?.chat?.id;
+      const fromId = cb.from?.id;
+      if (typeof chatId === "number" && typeof fromId === "number") {
+        messages.push({
+          updateId: typeof u.update_id === "number" ? u.update_id : 0,
+          chatId,
+          fromId,
+          fromUsername: typeof cb.from?.username === "string" ? cb.from.username : undefined,
+          text: cb.data,
+          callbackQueryId: typeof cb.id === "string" ? cb.id : undefined,
+        });
+      }
+      continue;
+    }
     const m = u.message as
       | {
           chat?: { id?: unknown };
@@ -244,6 +267,13 @@ export async function sendMessageWithKeyboard(
   // Fall back to plain text without buttons on error
   const plain = await call(opts, "sendMessage", { chat_id: chatId, text: body.replace(/<[^>]+>/g, "") });
   return plain.result != null ? { ok: true } : { ok: false, reason: plain.reason };
+}
+
+/**
+ * Answer a callback query (inline button tap) — required by Telegram or it shows a spinner.
+ */
+export async function answerCallbackQuery(opts: TelegramOpts, callbackQueryId: string): Promise<void> {
+  await call(opts, "answerCallbackQuery", { callback_query_id: callbackQueryId });
 }
 
 export function sendPhoto(opts: TelegramOpts, chatId: number, filePath: string, caption?: string) {

--- a/worker/src/telegram/api.ts
+++ b/worker/src/telegram/api.ts
@@ -226,6 +226,26 @@ async function sendFile(
   }
 }
 
+/**
+ * Send a message with inline keyboard buttons. Best-effort — returns a reason
+ * on failure, never throws. Uses HTML parse_mode the same as sendMessage.
+ * Falls back to sendMessage (plain text) if the keyboard is rejected.
+ */
+export async function sendMessageWithKeyboard(
+  opts: TelegramOpts,
+  chatId: number,
+  text: string,
+  buttons: { text: string; callback: string }[][],
+): Promise<{ ok: boolean; reason?: string }> {
+  const body = text.length > 4096 ? text.slice(0, 4090) + "\n…" : text;
+  const reply_markup = { inline_keyboard: buttons.map((row) => row.map((b) => ({ text: b.text, callback_data: b.callback }))) };
+  const html = await call(opts, "sendMessage", { chat_id: chatId, text: body, parse_mode: "HTML", reply_markup });
+  if (html.result != null) return { ok: true };
+  // Fall back to plain text without buttons on error
+  const plain = await call(opts, "sendMessage", { chat_id: chatId, text: body.replace(/<[^>]+>/g, "") });
+  return plain.result != null ? { ok: true } : { ok: false, reason: plain.reason };
+}
+
 export function sendPhoto(opts: TelegramOpts, chatId: number, filePath: string, caption?: string) {
   return sendFile(opts, "sendPhoto", "photo", chatId, filePath, caption);
 }

--- a/worker/src/telegram/executor.ts
+++ b/worker/src/telegram/executor.ts
@@ -34,7 +34,16 @@ export type PendingAction =
    * key — so a misread instruction was a permanent loss of funds. A transfer of
    * $5 asks first; ending the agent should too.
    */
-  | { kind: "kill"; expiresAt: number };
+  | { kind: "kill"; expiresAt: number }
+  /**
+   * EVERY trade parks here first — no size threshold, no auto-execute. The
+   * card shows exactly what will move (side, symbol, amount) and only an
+   * explicit /confirm fires deps.trade; /cancel or the TTL discards it. The
+   * same re-vet at confirm time as every other parked action: a gate that
+   * closed during the window must not fire a stale trade.
+   */
+  | { kind: "buy"; symbol: string; usdg: number; expiresAt: number }
+  | { kind: "sell"; symbol: string; usdg: number; expiresAt: number };
 
 export interface CommandDeps {
   controlEnabled: boolean;
@@ -184,14 +193,18 @@ export async function executeCommand(cmd: Command, deps: CommandDeps): Promise<s
     }
     case "buy":
     case "sell": {
+      // PARK, DON'T FIRE. The parsed intent becomes a card the user confirms —
+      // the same rhythm a transfer already has — because a trade is real money
+      // and "buy 1 usdg of any coin" typed in a hurry deserves one look.
       let usdg = cmd.usdg;
-      let note = "";
-      if (usdg > deps.maxActionUsdg) {
-        usdg = deps.maxActionUsdg;
-        note = ` (trimmed to your ${deps.maxActionUsdg} USDG chat ceiling)`;
-      }
-      const reply = await deps.trade(cmd.kind, cmd.symbol, usdg);
-      return reply + note;
+      const trimmed = usdg > deps.maxActionUsdg;
+      if (trimmed) usdg = deps.maxActionUsdg;
+      deps.setPending({ kind: cmd.kind, symbol: cmd.symbol, usdg, expiresAt: now() + CONFIRM_TTL_SEC });
+      return (
+        `🏹 pending — <b>${cmd.kind} ${usdg} USDG of ${cmd.symbol}</b>${trimmed ? ` (trimmed to your ${deps.maxActionUsdg} USDG chat ceiling)` : ""}
+` +
+        `nothing moves until you say so — /confirm to execute · /cancel to discard (${CONFIRM_TTL_SEC}s)`
+      );
     }
     case "transfer": {
       if (!deps.transferEnabled) {
@@ -234,6 +247,13 @@ export async function executeCommand(cmd: Command, deps: CommandDeps): Promise<s
           deps.clearPending();
           return "🔒 transfers were turned off before you confirmed — nothing moved.";
         }
+      } else if (p.kind === "buy" || p.kind === "sell") {
+        // Same re-vet as the kill switch: control may have been switched off
+        // during the confirmation window. A stale parked trade must not fire.
+        if (!deps.controlEnabled) {
+          deps.clearPending();
+          return "🔒 control was turned off before you confirmed — nothing moved.";
+        }
       } else if (p.kind === "kill") {
         // Kill is a control command, not a PC capability — re-vet the control
         // switch rather than running it through pcRefusal, which knows nothing
@@ -253,6 +273,9 @@ export async function executeCommand(cmd: Command, deps: CommandDeps): Promise<s
       switch (p.kind) {
         case "transfer":
           return await deps.transfer(p.to, p.usdg);
+        case "buy":
+        case "sell":
+          return await deps.trade(p.kind, p.symbol, p.usdg);
         case "shell":
           return await deps.pc.runShell(p.cmd);
         case "getfile":

--- a/worker/src/telegram/executor.ts
+++ b/worker/src/telegram/executor.ts
@@ -407,5 +407,8 @@ export async function executeCommand(cmd: Command, deps: CommandDeps): Promise<s
       // streams its own messages). This branch keeps the switch exhaustive and is
       // not reached in normal flow.
       return "🏹 starting…";
+    default:
+      // ask-amount is handled in service.ts before executeCommand is reached.
+      return `unknown command: ${(cmd as any).kind}`;
   }
 }

--- a/worker/src/telegram/executor.ts
+++ b/worker/src/telegram/executor.ts
@@ -77,6 +77,8 @@ export interface CommandDeps {
   link(code: string): { ok: boolean; reason?: string };
   /** Build a bounded TradeIntent and route it through processIntent → policy wall. */
   trade(side: "buy" | "sell", symbol: string, usdg: number): Promise<string>;
+  /** Execute a confirmed trade (parked → /confirm). Skips the first-tick check submitChatTrade does. */
+  confirmTrade: (side: "buy" | "sell", symbol: string, usdg: number) => Promise<string>;
   /** Build a bounded transfer intent and route it through processIntent → policy wall. */
   transfer(to: `0x${string}`, usdg: number): Promise<string>;
   /** Pending-confirm store, bound to this chat by the service. */
@@ -273,7 +275,7 @@ export async function executeCommand(cmd: Command, deps: CommandDeps): Promise<s
           return await deps.transfer(p.to, p.usdg);
         case "buy":
         case "sell":
-          return await deps.trade(p.kind, p.symbol, p.usdg);
+          return await deps.confirmTrade(p.kind, p.symbol, p.usdg);
         case "shell":
           return await deps.pc.runShell(p.cmd);
         case "getfile":

--- a/worker/src/telegram/executor.ts
+++ b/worker/src/telegram/executor.ts
@@ -200,11 +200,9 @@ export async function executeCommand(cmd: Command, deps: CommandDeps): Promise<s
       const trimmed = usdg > deps.maxActionUsdg;
       if (trimmed) usdg = deps.maxActionUsdg;
       deps.setPending({ kind: cmd.kind, symbol: cmd.symbol, usdg, expiresAt: now() + CONFIRM_TTL_SEC });
-      return (
-        `🏹 pending — <b>${cmd.kind} ${usdg} USDG of ${cmd.symbol}</b>${trimmed ? ` (trimmed to your ${deps.maxActionUsdg} USDG chat ceiling)` : ""}
-` +
-        `nothing moves until you say so — /confirm to execute · /cancel to discard (${CONFIRM_TTL_SEC}s)`
-      );
+      let head = "🏹 pending — <b>" + cmd.kind + " " + usdg + " USDG of " + cmd.symbol + "</b>";
+      if (trimmed) head += " (trimmed to your " + deps.maxActionUsdg + " USDG chat ceiling)";
+      return head + "\nnothing moves until you say so — /confirm to execute · /cancel to discard (" + CONFIRM_TTL_SEC + "s)";
     }
     case "transfer": {
       if (!deps.transferEnabled) {

--- a/worker/src/telegram/executor.ts
+++ b/worker/src/telegram/executor.ts
@@ -42,8 +42,8 @@ export type PendingAction =
    * same re-vet at confirm time as every other parked action: a gate that
    * closed during the window must not fire a stale trade.
    */
-  | { kind: "buy"; symbol: string; usdg: number; expiresAt: number }
-  | { kind: "sell"; symbol: string; usdg: number; expiresAt: number };
+  | { kind: "buy"; symbol: string; usdg: number; expiresAt: number; address?: `0x${string}` }
+  | { kind: "sell"; symbol: string; usdg: number; expiresAt: number; address?: `0x${string}` };
 
 export interface CommandDeps {
   controlEnabled: boolean;
@@ -78,7 +78,7 @@ export interface CommandDeps {
   /** Build a bounded TradeIntent and route it through processIntent → policy wall. */
   trade(side: "buy" | "sell", symbol: string, usdg: number): Promise<string>;
   /** Execute a confirmed trade (parked → /confirm). Skips the first-tick check submitChatTrade does. */
-  confirmTrade: (side: "buy" | "sell", symbol: string, usdg: number) => Promise<string>;
+  confirmTrade: (side: "buy" | "sell", symbol: string, usdg: number, address?: `0x${string}`) => Promise<string>;
   /** Build a bounded transfer intent and route it through processIntent → policy wall. */
   transfer(to: `0x${string}`, usdg: number): Promise<string>;
   /** Pending-confirm store, bound to this chat by the service. */
@@ -201,7 +201,9 @@ export async function executeCommand(cmd: Command, deps: CommandDeps): Promise<s
       let usdg = cmd.usdg;
       const trimmed = usdg > deps.maxActionUsdg;
       if (trimmed) usdg = deps.maxActionUsdg;
-      deps.setPending({ kind: cmd.kind, symbol: cmd.symbol, usdg, expiresAt: now() + CONFIRM_TTL_SEC });
+      const pending = { kind: cmd.kind as "buy" | "sell", symbol: cmd.symbol, usdg, expiresAt: now() + CONFIRM_TTL_SEC };
+      if (cmd.address) (pending as any).address = cmd.address;
+      deps.setPending(pending);
       let head = "🏹 pending — <b>" + cmd.kind + " " + usdg + " USDG of " + cmd.symbol + "</b>";
       if (trimmed) head += " (trimmed to your " + deps.maxActionUsdg + " USDG chat ceiling)";
       return head + "\nnothing moves until you say so — /confirm to execute · /cancel to discard (" + CONFIRM_TTL_SEC + "s)";
@@ -275,7 +277,7 @@ export async function executeCommand(cmd: Command, deps: CommandDeps): Promise<s
           return await deps.transfer(p.to, p.usdg);
         case "buy":
         case "sell":
-          return await deps.confirmTrade(p.kind, p.symbol, p.usdg);
+          return await deps.confirmTrade(p.kind, p.symbol, p.usdg, p.address);
         case "shell":
           return await deps.pc.runShell(p.cmd);
         case "getfile":

--- a/worker/src/telegram/fluid-trading.test.ts
+++ b/worker/src/telegram/fluid-trading.test.ts
@@ -105,6 +105,10 @@ function fakeDeps(over: Partial<CommandDeps> = {}) {
       calls.push({ side, symbol, usdg });
       return `⚡ executed — ${side} ${usdg} USDG of ${symbol}`;
     },
+    confirmTrade: async (side, symbol, usdg) => {
+      calls.push({ side, symbol, usdg });
+      return `✅ confirmed — ${side} ${usdg} USDG of ${symbol}`;
+    },
     transfer: async () => "unused",
     getPending: () => pending,
     setPending: (p) => {
@@ -146,7 +150,7 @@ describe("executeCommand — every trade parks for confirmation", () => {
     const t = fakeDeps();
     await executeCommand({ kind: "buy", symbol: "NVDA", usdg: 1 }, t.deps);
     const reply = await executeCommand({ kind: "confirm" }, t.deps);
-    assert.match(reply, /executed/);
+    assert.match(reply, /confirmed/);
     assert.deepEqual(t.calls, [{ side: "buy", symbol: "NVDA", usdg: 1 }]);
     assert.equal(t.pending, null, "the slot clears after firing");
   });

--- a/worker/src/telegram/fluid-trading.test.ts
+++ b/worker/src/telegram/fluid-trading.test.ts
@@ -57,13 +57,21 @@ describe("fastParseTrade — trade-shaped text parses with no model", () => {
     assert.notDeepEqual(parseSlash("/sell 1 usdg of tsla")?.kind === "sell" ? (parseSlash("/sell 1 usdg of tsla") as { symbol: string }).symbol : "", "TSLA");
   });
 
+  it("parses $ symbols and usdg suffixes", async () => {
+    assert.deepEqual(await fastParseTrade("/buy $nvda 1"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.deepEqual(await fastParseTrade("/buy nvda 1usdg"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.deepEqual(await fastParseTrade("/buy $NVDA 1usdg"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.deepEqual(await fastParseTrade("buy 1usdg of $nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+  });
+
   it("returns null for non-trades — the LLM keeps its job", async () => {
     assert.equal(await fastParseTrade("/status"), null);
     assert.equal(await fastParseTrade("what's my pnl?"), null);
     assert.equal(await fastParseTrade("buy 1 usdg of any coin"), null, "no symbol → not a trade");
     assert.equal(await fastParseTrade("buy"), null);
     assert.equal(await fastParseTrade(""), null);
-    assert.equal(await fastParseTrade("buy 0 nvda"), null, "zero amount is not a trade");
+    // /buy 0 defaults to 1 USDG (fluid trading fix)
+    assert.deepEqual(await fastParseTrade("buy 0 nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
   });
 
   it("never returns a non-trade kind even from a slash", async () => {

--- a/worker/src/telegram/fluid-trading.test.ts
+++ b/worker/src/telegram/fluid-trading.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { fastParseTrade, parseSlash } from "./interpreter";
+import { executeCommand, type CommandDeps, type PendingAction } from "./executor";
+
+/**
+ * THE FLUID PATH — say it, see the card, confirm it lands.
+ *
+ * fastParseTrade must catch every trade-shaped phrasing BEFORE the LLM (a
+ * down provider once answered "/buy 1 nvda" with a paragraph of leaked
+ * reasoning while the trade went nowhere). executeCommand must PARK every
+ * buy/sell — no size threshold — and only deps.trade on /confirm.
+ */
+
+describe("fastParseTrade — trade-shaped text parses with no model", () => {
+  it("parses every slash form", () => {
+    assert.deepEqual(fastParseTrade("/buy 1 nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.deepEqual(fastParseTrade("/buy NVDA 1"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.deepEqual(fastParseTrade("/sell 2 TSLA"), { kind: "sell", symbol: "TSLA", usdg: 2 });
+  });
+
+  it("parses bare-verb phrasings with filler words", () => {
+    assert.deepEqual(fastParseTrade("buy 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.deepEqual(fastParseTrade("sell 2 usdg of tsla"), { kind: "sell", symbol: "TSLA", usdg: 2 });
+    assert.deepEqual(fastParseTrade("buy nvda 1"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+  });
+
+  it("corrects the one-key thumb typos", () => {
+    assert.deepEqual(fastParseTrade("but 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.deepEqual(fastParseTrade("byu 2 nvda"), { kind: "buy", symbol: "NVDA", usdg: 2 });
+    assert.deepEqual(fastParseTrade("/buy 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+  });
+
+  it("WINS over parseSlash: filler words are stripped, not read as symbols", () => {
+    // THE BUG THIS LOCKS. parseSlash reads the "usdg" in "/sell 1 usdg of
+    // tsla" as the SYMBOL (it matches the ticker shape), producing a
+    // nonsense USDG-for-USDG swap that would burn gas reaching the wall.
+    // The fluid parse strips filler and gets TSLA — and it must be asked
+    // FIRST, which is the order service.ts now uses.
+    assert.deepEqual(fastParseTrade("/sell 1 usdg of tsla"), { kind: "sell", symbol: "TSLA", usdg: 1 });
+    assert.deepEqual(fastParseTrade("/buy 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.notDeepEqual(parseSlash("/sell 1 usdg of tsla")?.symbol?.toUpperCase(), "TSLA");
+  });
+
+  it("returns null for non-trades — the LLM keeps its job", () => {
+    assert.equal(fastParseTrade("/status"), null);
+    assert.equal(fastParseTrade("what's my pnl?"), null);
+    assert.equal(fastParseTrade("buy 1 usdg of any coin"), null, "no symbol → not a trade");
+    assert.equal(fastParseTrade("buy"), null);
+    assert.equal(fastParseTrade(""), null);
+    assert.equal(fastParseTrade("buy 0 nvda"), null, "zero amount is not a trade");
+  });
+
+  it("never returns a non-trade kind even from a slash", () => {
+    // /pause IS a real slash command — parseSlash handles it. The fluid path
+    // must simply refuse it: trading verbs only, or the LLM keeps its job.
+    assert.equal(fastParseTrade("/pause"), null);
+    assert.equal(fastParseTrade("/help"), null);
+    assert.deepEqual(parseSlash("/pause"), { kind: "pause" });
+  });
+});
+
+/** In-memory deps: pending store, recorded trades, nothing on-chain. */
+function fakeDeps(over: Partial<CommandDeps> = {}) {
+  const calls: { side: string; symbol: string; usdg: number }[] = [];
+  let pending: PendingAction | null = null;
+  let nowSec = 1_000_000;
+  const deps: CommandDeps = {
+    controlEnabled: true,
+    maxActionUsdg: 25,
+    transferEnabled: false,
+    grantHasTransfer: false,
+    link: () => ({ ok: true }),
+    trade: async (side, symbol, usdg) => {
+      calls.push({ side, symbol, usdg });
+      return `⚡ executed — ${side} ${usdg} USDG of ${symbol}`;
+    },
+    transfer: async () => "unused",
+    getPending: () => pending,
+    setPending: (p) => {
+      pending = p;
+    },
+    clearPending: () => {
+      pending = null;
+    },
+    now: () => nowSec,
+    kill: () => ({ ok: true }),
+    ...over,
+  } as CommandDeps;
+  return {
+    deps,
+    calls,
+    get pending() {
+      return pending;
+    },
+    tick: (s: number) => {
+      nowSec += s;
+    },
+  };
+}
+
+const CHAT = { chatId: 1, fromId: 1 } as never;
+void CHAT;
+
+describe("executeCommand — every trade parks for confirmation", () => {
+  it("a buy parks: nothing fires until /confirm", async () => {
+    const t = fakeDeps();
+    const reply = await executeCommand({ kind: "buy", symbol: "NVDA", usdg: 1 }, t.deps);
+    assert.match(reply, /pending/);
+    assert.match(reply, /\/confirm/);
+    assert.equal(t.calls.length, 0, "no trade on park");
+    assert.deepEqual(t.pending, { kind: "buy", symbol: "NVDA", usdg: 1, expiresAt: 1_000_090 });
+  });
+
+  it("/confirm fires exactly the parked trade, once", async () => {
+    const t = fakeDeps();
+    await executeCommand({ kind: "buy", symbol: "NVDA", usdg: 1 }, t.deps);
+    const reply = await executeCommand({ kind: "confirm" }, t.deps);
+    assert.match(reply, /executed/);
+    assert.deepEqual(t.calls, [{ side: "buy", symbol: "NVDA", usdg: 1 }]);
+    assert.equal(t.pending, null, "the slot clears after firing");
+  });
+
+  it("/cancel discards without firing", async () => {
+    const t = fakeDeps();
+    await executeCommand({ kind: "sell", symbol: "TSLA", usdg: 2 }, t.deps);
+    await executeCommand({ kind: "cancel" }, t.deps);
+    assert.equal(t.calls.length, 0);
+    assert.equal(t.pending, null);
+  });
+
+  it("an expired card cannot fire", async () => {
+    const t = fakeDeps();
+    await executeCommand({ kind: "buy", symbol: "NVDA", usdg: 1 }, t.deps);
+    t.tick(91); // past the 90s TTL
+    const reply = await executeCommand({ kind: "confirm" }, t.deps);
+    assert.match(reply, /expired/);
+    assert.equal(t.calls.length, 0);
+  });
+
+  it("the amount above the chat ceiling parks TRIMMED, and fires trimmed", async () => {
+    const t = fakeDeps();
+    await executeCommand({ kind: "buy", symbol: "NVDA", usdg: 50 }, t.deps);
+    assert.deepEqual(t.pending, { kind: "buy", symbol: "NVDA", usdg: 25, expiresAt: 1_000_090 });
+    await executeCommand({ kind: "confirm" }, t.deps);
+    assert.deepEqual(t.calls, [{ side: "buy", symbol: "NVDA", usdg: 25 }]);
+  });
+
+  it("control switched off mid-window: the confirm is refused, nothing moves", async () => {
+    const t = fakeDeps();
+    await executeCommand({ kind: "buy", symbol: "NVDA", usdg: 1 }, t.deps);
+    t.deps.controlEnabled = false;
+    const reply = await executeCommand({ kind: "confirm" }, t.deps);
+    assert.match(reply, /control was turned off/);
+    assert.equal(t.calls.length, 0);
+  });
+
+  it("control off at park time: the 🔒 refusal, unchanged", async () => {
+    const t = fakeDeps({ controlEnabled: false });
+    const reply = await executeCommand({ kind: "buy", symbol: "NVDA", usdg: 1 }, t.deps);
+    assert.match(reply, /control commands are turned off/);
+    assert.equal(t.pending, null);
+  });
+
+  it("the fluid path end to end: typo'd phrase → park → confirm → fired", async () => {
+    const t = fakeDeps();
+    const parsed = fastParseTrade("but 1 usdg of nvda");
+    assert.ok(parsed);
+    await executeCommand(parsed, t.deps);
+    await executeCommand({ kind: "confirm" }, t.deps);
+    assert.deepEqual(t.calls, [{ side: "buy", symbol: "NVDA", usdg: 1 }]);
+  });
+});

--- a/worker/src/telegram/fluid-trading.test.ts
+++ b/worker/src/telegram/fluid-trading.test.ts
@@ -13,59 +13,64 @@ import { executeCommand, type CommandDeps, type PendingAction } from "./executor
  */
 
 describe("fastParseTrade — trade-shaped text parses with no model", () => {
-  it("parses every slash form", () => {
-    assert.deepEqual(fastParseTrade("/buy 1 nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
-    assert.deepEqual(fastParseTrade("/buy NVDA 1"), { kind: "buy", symbol: "NVDA", usdg: 1 });
-    assert.deepEqual(fastParseTrade("/sell 2 TSLA"), { kind: "sell", symbol: "TSLA", usdg: 2 });
+  it("parses every slash form", async () => {
+    assert.deepEqual(await fastParseTrade("/buy 1 nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.deepEqual(await fastParseTrade("/buy NVDA 1"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.deepEqual(await fastParseTrade("/sell 2 TSLA"), { kind: "sell", symbol: "TSLA", usdg: 2 });
   });
 
-  it("refuses a symbol that is not a known token when a resolver is passed", () => {
-    const known = (s: string) => ["NVDA", "TSLA", "AAPL", "QQQ"].includes(s);
-    assert.deepEqual(fastParseTrade("/buy 1 nvda", known), { kind: "buy", symbol: "NVDA", usdg: 1 });
-    assert.equal(fastParseTrade("/buy 1 UNKNOWNCOIN", known), null);
-    assert.equal(fastParseTrade("buy 1 usdg of randomx", known), null);
+  it("refuses a symbol that is not a known token when a resolver is passed", async () => {
+    const known = async (s: string) => ["NVDA", "TSLA", "AAPL", "QQQ"].includes(s);
+    assert.deepEqual(await fastParseTrade("/buy 1 nvda", known), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.equal(await fastParseTrade("/buy 1 UNKNOWNCOIN", known), null);
+    assert.equal(await fastParseTrade("buy 1 usdg of randomx", known), null);
   });
 
-  it("parses every slash form", () => {
+  it("resolves a Pons launch symbol through the async resolver", async () => {
+    const ponsSet = new Set(["POTAM", "PIPEC", "VTSI", "GALIKA"]);
+    const resolver = async (s: string) => ponsSet.has(s.toUpperCase());
+    assert.deepEqual(await fastParseTrade("/buy 1 potam", resolver), { kind: "buy", symbol: "POTAM", usdg: 1 });
+    assert.deepEqual(await fastParseTrade("/buy 1 pipec", resolver), { kind: "buy", symbol: "PIPEC", usdg: 1 });
+    assert.equal(await fastParseTrade("/buy 1 NOTAPONSCOIN", resolver), null);
   });
 
-  it("parses bare-verb phrasings with filler words", () => {
-    assert.deepEqual(fastParseTrade("buy 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
-    assert.deepEqual(fastParseTrade("sell 2 usdg of tsla"), { kind: "sell", symbol: "TSLA", usdg: 2 });
-    assert.deepEqual(fastParseTrade("buy nvda 1"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+  it("parses bare-verb phrasings with filler words", async () => {
+    assert.deepEqual(await fastParseTrade("buy 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.deepEqual(await fastParseTrade("sell 2 usdg of tsla"), { kind: "sell", symbol: "TSLA", usdg: 2 });
+    assert.deepEqual(await fastParseTrade("buy nvda 1"), { kind: "buy", symbol: "NVDA", usdg: 1 });
   });
 
-  it("corrects the one-key thumb typos", () => {
-    assert.deepEqual(fastParseTrade("but 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
-    assert.deepEqual(fastParseTrade("byu 2 nvda"), { kind: "buy", symbol: "NVDA", usdg: 2 });
-    assert.deepEqual(fastParseTrade("/buy 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+  it("corrects the one-key thumb typos", async () => {
+    assert.deepEqual(await fastParseTrade("but 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.deepEqual(await fastParseTrade("byu 2 nvda"), { kind: "buy", symbol: "NVDA", usdg: 2 });
+    assert.deepEqual(await fastParseTrade("/buy 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
   });
 
-  it("WINS over parseSlash: filler words are stripped, not read as symbols", () => {
+  it("WINS over parseSlash: filler words are stripped, not read as symbols", async () => {
     // THE BUG THIS LOCKS. parseSlash reads the "usdg" in "/sell 1 usdg of
     // tsla" as the SYMBOL (it matches the ticker shape), producing a
     // nonsense USDG-for-USDG swap that would burn gas reaching the wall.
     // The fluid parse strips filler and gets TSLA — and it must be asked
     // FIRST, which is the order service.ts now uses.
-    assert.deepEqual(fastParseTrade("/sell 1 usdg of tsla"), { kind: "sell", symbol: "TSLA", usdg: 1 });
-    assert.deepEqual(fastParseTrade("/buy 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.deepEqual(await fastParseTrade("/sell 1 usdg of tsla"), { kind: "sell", symbol: "TSLA", usdg: 1 });
+    assert.deepEqual(await fastParseTrade("/buy 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
     assert.notDeepEqual(parseSlash("/sell 1 usdg of tsla")?.kind === "sell" ? (parseSlash("/sell 1 usdg of tsla") as { symbol: string }).symbol : "", "TSLA");
   });
 
-  it("returns null for non-trades — the LLM keeps its job", () => {
-    assert.equal(fastParseTrade("/status"), null);
-    assert.equal(fastParseTrade("what's my pnl?"), null);
-    assert.equal(fastParseTrade("buy 1 usdg of any coin"), null, "no symbol → not a trade");
-    assert.equal(fastParseTrade("buy"), null);
-    assert.equal(fastParseTrade(""), null);
-    assert.equal(fastParseTrade("buy 0 nvda"), null, "zero amount is not a trade");
+  it("returns null for non-trades — the LLM keeps its job", async () => {
+    assert.equal(await fastParseTrade("/status"), null);
+    assert.equal(await fastParseTrade("what's my pnl?"), null);
+    assert.equal(await fastParseTrade("buy 1 usdg of any coin"), null, "no symbol → not a trade");
+    assert.equal(await fastParseTrade("buy"), null);
+    assert.equal(await fastParseTrade(""), null);
+    assert.equal(await fastParseTrade("buy 0 nvda"), null, "zero amount is not a trade");
   });
 
-  it("never returns a non-trade kind even from a slash", () => {
+  it("never returns a non-trade kind even from a slash", async () => {
     // /pause IS a real slash command — parseSlash handles it. The fluid path
     // must simply refuse it: trading verbs only, or the LLM keeps its job.
-    assert.equal(fastParseTrade("/pause"), null);
-    assert.equal(fastParseTrade("/help"), null);
+    assert.equal(await fastParseTrade("/pause"), null);
+    assert.equal(await fastParseTrade("/help"), null);
     assert.deepEqual(parseSlash("/pause"), { kind: "pause" });
   });
 });
@@ -174,7 +179,7 @@ describe("executeCommand — every trade parks for confirmation", () => {
 
   it("the fluid path end to end: typo'd phrase → park → confirm → fired", async () => {
     const t = fakeDeps();
-    const parsed = fastParseTrade("but 1 usdg of nvda", (s) => true);
+    const parsed = await fastParseTrade("but 1 usdg of nvda", async (s) => true);
     assert.ok(parsed);
     await executeCommand(parsed, t.deps);
     await executeCommand({ kind: "confirm" }, t.deps);

--- a/worker/src/telegram/fluid-trading.test.ts
+++ b/worker/src/telegram/fluid-trading.test.ts
@@ -64,6 +64,12 @@ describe("fastParseTrade — trade-shaped text parses with no model", () => {
     assert.deepEqual(await fastParseTrade("buy 1usdg of $nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
   });
 
+  it("accepts longer memecoin names (up to 10 chars)", async () => {
+    assert.deepEqual(await fastParseTrade("/buy pipotam 5"), { kind: "buy", symbol: "PIPOTAM", usdg: 5 });
+    assert.deepEqual(await fastParseTrade("buy 2 pipotam"), { kind: "buy", symbol: "PIPOTAM", usdg: 2 });
+    assert.deepEqual(parseSlash("/buy PIPOTAM 1"), { kind: "buy", symbol: "PIPOTAM", usdg: 1 });
+  });
+
   it("returns null for non-trades — the LLM keeps its job", async () => {
     assert.equal(await fastParseTrade("/status"), null);
     assert.equal(await fastParseTrade("what's my pnl?"), null);

--- a/worker/src/telegram/fluid-trading.test.ts
+++ b/worker/src/telegram/fluid-trading.test.ts
@@ -76,8 +76,9 @@ describe("fastParseTrade — trade-shaped text parses with no model", () => {
     assert.equal(await fastParseTrade("buy 1 usdg of any coin"), null, "no symbol → not a trade");
     assert.equal(await fastParseTrade("buy"), null);
     assert.equal(await fastParseTrade(""), null);
-    // /buy 0 defaults to 1 USDG (fluid trading fix)
-    assert.deepEqual(await fastParseTrade("buy 0 nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    // /buy 0 is not a valid amount — returns ask-amount just like /buy without it
+    const zeroParse = await fastParseTrade("buy 0 nvda");
+    assert.ok(zeroParse === null || (zeroParse as any).kind === "ask-amount", "zero amount should not create a trade");
   });
 
   it("never returns a non-trade kind even from a slash", async () => {

--- a/worker/src/telegram/fluid-trading.test.ts
+++ b/worker/src/telegram/fluid-trading.test.ts
@@ -19,6 +19,16 @@ describe("fastParseTrade — trade-shaped text parses with no model", () => {
     assert.deepEqual(fastParseTrade("/sell 2 TSLA"), { kind: "sell", symbol: "TSLA", usdg: 2 });
   });
 
+  it("refuses a symbol that is not a known token when a resolver is passed", () => {
+    const known = (s: string) => ["NVDA", "TSLA", "AAPL", "QQQ"].includes(s);
+    assert.deepEqual(fastParseTrade("/buy 1 nvda", known), { kind: "buy", symbol: "NVDA", usdg: 1 });
+    assert.equal(fastParseTrade("/buy 1 UNKNOWNCOIN", known), null);
+    assert.equal(fastParseTrade("buy 1 usdg of randomx", known), null);
+  });
+
+  it("parses every slash form", () => {
+  });
+
   it("parses bare-verb phrasings with filler words", () => {
     assert.deepEqual(fastParseTrade("buy 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
     assert.deepEqual(fastParseTrade("sell 2 usdg of tsla"), { kind: "sell", symbol: "TSLA", usdg: 2 });
@@ -39,7 +49,7 @@ describe("fastParseTrade — trade-shaped text parses with no model", () => {
     // FIRST, which is the order service.ts now uses.
     assert.deepEqual(fastParseTrade("/sell 1 usdg of tsla"), { kind: "sell", symbol: "TSLA", usdg: 1 });
     assert.deepEqual(fastParseTrade("/buy 1 usdg of nvda"), { kind: "buy", symbol: "NVDA", usdg: 1 });
-    assert.notDeepEqual(parseSlash("/sell 1 usdg of tsla")?.symbol?.toUpperCase(), "TSLA");
+    assert.notDeepEqual(parseSlash("/sell 1 usdg of tsla")?.kind === "sell" ? (parseSlash("/sell 1 usdg of tsla") as { symbol: string }).symbol : "", "TSLA");
   });
 
   it("returns null for non-trades — the LLM keeps its job", () => {
@@ -164,7 +174,7 @@ describe("executeCommand — every trade parks for confirmation", () => {
 
   it("the fluid path end to end: typo'd phrase → park → confirm → fired", async () => {
     const t = fakeDeps();
-    const parsed = fastParseTrade("but 1 usdg of nvda");
+    const parsed = fastParseTrade("but 1 usdg of nvda", (s) => true);
     assert.ok(parsed);
     await executeCommand(parsed, t.deps);
     await executeCommand({ kind: "confirm" }, t.deps);

--- a/worker/src/telegram/interpreter.test.ts
+++ b/worker/src/telegram/interpreter.test.ts
@@ -164,6 +164,10 @@ function deps(over: Partial<CommandDeps> = {}): CommandDeps & { calls: string[] 
       calls.push(`trade:${side}:${sym}:${usdg}`);
       return `submitted ${side} ${usdg} ${sym}`;
     },
+    confirmTrade: async (side, sym, usdg) => {
+      calls.push(`confirmTrade:${side}:${sym}:${usdg}`);
+      return `confirmed ${side} ${usdg} ${sym}`;
+    },
     transfer: async (to, usdg) => {
       calls.push(`transfer:${to}:${usdg}`);
       return `submitted transfer ${usdg} to ${to}`;

--- a/worker/src/telegram/interpreter.test.ts
+++ b/worker/src/telegram/interpreter.test.ts
@@ -281,7 +281,7 @@ describe("executeCommand — code disposes", () => {
     assert.match(r, /trimmed to your 25 USDG/);
     assert.match(r, /\/confirm/);
     const done = await executeCommand({ kind: "confirm" }, d);
-    assert.deepEqual(d.calls, ["pend:buy", "trade:buy:QQQ:25"]); // 100 trimmed to 25
+    assert.deepEqual(d.calls, ["pend:buy", "confirmTrade:buy:QQQ:25"]); // 100 trimmed to 25 — routes through confirmTrade (skips first-tick gate)
     assert.match(done, /QQQ/);
   });
 

--- a/worker/src/telegram/interpreter.test.ts
+++ b/worker/src/telegram/interpreter.test.ts
@@ -264,11 +264,20 @@ describe("executeCommand — code disposes", () => {
     assert.deepEqual(d.calls, ["setCap:30"]); // stored the clamped value, not 999
   });
 
-  it("a trade is trimmed to the chat ceiling and routed through trade()", async () => {
+  it("a trade is trimmed to the chat ceiling, PARKED, and fires on /confirm", async () => {
+    // BEHAVIOR CHANGE (fluid trading): a buy/sell no longer fires on the
+    // message that parsed it. Every trade parks as a pending card — the same
+    // rhythm a transfer already had — and only an explicit /confirm routes it
+    // through trade(), with the ceiling-trimmed amount. The card names the
+    // trim; the execution carries it.
     const d = deps({ maxActionUsdg: 25 });
     const r = await executeCommand({ kind: "buy", symbol: "QQQ", usdg: 100 }, d);
-    assert.deepEqual(d.calls, ["trade:buy:QQQ:25"]); // 100 trimmed to 25
+    assert.deepEqual(d.calls, ["pend:buy"]); // parked, nothing fired
     assert.match(r, /trimmed to your 25 USDG/);
+    assert.match(r, /\/confirm/);
+    const done = await executeCommand({ kind: "confirm" }, d);
+    assert.deepEqual(d.calls, ["pend:buy", "trade:buy:QQQ:25"]); // 100 trimmed to 25
+    assert.match(done, /QQQ/);
   });
 
   it("pause/resume/strategy/link perform their one effect", async () => {

--- a/worker/src/telegram/interpreter.test.ts
+++ b/worker/src/telegram/interpreter.test.ts
@@ -74,7 +74,8 @@ describe("parseSlash — pure slash parser", () => {
   it("returns unknown (with usage) for malformed args, never throws", () => {
     assert.equal(parseSlash("/cap abc")?.kind, "unknown");
     assert.equal(parseSlash("/strategy")?.kind, "unknown");
-    assert.equal(parseSlash("/buy QQQ")?.kind, "unknown");
+    // /buy without amount now defaults to 1 USDG (fluid trading fix)
+    assert.deepEqual(parseSlash("/buy QQQ"), { kind: "buy", symbol: "QQQ", usdg: 1 });
     assert.equal(parseSlash("/wat")?.kind, "unknown");
   });
 

--- a/worker/src/telegram/interpreter.test.ts
+++ b/worker/src/telegram/interpreter.test.ts
@@ -74,8 +74,8 @@ describe("parseSlash — pure slash parser", () => {
   it("returns unknown (with usage) for malformed args, never throws", () => {
     assert.equal(parseSlash("/cap abc")?.kind, "unknown");
     assert.equal(parseSlash("/strategy")?.kind, "unknown");
-    // /buy without amount now defaults to 1 USDG (fluid trading fix)
-    assert.deepEqual(parseSlash("/buy QQQ"), { kind: "buy", symbol: "QQQ", usdg: 1 });
+    // /buy without amount now returns ask-amount (fluid trading)
+    assert.equal(parseSlash("/buy QQQ")?.kind, "ask-amount");
     assert.equal(parseSlash("/wat")?.kind, "unknown");
   });
 

--- a/worker/src/telegram/interpreter.ts
+++ b/worker/src/telegram/interpreter.ts
@@ -216,7 +216,7 @@ export function parseSlash(text: string): Command | null {
     case "levels": {
       // /depth NVDA — one ticker, because a depth map is per-pool and a list of
       // fourteen of them is a report nobody reads in a chat window.
-      const sym = rest.filter(Boolean).find((p) => /^[A-Za-z]{1,6}$/.test(p))?.toUpperCase();
+      const sym = rest.filter(Boolean).find((p) => /^[A-Za-z]{1,10}$/.test(p))?.toUpperCase();
       return sym ? { kind: "depth", symbol: sym } : { kind: "unknown", text: "usage: /depth &lt;SYMBOL&gt;" };
     }
     case "pnl":
@@ -248,7 +248,7 @@ export function parseSlash(text: string): Command | null {
       // Strip $ from symbols, strip usdg/usd suffix from amounts, default to 1.
       const parts = rest.filter(Boolean);
       const clean = parts.map((p) => p.replace(/^\$/, "").replace(/(usdg|usd)$/i, ""));
-      const sym = clean.find((p) => /^[A-Za-z]{1,6}$/.test(p))?.toUpperCase();
+      const sym = clean.find((p) => /^[A-Za-z]{1,10}$/.test(p))?.toUpperCase();
       const usdg = clean.map(Number).find((n) => Number.isFinite(n) && n > 0) ?? 1;
       return sym
         ? { kind: cmd, symbol: sym, usdg }
@@ -278,7 +278,7 @@ export function parseSlash(text: string): Command | null {
     case "alert": {
       // /alert QQQ > 600   ·   /alert QQQ above 600   ·   /alert QQQ < 550
       const parts = rest.filter(Boolean);
-      const sym = parts.find((p) => /^[A-Za-z]{1,6}$/.test(p) && !/^(above|below|over|under)$/i.test(p))?.toUpperCase();
+      const sym = parts.find((p) => /^[A-Za-z]{1,10}$/.test(p) && !/^(above|below|over|under)$/i.test(p))?.toUpperCase();
       const opTok = parts.find((p) => /^[<>]$/.test(p) || /^(above|below|over|under)$/i.test(p));
       const price = parts.map(Number).find((n) => Number.isFinite(n) && n > 0);
       const op: ">" | "<" | null = opTok

--- a/worker/src/telegram/interpreter.ts
+++ b/worker/src/telegram/interpreter.ts
@@ -156,7 +156,16 @@ const TRADE_TYPO: Record<string, string> = {
 /** Filler around the amount/symbol — stripped before the slash parser sees it. */
 const TRADE_FILLER = /^(usdg|usd|of|worth|dollars?|coins?|some|any|me|please|the)$/i;
 
-export function fastParseTrade(text: string): Command | null {
+/**
+ * Resolve a symbol against known tokens. Returns true when the symbol is
+ * recognised (a stock, a custom token, or a Pons launch). Passed as a seam
+ * from the service layer where the data sources live; a pure function with
+ * no lookup defaults to recognised-symbol-only (stocks), which is what the
+ * unit tests exercise.
+ */
+export type SymbolResolver = (symbol: string) => boolean | Promise<boolean>;
+
+export function fastParseTrade(text: string, resolveSymbol?: SymbolResolver): Command | null {
   const t = text.trim();
   if (!t) return null;
   const words = t.split(/\s+/).filter(Boolean);
@@ -165,7 +174,11 @@ export function fastParseTrade(text: string): Command | null {
   if (!verb) return null;
   const parts = words.slice(1).filter((w) => !TRADE_FILLER.test(w));
   const cmd = parseSlash(`/${verb} ${parts.join(" ")}`.trim());
-  return cmd && (cmd.kind === "buy" || cmd.kind === "sell") ? cmd : null;
+  if (!cmd || (cmd.kind !== "buy" && cmd.kind !== "sell")) return null;
+  // If the symbol is not recognised as a known token, refuse to park the
+  // trade — let the message fall through to the AI or a helpful error.
+  if (resolveSymbol && !resolveSymbol(cmd.symbol)) return null;
+  return cmd;
 }
 
 export function parseSlash(text: string): Command | null {

--- a/worker/src/telegram/interpreter.ts
+++ b/worker/src/telegram/interpreter.ts
@@ -157,7 +157,7 @@ const TRADE_TYPO: Record<string, string> = {
   seal: "sell",
 };
 /** Filler around the amount/symbol — stripped before the slash parser sees it. */
-const TRADE_FILLER = /^(usdg|usd|of|worth|dollars?|coins?|some|any|me|please|the)$/i;
+const TRADE_FILLER = /^(usdg|usd|of|worth|dollars?|coins?|some|any|me|please|the|my|that|this|a|an)$/i;
 
 /**
  * Resolve a symbol against known tokens. Returns true when the symbol is
@@ -177,7 +177,7 @@ export async function fastParseTrade(text: string, resolveSymbol?: SymbolResolve
   if (!verb) return null;
   const parts = words.slice(1).filter((w) => !TRADE_FILLER.test(w));
   const cmd = parseSlash(`/${verb} ${parts.join(" ")}`.trim());
-  if (!cmd || (cmd.kind !== "buy" && cmd.kind !== "sell")) return null;
+  if (!cmd || (cmd.kind !== "buy" && cmd.kind !== "sell" && cmd.kind !== "ask-amount")) return null;
   // If the symbol is not recognised as a known token, refuse to park the
   // trade — let the message fall through to the AI or a helpful error.
   // Skip this check when trading by contract address (address is set).

--- a/worker/src/telegram/interpreter.ts
+++ b/worker/src/telegram/interpreter.ts
@@ -165,7 +165,7 @@ const TRADE_FILLER = /^(usdg|usd|of|worth|dollars?|coins?|some|any|me|please|the
  */
 export type SymbolResolver = (symbol: string) => boolean | Promise<boolean>;
 
-export function fastParseTrade(text: string, resolveSymbol?: SymbolResolver): Command | null {
+export async function fastParseTrade(text: string, resolveSymbol?: SymbolResolver): Promise<Command | null> {
   const t = text.trim();
   if (!t) return null;
   const words = t.split(/\s+/).filter(Boolean);
@@ -177,7 +177,7 @@ export function fastParseTrade(text: string, resolveSymbol?: SymbolResolver): Co
   if (!cmd || (cmd.kind !== "buy" && cmd.kind !== "sell")) return null;
   // If the symbol is not recognised as a known token, refuse to park the
   // trade — let the message fall through to the AI or a helpful error.
-  if (resolveSymbol && !resolveSymbol(cmd.symbol)) return null;
+  if (resolveSymbol && !(await resolveSymbol(cmd.symbol))) return null;
   return cmd;
 }
 

--- a/worker/src/telegram/interpreter.ts
+++ b/worker/src/telegram/interpreter.ts
@@ -651,6 +651,27 @@ You're talking with your owner in plain language. Reply AS YOURSELF:
 - Never narrate your own machinery: no talk of memory files, notes, context, saving, or "setting things up". You simply remember; you don't describe how.`;
 
 /**
+/**
+ * Strip reasoning blocks from LLM responses. Some models (nemotron, deepseek)
+ * emit a chain-of-thought block before the actual reply, typically starting
+ * with "Here's a thinking process" or "1. **Analyze**". This strips everything
+ * up to and including the first blank line after the reasoning block.
+ */
+export function stripThinkingBlock(text: string): string {
+  const lines = text.split("\n");
+  // If the first line starts a thinking block, drop everything until the
+  // first line that doesn't look like part of the reasoning.
+  if (/^(Here's a thinking process|1\.\s*\*\*Analyze)/i.test(lines[0]?.trim() ?? "")) {
+    const idx = lines.findIndex((l, i) => i > 0 && /^$/.test(l) && i + 1 < lines.length && !/^\s*(\d+\.\s*)?\*\*/.test(lines[i + 1] ?? ""));
+    if (idx > 0) return lines.slice(idx + 1).join("\n").trim();
+    // Fallback: find the first line that looks like an actual reply
+    const replyStart = lines.findIndex((l) => /^[""“]/.test(l) || /^\w/.test(l) && !/^(\d+\.|Here's|Let me|I need|My task|The user|Looking at)/i.test(l) && l.length > 20);
+    if (replyStart > 0) return lines.slice(replyStart).join("\n").trim();
+  }
+  return text.trim();
+}
+
+/**
  * Turn a conversational message into a warm, in-character reply. Free text OUT
  * only — it becomes cmd.reply and can trigger nothing. Returns "" on any error
  * (the caller then falls back to the classifier's terse reply). Reuses the same

--- a/worker/src/telegram/interpreter.ts
+++ b/worker/src/telegram/interpreter.ts
@@ -85,7 +85,9 @@ export type Command =
    * agent loop (agent.ts), not executeCommand. Gated on agent mode + PC control. */
   | { kind: "agent"; task: string }
   | { kind: "chat"; reply: string }
-  | { kind: "unknown"; text: string };
+  | { kind: "unknown"; text: string }
+  /** Fluid trading: symbol was recognised but amount missing — ask the user for it. */
+  | { kind: "ask-amount"; symbol: string; side: "buy" | "sell" };
 
 /** Commands that change state — gated by telegramControlEnabled (TRADING control).
  * NOTE: "confirm" is deliberately NOT here — it just executes an already-gated
@@ -245,14 +247,15 @@ export function parseSlash(text: string): Command | null {
     case "buy":
     case "sell": {
       // /buy QQQ 10  or  /buy 10 QQQ  or  /buy $NVDA 1usdg  or  /buy pipotam
-      // Strip $ from symbols, strip usdg/usd suffix from amounts, default to 1.
+      // Strip $ from symbols, strip usdg/usd suffix from amounts.
       const parts = rest.filter(Boolean);
       const clean = parts.map((p) => p.replace(/^\$/, "").replace(/(usdg|usd)$/i, ""));
       const sym = clean.find((p) => /^[A-Za-z]{1,10}$/.test(p))?.toUpperCase();
-      const usdg = clean.map(Number).find((n) => Number.isFinite(n) && n > 0) ?? 1;
-      return sym
-        ? { kind: cmd, symbol: sym, usdg }
-        : { kind: "unknown", text: `usage: /${cmd} <SYMBOL> [usdg] — e.g. /buy NVDA 5` };
+      const usdg = clean.map(Number).find((n) => Number.isFinite(n) && n > 0);
+      if (sym && usdg) return { kind: cmd, symbol: sym, usdg };
+      // Symbol with no amount: return ask-amount so the service can prompt.
+      if (sym && !usdg) return { kind: "ask-amount", symbol: sym, side: cmd };
+      return { kind: "unknown", text: `usage: /${cmd} <SYMBOL> [usdg] — e.g. /buy NVDA 5` };
     }
     case "transfer":
     case "send":

--- a/worker/src/telegram/interpreter.ts
+++ b/worker/src/telegram/interpreter.ts
@@ -129,6 +129,45 @@ export const PC_DANGEROUS = new Set(["shell", "getfile", "type", "hotkey", "powe
 export const PC_KINDS = new Set([...Object.keys(PC_CAP_OF), "pc"]);
 
 /** Pure parser for slash commands. Returns null when the text isn't a slash command. */
+/**
+ * THE FLUID PATH — a deterministic front door for trade-shaped messages.
+ *
+ * Slash forms (/buy NVDA 1), bare-verb forms ("buy 1 usdg of nvda"), and the
+ * one-key typos thumbs actually make ("but ...", "byu ...") all parse HERE,
+ * with no model call. Returns ONLY buy/sell commands; every other kind of
+ * message is null and belongs to parseSlash or the LLM exactly as before.
+ *
+ * WHY THIS EXISTS. A parseable trade must never wait on — or fail with — an
+ * AI provider. The observed failure: "/buy 1 nvda" reached the LLM because a
+ * downstream gate refused it, and the down model answered with a paragraph of
+ * leaked reasoning while the trade went nowhere. The fix is upstream of all
+ * of that: if it parses as a trade, it IS a trade.
+ */
+const TRADE_TYPO: Record<string, string> = {
+  but: "buy",
+  byu: "buy",
+  bug: "buy",
+  bu: "buy",
+  guy: "buy",
+  sel: "sell",
+  slel: "sell",
+  seal: "sell",
+};
+/** Filler around the amount/symbol — stripped before the slash parser sees it. */
+const TRADE_FILLER = /^(usdg|usd|of|worth|dollars?|coins?|some|any|me|please|the)$/i;
+
+export function fastParseTrade(text: string): Command | null {
+  const t = text.trim();
+  if (!t) return null;
+  const words = t.split(/\s+/).filter(Boolean);
+  const head = (words[0] ?? "").toLowerCase().replace(/^[/.]+/, "");
+  const verb = TRADE_TYPO[head] ?? (/^(buy|sell)$/i.test(head) ? head.toLowerCase() : null);
+  if (!verb) return null;
+  const parts = words.slice(1).filter((w) => !TRADE_FILLER.test(w));
+  const cmd = parseSlash(`/${verb} ${parts.join(" ")}`.trim());
+  return cmd && (cmd.kind === "buy" || cmd.kind === "sell") ? cmd : null;
+}
+
 export function parseSlash(text: string): Command | null {
   const t = text.trim();
   if (!t.startsWith("/")) return null;

--- a/worker/src/telegram/interpreter.ts
+++ b/worker/src/telegram/interpreter.ts
@@ -244,13 +244,15 @@ export function parseSlash(text: string): Command | null {
     }
     case "buy":
     case "sell": {
-      // /buy QQQ 10  or  /buy 10 QQQ
+      // /buy QQQ 10  or  /buy 10 QQQ  or  /buy $NVDA 1usdg  or  /buy pipotam
+      // Strip $ from symbols, strip usdg/usd suffix from amounts, default to 1.
       const parts = rest.filter(Boolean);
-      const sym = parts.find((p) => /^[A-Za-z]{1,6}$/.test(p))?.toUpperCase();
-      const usdg = parts.map(Number).find((n) => Number.isFinite(n) && n > 0);
-      return sym && usdg
+      const clean = parts.map((p) => p.replace(/^\$/, "").replace(/(usdg|usd)$/i, ""));
+      const sym = clean.find((p) => /^[A-Za-z]{1,6}$/.test(p))?.toUpperCase();
+      const usdg = clean.map(Number).find((n) => Number.isFinite(n) && n > 0) ?? 1;
+      return sym
         ? { kind: cmd, symbol: sym, usdg }
-        : { kind: "unknown", text: `usage: /${cmd} <SYMBOL> <usdg>` };
+        : { kind: "unknown", text: `usage: /${cmd} <SYMBOL> [usdg] — e.g. /buy NVDA 5` };
     }
     case "transfer":
     case "send":

--- a/worker/src/telegram/interpreter.ts
+++ b/worker/src/telegram/interpreter.ts
@@ -43,8 +43,9 @@ export type Command =
   | { kind: "resume" }
   | { kind: "strategy"; name: string }
   | { kind: "cap"; usdg: number }
-  | { kind: "buy"; symbol: string; usdg: number }
-  | { kind: "sell"; symbol: string; usdg: number }
+  | { kind: "buy"; symbol: string; usdg: number; address?: `0x${string}` }
+  | { kind: "sell"; symbol: string; usdg: number; address?: `0x${string}` }
+  | { kind: "ask-amount"; symbol: string; side: "buy" | "sell"; address?: `0x${string}` }
   | { kind: "transfer"; to: `0x${string}`; usdg: number }
   | { kind: "confirm" }
   | { kind: "cancel" }
@@ -87,7 +88,7 @@ export type Command =
   | { kind: "chat"; reply: string }
   | { kind: "unknown"; text: string }
   /** Fluid trading: symbol was recognised but amount missing — ask the user for it. */
-  | { kind: "ask-amount"; symbol: string; side: "buy" | "sell" };
+  | { kind: "ask-amount"; symbol: string; side: "buy" | "sell"; address?: `0x${string}` };
 
 /** Commands that change state — gated by telegramControlEnabled (TRADING control).
  * NOTE: "confirm" is deliberately NOT here — it just executes an already-gated
@@ -179,7 +180,8 @@ export async function fastParseTrade(text: string, resolveSymbol?: SymbolResolve
   if (!cmd || (cmd.kind !== "buy" && cmd.kind !== "sell")) return null;
   // If the symbol is not recognised as a known token, refuse to park the
   // trade — let the message fall through to the AI or a helpful error.
-  if (resolveSymbol && !(await resolveSymbol(cmd.symbol))) return null;
+  // Skip this check when trading by contract address (address is set).
+  if (resolveSymbol && !cmd.address && !(await resolveSymbol(cmd.symbol))) return null;
   return cmd;
 }
 
@@ -247,15 +249,23 @@ export function parseSlash(text: string): Command | null {
     case "buy":
     case "sell": {
       // /buy QQQ 10  or  /buy 10 QQQ  or  /buy $NVDA 1usdg  or  /buy pipotam
+      // Also /buy 0x… 5 — trade by contract address.
       // Strip $ from symbols, strip usdg/usd suffix from amounts.
       const parts = rest.filter(Boolean);
       const clean = parts.map((p) => p.replace(/^\$/, "").replace(/(usdg|usd)$/i, ""));
       const sym = clean.find((p) => /^[A-Za-z]{1,10}$/.test(p))?.toUpperCase();
-      const usdg = clean.map(Number).find((n) => Number.isFinite(n) && n > 0);
+      const addr = clean.find((p): p is `0x${string}` => ADDRESS_RE.test(p));
+      // Amount is a number, but NOT a hex address (Number("0x…") parses as hex).
+      const usdg = clean
+        .filter((p) => !ADDRESS_RE.test(p))
+        .map(Number)
+        .find((n) => Number.isFinite(n) && n > 0);
+      if (addr && usdg) return { kind: cmd, symbol: addr.slice(0, 10), usdg, address: addr };
+      if (addr && !usdg) return { kind: "ask-amount", symbol: addr.slice(0, 10), side: cmd, address: addr };
       if (sym && usdg) return { kind: cmd, symbol: sym, usdg };
       // Symbol with no amount: return ask-amount so the service can prompt.
       if (sym && !usdg) return { kind: "ask-amount", symbol: sym, side: cmd };
-      return { kind: "unknown", text: `usage: /${cmd} <SYMBOL> [usdg] — e.g. /buy NVDA 5` };
+      return { kind: "unknown", text: `usage: /${cmd} <SYMBOL> [usdg] — e.g. /buy NVDA 5, or /buy 0x… 5` };
     }
     case "transfer":
     case "send":

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -86,6 +86,7 @@ export interface TelegramServiceDeps {
   readDepth: (symbol: string) => Promise<string>;
   /** Build a bounded TradeIntent and route it through processIntent. */
   submitTrade: (side: "buy" | "sell", symbol: string, usdg: number) => Promise<string>;
+  submitConfirmTrade: (side: "buy" | "sell", symbol: string, usdg: number) => Promise<string>;
   /** Build a bounded transfer intent and route it through processIntent. */
   submitTransfer: (to: `0x${string}`, usdg: number) => Promise<string>;
   /** Delete the grant (kill switch). */
@@ -394,6 +395,7 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
       },
       link: linkDep,
       trade: deps.submitTrade,
+      confirmTrade: deps.submitConfirmTrade,
       transfer: async (to, usdg) => {
         deps.note("warn", `Telegram: transfer ${usdg} USDG → ${to} confirmed by chat ${msg.chatId}`);
         return deps.submitTransfer(to, usdg);

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -723,7 +723,8 @@ Reply with ONLY the matching symbol (uppercase) if any, or "UNKNOWN" if none mat
     // Handle bare number replies to "how much to buy?" prompts
     if (!cmd && askAmountCtx.has(msg.chatId)) {
       const ctx = askAmountCtx.get(msg.chatId)!;
-      const num = Number(msg.text?.trim());
+      const cleaned = (msg.text ?? "").trim().replace(/^usdg|usd$/i, "").replace(/(usdg|usd)$/i, "");
+      const num = Number(cleaned);
       if (Number.isFinite(num) && num > 0) {
         cmd = { kind: ctx.side, symbol: ctx.symbol, usdg: Math.round(num) };
         await pushHistory(msg.chatId, "user", msg.text);

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -593,7 +593,7 @@ Reply with ONLY the matching symbol (uppercase) if any, or "UNKNOWN" if none mat
           try {
             const resolved = await llmText(llm, { system: "You are a symbol resolver. Respond with ONLY the ticker symbol or UNKNOWN.", prompt: resolveTask, maxTokens: 10 });
             const match = resolved?.trim().toUpperCase();
-            if (match && match !== "UNKNOWN" && match.length <= 6 && /^[A-Z]{1,6}$/.test(match)) {
+            if (match && match !== "UNKNOWN" && match.length <= 10 && /^[A-Z]{1,10}$/.test(match)) {
               cmd = { kind: partial.kind, symbol: match, usdg: partial.usdg };
               await pushHistory(msg.chatId, "user", msg.text);
             }

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -26,7 +26,7 @@ import { PC_CAPABILITIES, STOCK_TOKENS } from "../../../packages/core/src/index"
 import { patchSettingsFile, type ResolvedConfig } from "../settings";
 import { ensureHome, homePaths } from "../home";
 import { loadGrantFile } from "../grant";
-import { esc, getFileUrl, getMe, getUpdates, sendMessage, type TgMessage } from "./api";
+import { esc, getFileUrl, getMe, getUpdates, sendMessage, sendMessageWithKeyboard, type TgMessage } from "./api";
 import { runAgentTask } from "./agent";
 import { executeCommand, type CommandDeps, type PendingAction } from "./executor";
 import { resolveLlm } from "../llm";
@@ -120,6 +120,9 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
   let stopped = false;
   const stateRef = deps.stateRef;
   let warnedUnreachable = false;
+  // Ask-amount context: when the bot asks "how much to buy?", it remembers
+  // { side, symbol } per chat so a follow-up like "5" creates the full trade.
+  const askAmountCtx = new Map<number, { side: "buy" | "sell"; symbol: string }>();
   const now = deps.now ?? (() => Math.floor(Date.now() / 1000));
   ensureSoul(now()); // the merryman is born (IDENTITY/OWNER/JOURNAL.md) on first run
 
@@ -717,19 +720,46 @@ Reply with ONLY the matching symbol (uppercase) if any, or "UNKNOWN" if none mat
 
     // A failed command must still answer — silence reads as a dead bot.
     let reply: string;
-    if (cmd.kind === "ask-amount") {
-      reply = `how much ${cmd.side === "buy" ? "to buy" : "to sell"}? e.g. <code>/${cmd.side === "buy" ? "buy" : "sell"} ${cmd.symbol} 5</code>`;
-    } else {
-      try {
-        reply = await executeCommand(cmd, cmdDeps);
-      } catch (e) {
-        const m = e instanceof Error ? e.message : String(e);
-        deps.note("warn", `Telegram: ${cmd.kind} failed — ${m}`);
-        reply = `🚫 that ${cmd.kind} failed: ${esc(m.slice(0, 200))}`;
+    // Handle bare number replies to "how much to buy?" prompts
+    if (!cmd && askAmountCtx.has(msg.chatId)) {
+      const ctx = askAmountCtx.get(msg.chatId)!;
+      const num = Number(msg.text?.trim());
+      if (Number.isFinite(num) && num > 0) {
+        cmd = { kind: ctx.side, symbol: ctx.symbol, usdg: Math.round(num) };
+        await pushHistory(msg.chatId, "user", msg.text);
       }
+      askAmountCtx.delete(msg.chatId);
     }
+    if (!cmd) {
+      reply = "not sure what you want to do — try /buy, /sell, /status, or /help";
+      await sendMessage({ token }, msg.chatId, reply);
+      return;
+    }
+    if (cmd.kind === "ask-amount") {
+      askAmountCtx.set(msg.chatId, { side: cmd.side, symbol: cmd.symbol });
+      reply = `how much ${cmd.side === "buy" ? "to buy" : "to sell"}? e.g. <code>/${cmd.side === "buy" ? "buy" : "sell"} ${cmd.symbol} 5</code>`;
+      await sendMessage({ token }, msg.chatId, reply);
+      return;
+    }
+    try {
+      reply = await executeCommand(cmd, cmdDeps);
+    } catch (e) {
+      const m = e instanceof Error ? e.message : String(e);
+      deps.note("warn", `Telegram: ${cmd.kind} failed — ${m}`);
+      reply = `🚫 that ${cmd.kind} failed: ${esc(m.slice(0, 200))}`;
+    }
+    // Clear any leftover ask-amount context — a non-numeric message ends it.
+    if (cmd.kind !== "confirm" && cmd.kind !== "cancel") askAmountCtx.delete(msg.chatId);
+    // Use keyboard buttons when the reply contains "pending" (trade/transfer/kill cards).
+    const useKeyboard = reply.includes("pending") || reply.includes("confirm");
     if (!slash) await pushHistory(msg.chatId, "assistant", reply.replace(/<[^>]+>/g, ""), turnMemoryIds);
-    await sendMessage({ token }, msg.chatId, reply);
+    if (useKeyboard) {
+      await sendMessageWithKeyboard({ token }, msg.chatId, reply, [
+        [{ text: "✅ Confirm", callback: "/confirm" }, { text: "❌ Cancel", callback: "/cancel" }],
+      ]);
+    } else {
+      await sendMessage({ token }, msg.chatId, reply);
+    }
   };
 
   const pollOnce = async (): Promise<void> => {

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -123,7 +123,7 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
   let warnedUnreachable = false;
   // Ask-amount context: when the bot asks "how much to buy?", it remembers
   // { side, symbol } per chat so a follow-up like "5" creates the full trade.
-  const askAmountCtx = new Map<number, { side: "buy" | "sell"; symbol: string }>();
+  const askAmountCtx = new Map<number, { side: "buy" | "sell"; symbol: string; address?: `0x${string}` }>();
   const now = deps.now ?? (() => Math.floor(Date.now() / 1000));
   ensureSoul(now()); // the merryman is born (IDENTITY/OWNER/JOURNAL.md) on first run
 
@@ -728,7 +728,9 @@ Reply with ONLY the matching symbol (uppercase) if any, or "UNKNOWN" if none mat
       const cleaned = (msg.text ?? "").trim().replace(/^usdg|usd$/i, "").replace(/(usdg|usd)$/i, "");
       const num = Number(cleaned);
       if (Number.isFinite(num) && num > 0) {
-        cmd = { kind: ctx.side, symbol: ctx.symbol, usdg: Math.round(num) };
+        const base = { kind: ctx.side, symbol: ctx.symbol, usdg: Math.round(num) } as Command;
+        if (ctx.address) (base as any).address = ctx.address;
+        cmd = base;
         await pushHistory(msg.chatId, "user", msg.text);
       }
       askAmountCtx.delete(msg.chatId);
@@ -739,7 +741,7 @@ Reply with ONLY the matching symbol (uppercase) if any, or "UNKNOWN" if none mat
       return;
     }
     if (cmd.kind === "ask-amount") {
-      askAmountCtx.set(msg.chatId, { side: cmd.side, symbol: cmd.symbol });
+      askAmountCtx.set(msg.chatId, { side: cmd.side, symbol: cmd.symbol, address: cmd.address });
       reply = `how much ${cmd.side === "buy" ? "to buy" : "to sell"}? e.g. <code>/${cmd.side === "buy" ? "buy" : "sell"} ${cmd.symbol} 5</code>`;
       await sendMessage({ token }, msg.chatId, reply);
       return;

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -26,7 +26,7 @@ import { PC_CAPABILITIES, STOCK_TOKENS } from "../../../packages/core/src/index"
 import { patchSettingsFile, type ResolvedConfig } from "../settings";
 import { ensureHome, homePaths } from "../home";
 import { loadGrantFile } from "../grant";
-import { esc, getFileUrl, getMe, getUpdates, sendMessage, sendMessageWithKeyboard, type TgMessage } from "./api";
+import { answerCallbackQuery, esc, getFileUrl, getMe, getUpdates, sendMessage, sendMessageWithKeyboard, type TgMessage } from "./api";
 import { runAgentTask } from "./agent";
 import { executeCommand, type CommandDeps, type PendingAction } from "./executor";
 import { resolveLlm } from "../llm";
@@ -760,6 +760,10 @@ Reply with ONLY the matching symbol (uppercase) if any, or "UNKNOWN" if none mat
       ]);
     } else {
       await sendMessage({ token }, msg.chatId, reply);
+    }
+    // Answer callback queries (inline button taps) to dismiss the Telegram loading spinner.
+    if (msg.callbackQueryId) {
+      void answerCallbackQuery({ token }, msg.callbackQueryId);
     }
   };
 

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -22,7 +22,7 @@ import { existsSync, rmSync, writeFileSync } from "node:fs";
 // RELATIVE import only — the "@merrymen/core" alias exists solely in dev
 // tsconfigs; inside the installed package tsx can't resolve it and the worker
 // dies at startup (which silently kills Telegram). Never alias-import in worker/.
-import { PC_CAPABILITIES } from "../../../packages/core/src/index";
+import { PC_CAPABILITIES, STOCK_TOKENS } from "../../../packages/core/src/index";
 import { patchSettingsFile, type ResolvedConfig } from "../settings";
 import { ensureHome, homePaths } from "../home";
 import { loadGrantFile } from "../grant";
@@ -546,7 +546,16 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
     // the fluid parser strips filler words and typos. Trade-shaped text is
     // parsed deterministically; everything else falls to parseSlash, and the
     // LLM is last — a down provider can never strand an order.
-    const fluid = fastParseTrade(msg.text ?? "");
+    // Build a set of known symbols from the stock registry plus the owner's
+    // custom tokens. When the symbol is not recognised, the fluid path
+    // refuses to park the trade — the message falls through to the LLM or
+    // a helpful error instead of guessing against a coin that doesn't exist.
+    // (Pons launch symbols will be resolved from the store in Phase 2.)
+    const knownSymbols = new Set([
+      ...STOCK_TOKENS.map((t) => t.symbol.toUpperCase()),
+      ...(cfg.customTokens ?? []).map((t) => t.symbol.toUpperCase()),
+    ]);
+    const fluid = fastParseTrade(msg.text ?? "", (s) => knownSymbols.has(s.toUpperCase()));
     let cmd = fluid ?? slash;
     // What the narrator recalled this turn — stored on the assistant's reply so
     // the thread survives a restart, not just a process lifetime.

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -30,7 +30,7 @@ import { answerCallbackQuery, esc, getFileUrl, getMe, getUpdates, sendMessage, s
 import { runAgentTask } from "./agent";
 import { executeCommand, type CommandDeps, type PendingAction } from "./executor";
 import { resolveLlm } from "../llm";
-import { CONTROL_KINDS, PC_KINDS, fastParseTrade, interpretWithLlm, narrateChat, narrateWhy, parseSlash, type Command } from "./interpreter";
+import { CONTROL_KINDS, PC_KINDS, fastParseTrade, interpretWithLlm, narrateChat, narrateWhy, parseSlash, stripThinkingBlock, type Command } from "./interpreter";
 import { llmText } from "../llm";
 import { makePcActions, resolveInRoot } from "./pc";
 import { transcribeVoice } from "./voice";
@@ -649,6 +649,10 @@ Reply with ONLY the matching symbol (uppercase) if any, or "UNKNOWN" if none mat
           };
         }
         cmd = r.cmd;
+        // Strip any reasoning blocks from the LLM's reply
+        if (cmd.kind === "chat" && typeof cmd.reply === "string") {
+          cmd = { kind: "chat", reply: stripThinkingBlock(cmd.reply) };
+        }
         // The get-to-know-you side-channel: the model proposes a fact, the
         // sanitizer disposes (drops addresses/keys/markup, dedupes, caps). Only the
         // OWNER may write it — else a group member could poison/evict owner memory.
@@ -678,7 +682,7 @@ Reply with ONLY the matching symbol (uppercase) if any, or "UNKNOWN" if none mat
             history: await historyFor(msg.chatId),
           };
           const fluent = await narrateChat(msg.text, chatCtx, llm);
-          if (fluent) cmd = { kind: "chat", reply: fluent };
+          if (fluent) cmd = { kind: "chat", reply: stripThinkingBlock(fluent) };
           // Carry what was surfaced into the next turn so a pronoun follow-up
           // ("is it done?") keeps the thread instead of losing it to zero word
           // overlap. Persisted on the turn below, so it survives a restart too.

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -30,7 +30,7 @@ import { esc, getFileUrl, getMe, getUpdates, sendMessage, type TgMessage } from 
 import { runAgentTask } from "./agent";
 import { executeCommand, type CommandDeps, type PendingAction } from "./executor";
 import { resolveLlm } from "../llm";
-import { CONTROL_KINDS, PC_KINDS, fastParseTrade, interpretWithLlm, narrateChat, narrateWhy, parseSlash } from "./interpreter";
+import { CONTROL_KINDS, PC_KINDS, fastParseTrade, interpretWithLlm, narrateChat, narrateWhy, parseSlash, type Command } from "./interpreter";
 import { llmText } from "../llm";
 import { makePcActions, resolveInRoot } from "./pc";
 import { transcribeVoice } from "./voice";
@@ -579,28 +579,41 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
       // (buy/sell with amount) but the symbol wasn't recognised, ask the LLM
       // to resolve it before falling through to general chat. The LLM only
       // picks a symbol from a known list — never decides amounts or executes.
+      // Track whether there was a trade-shaped intent that failed resolution.
+      let hadTradePattern = false;
+      let partialTrade: Command | null = null;
       const llm = resolveLlm(cfg);
       if (llm && !slash) {
-        const partial = await fastParseTrade(msg.text ?? "");
-        if (partial && (partial.kind === "buy" || partial.kind === "sell")) {
+        partialTrade = await fastParseTrade(msg.text ?? "");
+        if (partialTrade && (partialTrade.kind === "buy" || partialTrade.kind === "sell")) {
+          hadTradePattern = true;
           const knownRoster = [...STOCK_TOKENS.map((t) => t.symbol), ...(cfg.customTokens ?? []).map((t) => t.symbol)]
             .map((s) => s.toUpperCase()).sort().join(", ");
           const ponsRoster = ponsSymbols ? [...ponsSymbols].sort().join(", ") : null;
-          const tradeText = `${partial.kind} ${partial.usdg} USDG of ${partial.symbol}`;
-          const resolveTask = `The user wants to ${tradeText}. I don't know "${partial.symbol}".
+          const tradeText = `${partialTrade.kind} ${partialTrade.usdg} USDG of ${partialTrade.symbol}`;
+          const resolveTask = `The user wants to ${tradeText}. I don't know "${partialTrade.symbol}".
 Known tokens: ${knownRoster}${ponsRoster ? `\nRecently discovered tokens: ${ponsRoster}` : ""}
 Reply with ONLY the matching symbol (uppercase) if any, or "UNKNOWN" if none match.`;
           try {
             const resolved = await llmText(llm, { system: "You are a symbol resolver. Respond with ONLY the ticker symbol or UNKNOWN.", prompt: resolveTask, maxTokens: 10 });
             const match = resolved?.trim().toUpperCase();
             if (match && match !== "UNKNOWN" && match.length <= 10 && /^[A-Z]{1,10}$/.test(match)) {
-              cmd = { kind: partial.kind, symbol: match, usdg: partial.usdg };
+              cmd = { kind: partialTrade.kind, symbol: match, usdg: partialTrade.usdg };
+              hadTradePattern = false;
               await pushHistory(msg.chatId, "user", msg.text);
             }
           } catch {
-            // LLM resolution failed — fall through to normal chat path
+            // LLM resolution failed — stay in the unknown-trade path
           }
         }
+      }
+      if (!cmd && hadTradePattern) {
+        // A trade pattern was identified but neither the fast path nor the LLM
+        // could resolve the symbol. Reply cleanly — never fall through to a
+        // general chat that might leak internal reasoning.
+        const sym = partialTrade && "symbol" in partialTrade ? partialTrade.symbol : msg.text.trim().split(/\s+/).slice(1)[0];
+        cmd = { kind: "chat", reply: `I don't know "${sym}". Check /discoveries for new tokens, or paste the contract address.` };
+        await pushHistory(msg.chatId, "user", msg.text);
       }
       if (!cmd) {
         const llm = resolveLlm(cfg);
@@ -704,12 +717,16 @@ Reply with ONLY the matching symbol (uppercase) if any, or "UNKNOWN" if none mat
 
     // A failed command must still answer — silence reads as a dead bot.
     let reply: string;
-    try {
-      reply = await executeCommand(cmd, cmdDeps);
-    } catch (e) {
-      const m = e instanceof Error ? e.message : String(e);
-      deps.note("warn", `Telegram: ${cmd.kind} failed — ${m}`);
-      reply = `🚫 that ${cmd.kind} failed: ${esc(m.slice(0, 200))}`;
+    if (cmd.kind === "ask-amount") {
+      reply = `how much ${cmd.side === "buy" ? "to buy" : "to sell"}? e.g. <code>/${cmd.side === "buy" ? "buy" : "sell"} ${cmd.symbol} 5</code>`;
+    } else {
+      try {
+        reply = await executeCommand(cmd, cmdDeps);
+      } catch (e) {
+        const m = e instanceof Error ? e.message : String(e);
+        deps.note("warn", `Telegram: ${cmd.kind} failed — ${m}`);
+        reply = `🚫 that ${cmd.kind} failed: ${esc(m.slice(0, 200))}`;
+      }
     }
     if (!slash) await pushHistory(msg.chatId, "assistant", reply.replace(/<[^>]+>/g, ""), turnMemoryIds);
     await sendMessage({ token }, msg.chatId, reply);

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -30,7 +30,7 @@ import { esc, getFileUrl, getMe, getUpdates, sendMessage, type TgMessage } from 
 import { runAgentTask } from "./agent";
 import { executeCommand, type CommandDeps, type PendingAction } from "./executor";
 import { resolveLlm } from "../llm";
-import { CONTROL_KINDS, PC_KINDS, interpretWithLlm, narrateChat, narrateWhy, parseSlash } from "./interpreter";
+import { CONTROL_KINDS, PC_KINDS, fastParseTrade, interpretWithLlm, narrateChat, narrateWhy, parseSlash } from "./interpreter";
 import { makePcActions, resolveInRoot } from "./pc";
 import { transcribeVoice } from "./voice";
 import { fmtReminders, fmtWatchers, parseWatchSpec, parseWhenSec } from "./watchers";
@@ -540,7 +540,14 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
     }
 
     // Slash command wins; else natural language (LLM) if a key is set; else nudge.
-    let cmd = slash;
+    // ORDER MATTERS: the fluid trade parse WINS over the raw slash parse.
+    // parseSlash reads the "usdg" in "/sell 1 usdg of tsla" as the SYMBOL
+    // (it matches the ticker shape — a nonsense USDG-for-USDG swap), while
+    // the fluid parser strips filler words and typos. Trade-shaped text is
+    // parsed deterministically; everything else falls to parseSlash, and the
+    // LLM is last — a down provider can never strand an order.
+    const fluid = fastParseTrade(msg.text ?? "");
+    let cmd = fluid ?? slash;
     // What the narrator recalled this turn — stored on the assistant's reply so
     // the thread survives a restart, not just a process lifetime.
     let turnMemoryIds: string[] | undefined;
@@ -554,7 +561,24 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
         const identity = identityBlock(st.linkedAt, st.messageCount, now());
         const liveState = readLlmState(statusCtx());
         const routeCtx = { state: `SOUL:\n${identity}\n\n${liveState}`, history: await historyFor(msg.chatId) };
-        const r = await interpretWithLlm(msg.text, routeCtx, llm);
+        // A DOWN PROVIDER MUST NOT LOOK LIKE A PERSONALITY. The observed
+        // failure: the free model answered with a paragraph of leaked
+        // reasoning and the user's trade went nowhere. On any throw, reply
+        // with the deterministic signpost — trades never wait on this path.
+        let llmDown = false;
+        let r: Awaited<ReturnType<typeof interpretWithLlm>>;
+        try {
+          r = await interpretWithLlm(msg.text, routeCtx, llm);
+        } catch {
+          llmDown = true;
+          r = {
+            remember: "",
+            cmd: {
+              kind: "chat",
+              reply: "⚠️ my brain didn't answer (the AI provider failed). Trades never wait on it: /buy SYMBOL AMOUNT · /sell SYMBOL AMOUNT · /status · /help",
+            },
+          };
+        }
         cmd = r.cmd;
         // The get-to-know-you side-channel: the model proposes a fact, the
         // sanitizer disposes (drops addresses/keys/markup, dedupes, caps). Only the
@@ -567,7 +591,7 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
         // actually just said, so a fact from months back is reachable when it's
         // the one being asked about. Written AFTER the remember side-channel, so
         // something learned this turn can be recalled in the very same reply.
-        if (cmd.kind === "chat") {
+        if (cmd.kind === "chat" && !llmDown) {
           const recalled = recallForPrompt(msg.text, now(), stickyIds.get(msg.chatId));
           // Read BEFORE this turn is written, so it's the gap since they last
           // spoke rather than zero.

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -122,8 +122,12 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
   const stateRef = deps.stateRef;
   let warnedUnreachable = false;
   // Ask-amount context: when the bot asks "how much to buy?", it remembers
-  // { side, symbol } per chat so a follow-up like "5" creates the full trade.
-  const askAmountCtx = new Map<number, { side: "buy" | "sell"; symbol: string; address?: `0x${string}` }>();
+  // { side, symbol } per user so a follow-up like "5" creates the full trade.
+  // Keyed by chat:from (like pending) so one member can't hijack another's in a group.
+  // TTL 120s so a stale "5" an hour later doesn't fire a trade.
+  const askAmountCtx = new Map<string, { side: "buy" | "sell"; symbol: string; address?: `0x${string}`; expiresAt: number }>();
+  const askKey = (chatId: number, fromId: number) => `${chatId}:${fromId}`;
+  const ASK_TTL_SEC = 120;
   const now = deps.now ?? (() => Math.floor(Date.now() / 1000));
   ensureSoul(now()); // the merryman is born (IDENTITY/OWNER/JOURNAL.md) on first run
 
@@ -726,18 +730,25 @@ Reply with ONLY the matching symbol (uppercase) if any, or "UNKNOWN" if none mat
 
     // A failed command must still answer — silence reads as a dead bot.
     let reply: string;
-    // Handle bare number replies to "how much to buy?" prompts
-    if (!cmd && askAmountCtx.has(msg.chatId)) {
-      const ctx = askAmountCtx.get(msg.chatId)!;
-      const cleaned = (msg.text ?? "").trim().replace(/^usdg|usd$/i, "").replace(/(usdg|usd)$/i, "");
-      const num = Number(cleaned);
-      if (Number.isFinite(num) && num > 0) {
-        const base = { kind: ctx.side, symbol: ctx.symbol, usdg: Math.round(num) } as Command;
-        if (ctx.address) (base as any).address = ctx.address;
-        cmd = base;
-        await pushHistory(msg.chatId, "user", msg.text);
+    let needsKeyboard = false;
+    // Handle bare number replies to "how much to buy?" prompts — scoped per user with TTL
+    const askCtx = askAmountCtx.get(askKey(msg.chatId, msg.fromId));
+    if (!cmd && askCtx) {
+      if (now() > askCtx.expiresAt) {
+        askAmountCtx.delete(askKey(msg.chatId, msg.fromId));
+      } else {
+        const cleaned = (msg.text ?? "").trim().replace(/^usdg|usd$/i, "").replace(/(usdg|usd)$/i, "");
+        const num = Number(cleaned);
+        if (Number.isFinite(num) && num > 0 && !Number.isNaN(Number(cleaned))) {
+          // Guard: Number("0x12") parses hex — but bareMatch here is already numeric-only path,
+          // and address follow-ups carry ctx.address separately, never via amount.
+          const base = { kind: askCtx.side, symbol: askCtx.symbol, usdg: Math.round(num) } as Command;
+          if (askCtx.address) (base as any).address = askCtx.address;
+          cmd = base;
+          await pushHistory(msg.chatId, "user", msg.text);
+        }
+        askAmountCtx.delete(askKey(msg.chatId, msg.fromId));
       }
-      askAmountCtx.delete(msg.chatId);
     }
     if (!cmd) {
       reply = "not sure what you want to do — try /buy, /sell, /status, or /help";
@@ -745,22 +756,25 @@ Reply with ONLY the matching symbol (uppercase) if any, or "UNKNOWN" if none mat
       return;
     }
     if (cmd.kind === "ask-amount") {
-      askAmountCtx.set(msg.chatId, { side: cmd.side, symbol: cmd.symbol, address: cmd.address });
+      askAmountCtx.set(askKey(msg.chatId, msg.fromId), { side: cmd.side, symbol: cmd.symbol, address: cmd.address, expiresAt: now() + ASK_TTL_SEC });
       reply = `how much ${cmd.side === "buy" ? "to buy" : "to sell"}? e.g. <code>/${cmd.side === "buy" ? "buy" : "sell"} ${cmd.symbol} 5</code>`;
       await sendMessage({ token }, msg.chatId, reply);
       return;
     }
     try {
       reply = await executeCommand(cmd, cmdDeps);
+      // needsKeyboard is explicit from parked pending — not substring on reply text,
+      // so an LLM chat reply containing "pending/confirm" never gets buttons.
+      needsKeyboard = pending.get(`${msg.chatId}:${msg.fromId}`) != null;
     } catch (e) {
       const m = e instanceof Error ? e.message : String(e);
       deps.note("warn", `Telegram: ${cmd.kind} failed — ${m}`);
       reply = `🚫 that ${cmd.kind} failed: ${esc(m.slice(0, 200))}`;
     }
     // Clear any leftover ask-amount context — a non-numeric message ends it.
-    if (cmd.kind !== "confirm" && cmd.kind !== "cancel") askAmountCtx.delete(msg.chatId);
-    // Use keyboard buttons when the reply contains "pending" (trade/transfer/kill cards).
-    const useKeyboard = reply.includes("pending") || reply.includes("confirm");
+    if (cmd.kind !== "confirm" && cmd.kind !== "cancel") askAmountCtx.delete(askKey(msg.chatId, msg.fromId));
+    // Use keyboard buttons when a pending card was just parked for this user.
+    const useKeyboard = needsKeyboard;
     if (!slash) await pushHistory(msg.chatId, "assistant", reply.replace(/<[^>]+>/g, ""), turnMemoryIds);
     if (useKeyboard) {
       await sendMessageWithKeyboard({ token }, msg.chatId, reply, [

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -31,6 +31,7 @@ import { runAgentTask } from "./agent";
 import { executeCommand, type CommandDeps, type PendingAction } from "./executor";
 import { resolveLlm } from "../llm";
 import { CONTROL_KINDS, PC_KINDS, fastParseTrade, interpretWithLlm, narrateChat, narrateWhy, parseSlash } from "./interpreter";
+import { llmText } from "../llm";
 import { makePcActions, resolveInRoot } from "./pc";
 import { transcribeVoice } from "./voice";
 import { fmtReminders, fmtWatchers, parseWatchSpec, parseWhenSec } from "./watchers";
@@ -574,7 +575,35 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
     // the thread survives a restart, not just a process lifetime.
     let turnMemoryIds: string[] | undefined;
     if (!cmd) {
+      // LLM SYMBOL RESOLUTION: when the fast path caught a trade pattern
+      // (buy/sell with amount) but the symbol wasn't recognised, ask the LLM
+      // to resolve it before falling through to general chat. The LLM only
+      // picks a symbol from a known list — never decides amounts or executes.
       const llm = resolveLlm(cfg);
+      if (llm && !slash) {
+        const partial = await fastParseTrade(msg.text ?? "");
+        if (partial && (partial.kind === "buy" || partial.kind === "sell")) {
+          const knownRoster = [...STOCK_TOKENS.map((t) => t.symbol), ...(cfg.customTokens ?? []).map((t) => t.symbol)]
+            .map((s) => s.toUpperCase()).sort().join(", ");
+          const ponsRoster = ponsSymbols ? [...ponsSymbols].sort().join(", ") : null;
+          const tradeText = `${partial.kind} ${partial.usdg} USDG of ${partial.symbol}`;
+          const resolveTask = `The user wants to ${tradeText}. I don't know "${partial.symbol}".
+Known tokens: ${knownRoster}${ponsRoster ? `\nRecently discovered tokens: ${ponsRoster}` : ""}
+Reply with ONLY the matching symbol (uppercase) if any, or "UNKNOWN" if none match.`;
+          try {
+            const resolved = await llmText(llm, { system: "You are a symbol resolver. Respond with ONLY the ticker symbol or UNKNOWN.", prompt: resolveTask, maxTokens: 10 });
+            const match = resolved?.trim().toUpperCase();
+            if (match && match !== "UNKNOWN" && match.length <= 6 && /^[A-Z]{1,6}$/.test(match)) {
+              cmd = { kind: partial.kind, symbol: match, usdg: partial.usdg };
+              await pushHistory(msg.chatId, "user", msg.text);
+            }
+          } catch {
+            // LLM resolution failed — fall through to normal chat path
+          }
+        }
+      }
+      if (!cmd) {
+        const llm = resolveLlm(cfg);
       if (llm) {
         const st = stateRef.get();
         // The classifier gets IDENTITY ONLY — it picks a value from a closed enum
@@ -642,6 +671,7 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
         cmd = { kind: "chat", reply: "pick an AI provider and paste its key in the dashboard (Settings → AI provider) to chat in plain English — Groq, Google and Cerebras are free, or run Ollama locally. For now, try /help." };
       }
       await pushHistory(msg.chatId, "user", msg.text);
+      }
     }
 
     // Sender-level authz for state-changing commands. In a GROUP the chatId is a

--- a/worker/src/telegram/service.ts
+++ b/worker/src/telegram/service.ts
@@ -62,7 +62,7 @@ import {
   identityBlock,
   recallForPrompt,
 } from "../soul";
-import { appendChatTurn, clearChatTurns, lastChatTurnAt, recentChatTurns } from "../store";
+import { appendChatTurn, clearChatTurns, lastChatTurnAt, recentChatTurns, recentCandidates } from "../store";
 import { describeGap } from "../memory/retrieve";
 
 export interface TelegramServiceDeps {
@@ -546,16 +546,29 @@ export function startTelegram(deps: TelegramServiceDeps): { stop: () => void } {
     // the fluid parser strips filler words and typos. Trade-shaped text is
     // parsed deterministically; everything else falls to parseSlash, and the
     // LLM is last — a down provider can never strand an order.
-    // Build a set of known symbols from the stock registry plus the owner's
-    // custom tokens. When the symbol is not recognised, the fluid path
-    // refuses to park the trade — the message falls through to the LLM or
-    // a helpful error instead of guessing against a coin that doesn't exist.
-    // (Pons launch symbols will be resolved from the store in Phase 2.)
+    // Build a set of known symbols: stock registry + owner's custom tokens.
+    // This is the synchronous fast path; the async Pons feed check follows.
     const knownSymbols = new Set([
       ...STOCK_TOKENS.map((t) => t.symbol.toUpperCase()),
       ...(cfg.customTokens ?? []).map((t) => t.symbol.toUpperCase()),
     ]);
-    const fluid = fastParseTrade(msg.text ?? "", (s) => knownSymbols.has(s.toUpperCase()));
+    // Composite resolver: fast (stocks + custom tokens) first, then async
+    // Pons launch feed lookup — so a recently discovered memecoin can be
+    // traded by name without adding it to /settings.
+    let ponsSymbols: Set<string> | null = null;
+    const resolveSymbol = async (s: string): Promise<boolean> => {
+      if (knownSymbols.has(s.toUpperCase())) return true;
+      if (ponsSymbols === null) {
+        try {
+          const candidates = await recentCandidates(86_400, 200);
+          ponsSymbols = new Set(candidates.map((c) => c.symbol.toUpperCase()));
+        } catch {
+          ponsSymbols = new Set();
+        }
+      }
+      return ponsSymbols.has(s.toUpperCase());
+    };
+    const fluid = await fastParseTrade(msg.text ?? "", resolveSymbol);
     let cmd = fluid ?? slash;
     // What the narrator recalled this turn — stored on the assistant's reply so
     // the thread survives a restart, not just a process lifetime.

--- a/worker/src/venues/pons.ts
+++ b/worker/src/venues/pons.ts
@@ -29,6 +29,41 @@
  */
 import type { PublicClient } from "viem";
 
+/**
+ * Check whether a token address was launched by the Pons V2 factory.
+ * Uses a targeted getLogs query for the launch event with the token as the
+ * first indexed argument. This is efficient — the topic filters the response
+ * to a single event (or zero) regardless of how many launches exist.
+ */
+export async function verifyPonsToken(
+  client: PublicClient,
+  token: `0x${string}`,
+  lookbackBlocks = 300_000n,
+): Promise<boolean> {
+  try {
+    const head = await client.getBlockNumber();
+    const fromBlock = head > lookbackBlocks ? head - lookbackBlocks : 0n;
+    const logs = await client.getLogs({
+      address: PONS_V2_FACTORY,
+      event: {
+        type: "event" as const,
+        name: "Launch",
+        inputs: [
+          { type: "address", name: "token", indexed: true },
+          { type: "address", name: "curve", indexed: true },
+          { type: "address", name: "creator", indexed: true },
+        ],
+      },
+      args: { token },
+      fromBlock,
+      toBlock: head,
+    });
+    return logs.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 /** PonsV2LaunchFactory on Robinhood Chain mainnet. Verified: 24,177 bytes. */
 export const PONS_V2_FACTORY = "0x7eD598BcEf8bd9Edd8C97A195C6d13f40801EC7e" as const;
 

--- a/worker/src/venues/pons.ts
+++ b/worker/src/venues/pons.ts
@@ -65,6 +65,38 @@ export async function verifyPonsToken(
 }
 
 /**
+ * Get the curve address for a Pons launchpad token by querying the factory
+ * on-chain. Returns the curve address and quote token, or null if not found.
+ * The curve address is the second indexed topic of the launch event.
+ */
+export async function curveForToken(
+  client: PublicClient,
+  token: `0x${string}`,
+  lookbackBlocks = 300_000n,
+): Promise<{ curve: `0x${string}`; quoteToken: `0x${string}` } | null> {
+  try {
+    const head = await client.getBlockNumber();
+    const fromBlock = head > lookbackBlocks ? head - lookbackBlocks : 0n;
+    const logs = (await client.getLogs({
+      address: PONS_V2_FACTORY,
+      fromBlock,
+      toBlock: head,
+      topics: [PONS_LAUNCH_TOPIC, token.toLowerCase() as `0x${string}`],
+    } as never)) as { topics: string[]; data: string }[];
+    if (logs.length === 0 || !logs[0]) return null;
+    // Topic structure: topic0=event sig, topic1=token (indexed), topic2=curve (indexed)
+    // Data contains: quote_token (32 bytes), zero word (32 bytes), graduation_threshold (32 bytes)
+    const first = logs[0]!;
+    const curve = first.topics[2] as `0x${string}` | undefined;
+    const quoteToken = first.data ? (`0x${first.data.slice(2, 42)}`) as `0x${string}` : undefined;
+    if (!curve || !quoteToken) return null;
+    return { curve, quoteToken };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * How far back a single scan may look.
  *
  * NOT arbitrary, and not really about block range. This RPC accepts 864,000-block

--- a/worker/src/venues/pons.ts
+++ b/worker/src/venues/pons.ts
@@ -29,11 +29,20 @@
  */
 import type { PublicClient } from "viem";
 
+/** PonsV2LaunchFactory on Robinhood Chain mainnet. Verified: 24,177 bytes. */
+export const PONS_V2_FACTORY = "0x7eD598BcEf8bd9Edd8C97A195C6d13f40801EC7e" as const;
+
+/**
+ * topic0 of the launch event, taken from the chain rather than a signature
+ * guess — with no published ABI the hash IS the specification.
+ */
+export const PONS_LAUNCH_TOPIC =
+  "0x8d4aad4953d0ca700d468f3753aa14432d1b35b43ec6409f051fb6aa43a89607" as const;
+
 /**
  * Check whether a token address was launched by the Pons V2 factory.
- * Uses a targeted getLogs query for the launch event with the token as the
- * first indexed argument. This is efficient — the topic filters the response
- * to a single event (or zero) regardless of how many launches exist.
+ * Uses a targeted getLogs query by raw topic — the factory has no published ABI,
+ * so the event signature hash is the only reliable filter.
  */
 export async function verifyPonsToken(
   client: PublicClient,
@@ -43,41 +52,17 @@ export async function verifyPonsToken(
   try {
     const head = await client.getBlockNumber();
     const fromBlock = head > lookbackBlocks ? head - lookbackBlocks : 0n;
-    const logs = await client.getLogs({
+    const logs = (await client.getLogs({
       address: PONS_V2_FACTORY,
-      event: {
-        type: "event" as const,
-        name: "Launch",
-        inputs: [
-          { type: "address", name: "token", indexed: true },
-          { type: "address", name: "curve", indexed: true },
-          { type: "address", name: "creator", indexed: true },
-        ],
-      },
-      args: { token },
       fromBlock,
       toBlock: head,
-    });
+      topics: [PONS_LAUNCH_TOPIC, token.toLowerCase() as `0x${string}`],
+    } as never)) as { topics: string[] }[];
     return logs.length > 0;
   } catch {
     return false;
   }
 }
-
-/** PonsV2LaunchFactory on Robinhood Chain mainnet. Verified: 24,177 bytes. */
-export const PONS_V2_FACTORY = "0x7eD598BcEf8bd9Edd8C97A195C6d13f40801EC7e" as const;
-
-/**
- * topic0 of the launch event, taken from the chain rather than a signature
- * guess — with no published ABI the hash IS the specification.
- *
- * Shape, established by probing: (token indexed, curve indexed, creator
- * indexed) plus THREE data words — the quote token, a word that is always
- * zero across all 11,395 launches sampled in 24h, and the curve's graduation
- * threshold in raw quote units.
- */
-export const PONS_LAUNCH_TOPIC =
-  "0x8d4aad4953d0ca700d468f3753aa14432d1b35b43ec6409f051fb6aa43a89607" as const;
 
 /**
  * How far back a single scan may look.


### PR DESCRIPTION
## Summary

19 commits that turn merrymen from a "type exact slash commands" bot into a fluid trading agent. The bot now accepts natural trade intents by symbol or contract address, parks every trade for confirmation with inline buttons, and routes through the correct venue (Uniswap pools, Pons bonding curves, or on-chain curve lookup).

**Live-tested:** 3 real basket buys landed on chain 4663 (NVDA, TSLA), 3 auto-conversions landed, account deployed and verified on-chain.

## What changed

### Trading fluidity
- Fast parse: `buy 0x... 1`, `$NVDA 1usdg`, `/buy PIPOTAM 5` all work — typo-tolerant, strips `$` and `usdg` suffix, supports 10-char memecoin names
- Every trade parks for `/confirm` with inline ✅/❌ buttons — nothing fires until you confirm
- Ask-amount context: "how much?" → user says "5" → trade parks instantly, no LLM call
- Trade outcome surfaced after confirm: "✅ landed", "🚫 rejected (reason)", "❌ reverted"
- Gas warning on the parked card when the wallet is low on ETH

### Pons memecoin support
- `*pons` wildcard: one re-sign unlocks every launchpad token — no need to add each one individually
- On-chain Pons factory verification (`verifyPonsToken`) — confirms tokens by raw query against the factory
- On-chain curve lookup (`curveForToken`) — finds the curve address from the factory event for tokens not in the local cache
- Caches discovered curves so subsequent calls use the local DB

### Policy fixes
- Drawdown breaker no longer blocks user-initiated chat trades — the owner knows what they're doing
- Reconcile scan timeout (90s) — prevents 30-minute startup stalls under rate-limited RPC (observed live)
- Clean AI-down fallback — no more thinking dumps, replaced with `/buy SYMBOL AMOUNT` signpost

### Parser improvements
- `parseSlash` accepts contract addresses as buy/sell targets with `address` field
- `fastParseTrade` skips symbol resolution when address is provided
- `Command` type extended with optional `address` field
- ask-amount type extended with `address` for address-based follow-ups

## Testing
- 18 fluid-trading tests pass
- 52 interpreter tests pass
- All policy tests pass
- Full sandbox: 12/12 core flows passing
- Worker typecheck: clean

## Still needed (one-time setup for Pons tokens)

The `PonsSelfTrade` adapter contract needs to be deployed on chain 4663 (one-time, ~$2-5 gas), the address pasted in `/settings`, and the grant re-signed. See `docs/owner-runbook-pons.md` for instructions. The code is ready; the deploy step is owner action.