### PR TITLE
The first operation was refused by our own doubling, not by the chain

### DIFF
--- a/spikes/first-op-gas/check-extras.ts
+++ b/spikes/first-op-gas/check-extras.ts
@@ -1,0 +1,99 @@
+/**
+ * Do `extraTokens` actually widen the wall's policies, and is the estimation
+ * stub the REAL enable blob or a fixed-size dummy?
+ *
+ * The gas sweep returned an identical 7,418,031 verificationGasLimit at +0, +5,
+ * +15 and +40 extra tokens, with the stub pinned at 10,932 bytes. Either the
+ * wall's size genuinely does not drive the cost, or the extras never reached
+ * `buildWallPolicies`, or the stub is a constant that does not reflect the real
+ * enable data. Those three have completely different consequences, so this
+ * separates them before any conclusion is drawn.
+ *
+ * No network writes. Nothing signed, nothing broadcast.
+ */
+import { createPublicClient, http, type Address } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { getEntryPoint, KERNEL_V3_3 } from "@zerodev/sdk/constants";
+import { createKernelAccount } from "@zerodev/sdk";
+import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
+import { toPermissionValidator } from "@zerodev/permissions";
+import { toECDSASigner } from "@zerodev/permissions/signers";
+import { buildWallPolicies, chainForId } from "../../packages/core/src/index";
+
+const CAPS = { perTradeUsdg: 50, dailyUsdg: 500, expiryDays: 14, maxDrawdownPct: 10, maxOpsPerDay: 48 };
+
+async function main() {
+  const publicClient = createPublicClient({
+    chain: chainForId(4663),
+    transport: http("https://rpc.mainnet.chain.robinhood.com"),
+  });
+  const entryPoint = getEntryPoint("0.7");
+
+  for (const n of [0, 40]) {
+    const extras = Array.from({ length: n }, (_, i) => ({
+      // isValidCustomToken requires exactly {symbol, address, decimals} — my
+      // first attempt passed the STOCK_TOKENS shape (name/chainlinkFeed/kind,
+      // no decimals) and every entry was silently dropped, which made the sweep
+      // look like the wall size did not matter when it had never been varied.
+      symbol: `X${i}`,
+      address: `0x${(i + 0x1000).toString(16).padStart(40, "0")}` as Address,
+      decimals: 18,
+    }));
+    const owner = privateKeyToAccount(generatePrivateKey());
+    const ecdsa = await signerToEcdsaValidator(publicClient, {
+      signer: owner,
+      entryPoint,
+      kernelVersion: KERNEL_V3_3,
+    });
+    const sudoOnly = await createKernelAccount(publicClient, {
+      entryPoint,
+      kernelVersion: KERNEL_V3_3,
+      plugins: { sudo: ecdsa },
+    });
+    const { policies } = buildWallPolicies({
+      caps: CAPS,
+      smartAccount: sudoOnly.address,
+      ...(n ? { extraTokens: extras as never } : {}),
+    });
+
+    // The CALL policy's own serialized data is where the ONE_OF lists live.
+    const sizes = policies.map((p: unknown) => {
+      const o = p as { policyParams?: { type?: string }; getPolicyData?: () => string };
+      let bytes: number | string = "n/a";
+      try {
+        const d = o.getPolicyData?.();
+        if (typeof d === "string") bytes = d.length / 2 - 1;
+      } catch {
+        bytes = "threw";
+      }
+      return `${o.policyParams?.type ?? "?"}:${bytes}`;
+    });
+
+    const sess = await toECDSASigner({ signer: privateKeyToAccount(generatePrivateKey()) });
+    const pv = await toPermissionValidator(publicClient, {
+      entryPoint,
+      kernelVersion: KERNEL_V3_3,
+      signer: sess,
+      policies,
+      flag: "0x0002",
+    });
+
+    let enableBytes: number | string = "n/a";
+    try {
+      const v = pv as unknown as { getEnableData?: (a: Address) => Promise<string> };
+      const e = await v.getEnableData?.(sudoOnly.address);
+      if (typeof e === "string") enableBytes = e.length / 2 - 1;
+    } catch (err) {
+      enableBytes = `threw: ${String(err).slice(0, 40)}`;
+    }
+
+    console.log(
+      `extras ${String(n).padStart(2)} · policies ${policies.length} · [${sizes.join(" ")}] · enableData ${enableBytes}B`,
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error(String(e).slice(0, 400));
+  process.exit(1);
+});

--- a/spikes/first-op-gas/gate-v2-verify.mjs
+++ b/spikes/first-op-gas/gate-v2-verify.mjs
@@ -1,0 +1,116 @@
+/**
+ * TWO CLAIMS THE GATE RESTS ON, CHECKED WITHOUT THE SDK.
+ *
+ * READ-ONLY: eth_call only (EntryPoint.getNonce and Kernel.permissionConfig).
+ *
+ * CLAIM 1 (C2's premise). After a permission enable LANDS, the EntryPoint's
+ *   counter for that ENABLE key is 1 and never 0 again, while the DEFAULT key
+ *   for the same permission id carries the ordinary traffic. If that holds,
+ *   `sequence == 0` is a genuine once-per-inclusion bound and refuses only
+ *   operations that would revert.
+ *
+ * CLAIM 2 (C4's premise). permissionConfig(pId) read straight off the account
+ *   distinguishes installed from not-installed per (account, permissionId), and
+ *   a codeless account answers with empty returndata rather than with zeros —
+ *   which is why "no code" must be a separate branch and not a parse result.
+ */
+const RPC = "https://rpc.mainnet.chain.robinhood.com";
+const EP = "0x0000000071727De22E5E9d8BAf0edAc6f37da032";
+const LIVE_WITH_PERM = "0xa48cE91e2F3237E69660C1543042c007B8D33e75";
+const MERRYMEN = "0x032Da6A0Ccf866474e45854E7fDEF9afd1509036";
+const INSTALLED_PID = "3ca1cec8";
+const NEVER_PID = "deadbeef";
+/** An address with no code, so the codeless branch is exercised on a real read. */
+const CODELESS = "0x00000000000000000000000000000000000c0de5";
+
+async function call(to, data) {
+  for (let i = 0; i < 4; i++) {
+    const r = await fetch(RPC, {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_call", params: [{ to, data }, "latest"] }),
+    }).then((x) => x.json()).catch((e) => ({ error: { message: String(e) } }));
+    if (r.error && /too many requests/i.test(r.error.message ?? "") && i < 3) {
+      await new Promise((s) => setTimeout(s, 800 * 2 ** i)); continue;
+    }
+    return r;
+  }
+}
+async function getCode(a) {
+  const r = await fetch(RPC, {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_getCode", params: [a, "latest"] }),
+  }).then((x) => x.json());
+  return r.result;
+}
+
+/** EntryPoint.getNonce(address sender, uint192 key) -> uint256 */
+async function nonceFor(sender, key24Hex) {
+  const data = "0x35567e1a" + sender.slice(2).toLowerCase().padStart(64, "0") + key24Hex.padStart(64, "0");
+  const r = await call(EP, data);
+  if (typeof r.result !== "string") return { seq: null, err: r.error?.message ?? "unread" };
+  return { seq: BigInt(r.result) & 0xffff_ffff_ffff_ffffn, raw: r.result };
+}
+
+/** mode ‖ vType ‖ pId left-aligned in 20 bytes ‖ 2-byte nonce key = 24 bytes = uint192 */
+const keyFor = (mode, vType, pid) => mode + vType + pid.padEnd(40, "0") + "0000";
+
+async function permissionConfig(account, pid) {
+  const r = await call(account, "0xc3e58978" + pid.padEnd(64, "0"));
+  if (typeof r.result !== "string") return { state: "UNREAD", err: r.error?.message };
+  if (r.result === "0x") return { state: "EMPTY RETURNDATA" };
+  if (r.result.length < 2 + 3 * 64) return { state: `SHORT (${(r.result.length - 2) / 2} bytes)` };
+  const signer = "0x" + r.result.slice(2 + 128 + 24, 2 + 192);
+  const flag = "0x" + r.result.slice(2 + 64, 2 + 68); // bytes2 is LEFT-aligned in its word
+  return { state: signer === "0x0000000000000000000000000000000000000000" ? "not installed" : "INSTALLED", signer, flag };
+}
+
+console.log("══ CLAIM 1 — the EntryPoint's own counters, read directly (no SDK) ══");
+console.log(`  account ${LIVE_WITH_PERM}, permission id 0x${INSTALLED_PID} (its enable landed at block 51,847,124)`);
+for (const [label, key] of [
+  ["ENABLE  key (mode 0x01, vType 0x02)", keyFor("01", "02", INSTALLED_PID)],
+  ["DEFAULT key (mode 0x00, vType 0x02)", keyFor("00", "02", INSTALLED_PID)],
+]) {
+  const n = await nonceFor(LIVE_WITH_PERM, key);
+  console.log(`    ${label}  key 0x${key}`);
+  console.log(`      -> sequence ${n.seq === null ? `UNREAD (${n.err})` : n.seq}`);
+}
+console.log(`  and a permission id that has NEVER been used on that account, as a control:`);
+{
+  const n = await nonceFor(LIVE_WITH_PERM, keyFor("01", "02", NEVER_PID));
+  console.log(`    ENABLE key for 0x${NEVER_PID} -> sequence ${n.seq === null ? "UNREAD" : n.seq}`);
+}
+console.log(`  merrymen's own account, which has executed exactly one op ever (a sudo deploy):`);
+{
+  const sudo = await nonceFor(MERRYMEN, "0000845adb2c711129d4f3966735ed98a9f09fc4ce570000");
+  const enable = await nonceFor(MERRYMEN, keyFor("01", "02", "12345678"));
+  console.log(`    SUDO/DEFAULT key -> sequence ${sudo.seq === null ? "UNREAD" : sudo.seq}   (1 = the deploy landed)`);
+  console.log(`    a never-used ENABLE key -> sequence ${enable.seq === null ? "UNREAD" : enable.seq}`);
+}
+console.log(`
+  READING: an enable that LANDED leaves its enable key at 1 and moves the traffic
+  to the default key. An enable that never landed leaves its key at 0. So C2's
+  "sequence must be 0" refuses exactly the enable-shaped operations whose id has
+  already been installed — operations that revert AA23 0xc48cf8ee if sent.
+`);
+
+console.log("══ CLAIM 2 — permissionConfig is per-(account, permissionId), and codeless is its own case ══");
+for (const [acct, pid, note] of [
+  [LIVE_WITH_PERM, INSTALLED_PID, "the id this account really installed"],
+  [LIVE_WITH_PERM, NEVER_PID, "control: an id it never installed"],
+  [MERRYMEN, INSTALLED_PID, "control: the SAME id, on a different live account"],
+  [CODELESS, INSTALLED_PID, "control: an address with no code"],
+]) {
+  const code = await getCode(acct);
+  const c = await permissionConfig(acct, pid);
+  console.log(`  ${acct}  0x${pid}`);
+  console.log(`    code ${code === undefined ? "UNREAD" : code === "0x" ? "NONE" : `${(code.length - 2) / 2} bytes`} · ${c.state}${c.signer ? ` signer ${c.signer} flag ${c.flag}` : ""}   (${note})`);
+}
+console.log(`
+  READING: the same permission id reads INSTALLED on one live account and
+  "not installed" on another, so the read is genuinely keyed by the pair. And a
+  codeless address answers with EMPTY RETURNDATA, not with a zero signer — which
+  is why permissionIdInstalled() must branch on getCode first: parsing that reply
+  as "not installed" is correct only because the account cannot hold anything,
+  and treating an unparseable reply from a CODED account the same way would hand
+  the elevated ceiling to any truncated response.
+`);

--- a/spikes/first-op-gas/nonce-mode.ts
+++ b/spikes/first-op-gas/nonce-mode.ts
@@ -1,0 +1,52 @@
+/**
+ * Can we PROVE, from the operation itself, that it carries a permission-validator
+ * enable — rather than inferring it from "the account has no code"?
+ *
+ * Kernel v3 packs the validator mode into the nonce key:
+ *   nonce = key(24 bytes) ‖ seq(8 bytes),  key = mode(1) ‖ vType(1) ‖ validator(20) ‖ id(2)
+ * and @zerodev/sdk sets VALIDATOR_MODE.ENABLE (0x01) exactly when the regular
+ * validator is not yet enabled on-chain (toKernelPluginManager.ts:388-395).
+ *
+ * If that holds, the nonce is a structural proof of the enable and the elevated
+ * ceiling can be gated on it instead of on "undeployed", which is what the spec
+ * asks for. Nothing signed, nothing broadcast.
+ */
+import { createPublicClient, http } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { getEntryPoint, KERNEL_V3_3 } from "@zerodev/sdk/constants";
+import { createKernelAccount } from "@zerodev/sdk";
+import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
+import { toPermissionValidator } from "@zerodev/permissions";
+import { toECDSASigner } from "@zerodev/permissions/signers";
+import { buildWallPolicies, chainForId } from "../../packages/core/src/index";
+
+const CAPS = { perTradeUsdg: 50, dailyUsdg: 500, expiryDays: 14, maxDrawdownPct: 10, maxOpsPerDay: 48 };
+
+/** The candidate predicate, exactly as it would ship. */
+const modeOf = (nonce: bigint) => Number((nonce >> 248n) & 0xffn);
+
+async function main() {
+  const publicClient = createPublicClient({ chain: chainForId(4663), transport: http("https://rpc.mainnet.chain.robinhood.com") });
+  const entryPoint = getEntryPoint("0.7");
+  const owner = privateKeyToAccount(generatePrivateKey());
+  const ecdsa = await signerToEcdsaValidator(publicClient, { signer: owner, entryPoint, kernelVersion: KERNEL_V3_3 });
+
+  const sudoOnly = await createKernelAccount(publicClient, { entryPoint, kernelVersion: KERNEL_V3_3, plugins: { sudo: ecdsa } });
+  const sudoNonce = await sudoOnly.getNonce();
+  console.log(`sudo-only  nonce 0x${sudoNonce.toString(16).padStart(64, "0")}`);
+  console.log(`           top byte (mode) = 0x${modeOf(sudoNonce).toString(16).padStart(2, "0")}`);
+
+  const sess = await toECDSASigner({ signer: privateKeyToAccount(generatePrivateKey()) });
+  const { policies } = buildWallPolicies({ caps: CAPS, smartAccount: sudoOnly.address });
+  const pv = await toPermissionValidator(publicClient, { entryPoint, kernelVersion: KERNEL_V3_3, signer: sess, policies, flag: "0x0002" });
+  const walled = await createKernelAccount(publicClient, { entryPoint, kernelVersion: KERNEL_V3_3, plugins: { sudo: ecdsa, regular: pv } });
+  const wallNonce = await walled.getNonce();
+  console.log(`walled     nonce 0x${wallNonce.toString(16).padStart(64, "0")}`);
+  console.log(`           top byte (mode) = 0x${modeOf(wallNonce).toString(16).padStart(2, "0")}`);
+
+  console.log("");
+  console.log(`sudo-only is ENABLE-mode?  ${modeOf(sudoNonce) === 1 ? "YES" : "no"}   (want: no)`);
+  console.log(`walled    is ENABLE-mode?  ${modeOf(wallNonce) === 1 ? "YES" : "no"}   (want: YES)`);
+  console.log(`\n=> the nonce ${modeOf(wallNonce) === 1 && modeOf(sudoNonce) !== 1 ? "IS" : "is NOT"} a usable structural proof of the enable`);
+}
+main().catch((e) => { console.error(String(e).slice(0, 300)); process.exit(1); });

--- a/spikes/first-op-gas/probe.ts
+++ b/spikes/first-op-gas/probe.ts
@@ -1,0 +1,379 @@
+/**
+ * WHY AA21, AND DOES A BALANCE OVERRIDE FIX IT?
+ *
+ * Twenty-four consecutive live swap attempts by tenant 0x42773b died on
+ * `AA21 didn't pay prefund` during ESTIMATION — before anything was signed or
+ * sent. `boundGas` never received a number, so the three limits were never
+ * logged and the 8M ceiling was never reached.
+ *
+ * THE HYPOTHESIS. viem's `estimateUserOperationGas` prepares only
+ * `factory, fees, nonce, paymaster, signature` — never `gas` — and passes no
+ * `stateOverride`. So the operation reaches Pimlico with NO gas limits at all,
+ * Pimlico substitutes its own for the simulation, and the EntryPoint's prefund
+ * check then runs against the account's real balance. On chain 4663 the block
+ * gas limit is 1.125e15, so a bundler seeding a search from it demands a
+ * prefund no account could ever hold. If that is what is happening, the account
+ * is underfunded for the SIMULATION, not for the operation.
+ *
+ * WHAT THIS PROBE DOES. Builds a throwaway Kernel account with the identical
+ * wall shape (same buildWallPolicies, same WALL_POLICY_FLAG, same
+ * KERNEL_V3_3 / EntryPoint 0.7), confirms it is undeployed and holds nothing,
+ * and asks Pimlico to estimate the same shape of first operation twice: once as
+ * the worker asks today, and once with a balance-only `stateOverride`.
+ *
+ * NOTHING IS SIGNED AND NOTHING IS BROADCAST. `eth_estimateUserOperationGas` is
+ * a simulation. The keys are generated here, used for nothing else, never
+ * written to disk, and never funded. The override exists only inside the
+ * estimation RPC call — it cannot reach a signed operation, because this script
+ * never produces one.
+ *
+ * Run: railway run --service orchestrator -- npx tsx spikes/first-op-gas/probe.ts
+ * (railway supplies MERRYMEN_BUNDLER_API_KEY; the Pimlico host is public.)
+ */
+import { createPublicClient, encodeFunctionData, erc20Abi, http, parseEther, type Address, type Hex } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { getEntryPoint, KERNEL_V3_3 } from "@zerodev/sdk/constants";
+import { createKernelAccount } from "@zerodev/sdk";
+import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
+import { toPermissionValidator } from "@zerodev/permissions";
+import { toECDSASigner } from "@zerodev/permissions/signers";
+import {
+  buildWallPolicies,
+  CASH,
+  chainForId,
+  pimlicoBundlerUrl,
+  UNISWAP,
+  STOCK_TOKENS,
+  TRADEABLE_SYMBOLS,
+  UNISWAP_SWAP_ROUTER_ABI,
+  WALL_POLICY_FLAG,
+} from "../../packages/core/src/index";
+
+const CHAIN_ID = 4663;
+const RPC = "https://rpc.mainnet.chain.robinhood.com";
+
+/** The landed-deploy anchors, decoded from handleOps calldata on 4663. */
+const LANDED = {
+  verificationGasLimit: 358_217n,
+  callGasLimit: 50_180n,
+  preVerificationGas: 54_538n,
+  signedTotal: 462_935n,
+  actualGasUsed: 359_497n,
+  note: "owner-signed sudo deploy + ERC-20 transfer (tx 0xc6562c38…, block 51207025)",
+};
+
+const gwei = (n: bigint) => `${(Number(n) / 1e9).toFixed(6)} gwei`;
+
+async function rpc(url: string, method: string, params: unknown[]): Promise<{ result?: unknown; error?: unknown }> {
+  const r = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  return (await r.json()) as { result?: unknown; error?: unknown };
+}
+
+function errText(e: unknown): string {
+  const o = e as { message?: string; data?: unknown; code?: unknown } | null;
+  const parts = [o?.code !== undefined ? `code ${String(o.code)}` : "", o?.message ?? "", typeof o?.data === "string" ? o.data : ""];
+  return parts.filter(Boolean).join(" · ").slice(0, 400);
+}
+
+async function main() {
+  const apiKey = process.env.MERRYMEN_BUNDLER_API_KEY;
+  if (!apiKey) {
+    console.error("no MERRYMEN_BUNDLER_API_KEY — run this under `railway run --service orchestrator --`");
+    process.exit(1);
+  }
+  const bundler = pimlicoBundlerUrl(CHAIN_ID, apiKey);
+  console.log(`bundler host: ${new URL(bundler).host} (key present, ${apiKey.length} chars — value never printed)`);
+
+  const chain = chainForId(CHAIN_ID);
+  const publicClient = createPublicClient({ chain, transport: http(RPC) });
+  const entryPoint = getEntryPoint("0.7");
+
+  // ── a throwaway account with the REAL wall shape ────────────────────────
+  const ownerKey = generatePrivateKey();
+  const owner = privateKeyToAccount(ownerKey);
+  const ecdsa = await signerToEcdsaValidator(publicClient, { signer: owner, entryPoint, kernelVersion: KERNEL_V3_3 });
+  const sudoOnly = await createKernelAccount(publicClient, {
+    entryPoint,
+    kernelVersion: KERNEL_V3_3,
+    plugins: { sudo: ecdsa },
+  });
+
+  const sessionKey = generatePrivateKey();
+  const sessionSigner = await toECDSASigner({ signer: privateKeyToAccount(sessionKey) });
+  const { policies } = buildWallPolicies({
+    caps: { perTradeUsdg: 50, dailyUsdg: 500, expiryDays: 14, maxDrawdownPct: 10, maxOpsPerDay: 48 },
+    smartAccount: sudoOnly.address,
+  });
+  const permission = await toPermissionValidator(publicClient, {
+    entryPoint,
+    kernelVersion: KERNEL_V3_3,
+    signer: sessionSigner,
+    policies,
+    flag: WALL_POLICY_FLAG,
+  });
+  const account = await createKernelAccount(publicClient, {
+    entryPoint,
+    kernelVersion: KERNEL_V3_3,
+    plugins: { sudo: ecdsa, regular: permission },
+  });
+
+  const sender = account.address as Address;
+  const code = await publicClient.getCode({ address: sender }).catch(() => undefined);
+  const balance = await publicClient.getBalance({ address: sender }).catch(() => null);
+  console.log(`\nsynthetic account ${sender}`);
+  console.log(`  deployed: ${code && code !== "0x" ? "YES (unexpected)" : "NO — counterfactual, as required"}`);
+  console.log(`  balance:  ${balance === null ? "unread" : `${balance} wei`}`);
+  if (balance !== null && balance !== 0n) console.log("  NOTE: not zero — this address has been used before");
+
+  // ── the same first operation the worker builds: approve + exactInputSingle ─
+  const amountIn = 5_000_000n; // 5 USDG
+  const minOut = 1n;
+  // WALL-LEGAL BOTH LEGS. buildCallPermissions pins tokenIn and tokenOut to
+  // ONE_OF adapterAssets = USDG + the TRADEABLE stock tokens. WETH is NOT in
+  // that set, so a WETH leg is refused by the permission validator itself —
+  // which is the wall working, and not the thing this probe is measuring.
+  const outToken = STOCK_TOKENS.find((t) => (TRADEABLE_SYMBOLS as readonly string[]).includes(t.symbol))!
+    .address as Address;
+  console.log(`  swapping USDG -> ${STOCK_TOKENS.find((t) => t.address === outToken)!.symbol} (both legs in adapterAssets)`);
+  const calls = [
+    {
+      to: CASH.USDG as Address,
+      value: 0n,
+      data: encodeFunctionData({ abi: erc20Abi, functionName: "approve", args: [UNISWAP.swapRouter02 as Address, amountIn] }),
+    },
+    {
+      to: UNISWAP.swapRouter02 as Address,
+      value: 0n,
+      data: encodeFunctionData({
+        abi: UNISWAP_SWAP_ROUTER_ABI,
+        functionName: "exactInputSingle",
+        args: [
+          {
+            tokenIn: CASH.USDG as Address,
+            tokenOut: outToken,
+            fee: 500,
+            recipient: sender,
+            amountIn,
+            amountOutMinimum: minOut,
+            sqrtPriceLimitX96: 0n,
+          } as never,
+        ],
+      }),
+    },
+  ];
+  const callData = await account.encodeCalls(calls);
+
+  const factoryArgs = await account.getFactoryArgs();
+  const nonce = await account.getNonce();
+  // The permission validator derives its stub from the operation (the
+  // plugin-enable blob is signed over the op), so it must be handed one.
+  const stub = await account.getStubSignature({
+    sender,
+    nonce,
+    callData,
+    callGasLimit: 0n,
+    verificationGasLimit: 0n,
+    preVerificationGas: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    signature: "0x",
+    ...factoryArgs,
+  } as never);
+
+  // Fees from the chain, in the same shape the worker signs against.
+  const fees = await publicClient.estimateFeesPerGas().catch(() => null);
+  const maxFeePerGas = fees?.maxFeePerGas ?? 1_000_000_000n;
+  const maxPriorityFeePerGas = fees?.maxPriorityFeePerGas ?? 1_000_000n;
+
+  const userOp = {
+    sender,
+    nonce: `0x${nonce.toString(16)}`,
+    factory: factoryArgs.factory,
+    factoryData: factoryArgs.factoryData,
+    callData,
+    maxFeePerGas: `0x${maxFeePerGas.toString(16)}`,
+    maxPriorityFeePerGas: `0x${maxPriorityFeePerGas.toString(16)}`,
+    signature: stub,
+  };
+
+  console.log(`\n── THE OPERATION SENT FOR ESTIMATION ─────────────────────────`);
+  console.log(`  sender                ${userOp.sender}`);
+  console.log(`  nonce                 ${nonce}`);
+  console.log(`  factory               ${userOp.factory}`);
+  console.log(`  factoryData           ${String(userOp.factoryData).length / 2 - 1} bytes`);
+  console.log(`  callData              ${callData.length / 2 - 1} bytes (approve + exactInputSingle)`);
+  console.log(`  signature (stub)      ${stub.length / 2 - 1} bytes  ← the plugin-enable blob`);
+  console.log(`  maxFeePerGas          ${gwei(maxFeePerGas)}`);
+  console.log(`  maxPriorityFeePerGas  ${gwei(maxPriorityFeePerGas)}`);
+  console.log(`  callGasLimit          (ABSENT — viem never sends one)`);
+  console.log(`  verificationGasLimit  (ABSENT)`);
+  console.log(`  preVerificationGas    (ABSENT)`);
+  console.log(`  stateOverride         (ABSENT)`);
+
+  const ep = entryPoint.address;
+
+  // ── 1. exactly as the worker asks today ────────────────────────────────
+  console.log(`\n── 1. ESTIMATE AS THE WORKER ASKS TODAY (no override) ────────`);
+  const a = await rpc(bundler, "eth_estimateUserOperationGas", [userOp, ep]);
+  if (a.error) console.log(`  REFUSED: ${errText(a.error)}`);
+  else console.log(`  ${JSON.stringify(a.result)}`);
+
+  // ── 2. the same op, with a balance-only override ───────────────────────
+  console.log(`\n── 2. SAME OP, balance-only stateOverride (1 ETH) ────────────`);
+  // Pimlico rejected the array form with "expected object, received array at
+  // params[2]", so the shape is the eth_call one: keyed by address.
+  const override = { [sender]: { balance: `0x${parseEther("1").toString(16)}` } };
+  const b = await rpc(bundler, "eth_estimateUserOperationGas", [userOp, ep, override]);
+  if (b.error) console.log(`  REFUSED: ${errText(b.error)}`);
+  else console.log(`  ${JSON.stringify(b.result)}`);
+
+  // ── 3. does Pimlico honour the override at all, or ignore it? ──────────
+  // An override of a DIFFERENT, irrelevant address should change nothing. If
+  // result 2 differs from result 1 but result 3 matches result 1, the override
+  // is genuinely being applied rather than the difference being noise.
+  console.log(`\n── 3. CONTROL: override an unrelated address ─────────────────`);
+  const control = { "0x000000000000000000000000000000000000dEaD": { balance: `0x${parseEther("1").toString(16)}` } };
+  const c = await rpc(bundler, "eth_estimateUserOperationGas", [userOp, ep, control]);
+  if (c.error) console.log(`  REFUSED: ${errText(c.error)}`);
+  else console.log(`  ${JSON.stringify(c.result)}`);
+
+  // ── 4. the fallback, if Pimlico will not override ──────────────────────
+  // simulateHandleOp against the chain RPC with the same override. This does
+  // not need the bundler at all.
+  console.log(`\n── 4. FALLBACK: EntryPoint.simulateHandleOp via eth_call + override ──`);
+  const d = await rpc(RPC, "eth_call", [
+    { to: ep, data: "0x", from: "0x0000000000000000000000000000000000000000" },
+    "latest",
+    { [sender]: { balance: `0x${parseEther("1").toString(16)}` } },
+  ]);
+  console.log(`  does this RPC accept a 3rd state-override param at all? ${d.error ? `NO — ${errText(d.error)}` : "YES (empty call returned)"}`);
+
+  // ── 5. REAL NUMBERS: balance override + a callData that needs no funds ──
+  // The swap above reverts on the synthetic account for a legitimate reason —
+  // it holds no USDG (STF = SAFE_TRANSFER_FROM_FAILED). An approve costs no
+  // balance, so this isolates the terms that actually dominate a first op:
+  // the account deployment, the plugin-enable, and the enable-signature check.
+  console.log(`
+── 5. balance override + approve-only callData (needs no USDG) ──`);
+  const approveOnly = await account.encodeCalls([calls[0]!]);
+  const stub2 = await account.getStubSignature({
+    sender, nonce, callData: approveOnly,
+    callGasLimit: 0n, verificationGasLimit: 0n, preVerificationGas: 0n,
+    maxFeePerGas: 0n, maxPriorityFeePerGas: 0n, signature: "0x", ...factoryArgs,
+  } as never);
+  const e = await rpc(bundler, "eth_estimateUserOperationGas", [
+    { ...userOp, callData: approveOnly, signature: stub2 },
+    ep,
+    override,
+  ]);
+  if (e.error) console.log(`  REFUSED: ${errText(e.error)}`);
+  else console.log(`  ${JSON.stringify(e.result)}`);
+
+  // ── 6. DOES THE ESTIMATE SCALE WITH THE OVERRIDDEN BALANCE? ────────────
+  // If it does, then 1 ETH is not a neutral simulation aid — it hands the
+  // bundler an unbounded search space (block gas limit on 4663 is 1.125e15) and
+  // the number that comes back describes the override, not the operation.
+  // The right override would then be the SMALLEST one that clears the prefund
+  // for the gas WE are willing to sign, so the estimate stays inside our policy.
+  const read = (r: { result?: unknown }) => {
+    const o = r.result as Record<string, string> | undefined;
+    if (!o) return null;
+    const n2 = (k: string) => (o[k] === undefined ? 0n : BigInt(o[k]));
+    const call = n2("callGasLimit"), ver = n2("verificationGasLimit"), pre = n2("preVerificationGas");
+    return { call, ver, pre, total: call + ver + pre };
+  };
+  console.log(`
+── 6. estimate vs overridden balance (approve-only) ───────────`);
+  for (const eth of ["0.003738797702007072", "0.01", "0.05", "0.2", "1"]) {
+    const wei = BigInt(Math.round(Number(eth) * 1e18));
+    const r = await rpc(bundler, "eth_estimateUserOperationGas", [
+      { ...userOp, callData: approveOnly, signature: stub2 },
+      ep,
+      { [sender]: { balance: `0x${wei.toString(16)}` } },
+    ]);
+    const v = read(r);
+    const affordable = wei / maxFeePerGas;
+    console.log(
+      `  ${eth.padEnd(22)} ETH (buys ${String(affordable).padStart(12)} gas) -> ` +
+        (v ? `verif ${String(v.ver).padStart(9)} · preVerif ${String(v.pre).padStart(7)} · raw ${v.total}` : `REFUSED: ${errText(r.error).slice(0, 60)}`),
+    );
+  }
+
+  // ── 7. DECOMPOSE: how much of the 7.4M is the DEPLOY, and how much the
+  //       PLUGIN-ENABLE? The two landed ops on 4663 were sudo-only (65-byte
+  //       signature, no permission validator) and signed 462,935 total. Estimate
+  //       the identical deploy WITHOUT the wall, and the difference is the
+  //       enable.
+  console.log(`
+── 7. sudo-only deploy (no wall) vs the same deploy WITH the wall ──`);
+  const sudoNonce = await sudoOnly.getNonce();
+  const sudoFactory = await sudoOnly.getFactoryArgs();
+  const sudoCallData = await sudoOnly.encodeCalls([calls[0]!]);
+  const sudoStub = await sudoOnly.getStubSignature({
+    sender: sudoOnly.address, nonce: sudoNonce, callData: sudoCallData,
+    callGasLimit: 0n, verificationGasLimit: 0n, preVerificationGas: 0n,
+    maxFeePerGas: 0n, maxPriorityFeePerGas: 0n, signature: "0x", ...sudoFactory,
+  } as never);
+  console.log(`  sudo-only stub signature: ${sudoStub.length / 2 - 1} bytes (vs ${stub2.length / 2 - 1} with the wall)`);
+  const g = await rpc(bundler, "eth_estimateUserOperationGas", [
+    {
+      sender: sudoOnly.address, nonce: `0x${sudoNonce.toString(16)}`,
+      factory: sudoFactory.factory, factoryData: sudoFactory.factoryData,
+      callData: sudoCallData, signature: sudoStub,
+      maxFeePerGas: `0x${maxFeePerGas.toString(16)}`,
+      maxPriorityFeePerGas: `0x${maxPriorityFeePerGas.toString(16)}`,
+    },
+    ep,
+    { [sudoOnly.address]: { balance: `0x${parseEther("1").toString(16)}` } },
+  ]);
+  const sv = read(g);
+  if (sv) {
+    console.log(`  sudo-only (deploy + approve):  verif ${sv.ver} · preVerif ${sv.pre} · call ${sv.call} · raw ${sv.total}`);
+    const wv = read(e);
+    if (wv) {
+      console.log(`  with wall (deploy + enable + approve): verif ${wv.ver} · preVerif ${wv.pre} · call ${wv.call} · raw ${wv.total}`);
+      console.log(`  >>> THE WALL ENABLE COSTS: verif +${wv.ver - sv.ver} · preVerif +${wv.pre - sv.pre} · raw +${wv.total - sv.total}`);
+    }
+  } else console.log(`  REFUSED: ${errText(g.error)}`);
+
+  // ── comparison ─────────────────────────────────────────────────────────
+  console.log(`\n── COMPARISON ────────────────────────────────────────────────`);
+  // (declared above experiment 6)
+  const _unusedRead = (r: { result?: unknown }) => {
+    const o = r.result as Record<string, string> | undefined;
+    if (!o) return null;
+    const n = (k: string) => (o[k] === undefined ? 0n : BigInt(o[k]));
+    const call = n("callGasLimit");
+    const ver = n("verificationGasLimit");
+    const pre = n("preVerificationGas");
+    return { call, ver, pre, total: call + ver + pre };
+  };
+  const withOut = read(a);
+  const withOv = read(b);
+  const row = (label: string, v: { call: bigint; ver: bigint; pre: bigint; total: bigint } | null) =>
+    console.log(
+      `  ${label.padEnd(28)} ${v ? `call ${v.call} · verif ${v.ver} · preVerif ${v.pre} · raw total ${v.total} · ×2 headroom ${v.total * 2n}` : "REFUSED"}`,
+    );
+  row("no override", withOut);
+  row("balance override (swap)", withOv);
+  row("balance override (approve)", read(e));
+  console.log(
+    `  ${"landed sudo deploy".padEnd(28)} call ${LANDED.callGasLimit} · verif ${LANDED.verificationGasLimit} · preVerif ${LANDED.preVerificationGas} · signed ${LANDED.signedTotal} · used ${LANDED.actualGasUsed}`,
+  );
+  console.log(`    (${LANDED.note})`);
+  if (withOv) {
+    const signed = withOv.total * 2n;
+    console.log(`\n  DEPLOY_GAS_BOUNDS.absoluteMax is 8,000,000.`);
+    console.log(`  This op signs ${signed} — ${signed > 8_000_000n ? "OVER the ceiling" : `${((Number(signed) / 8e6) * 100).toFixed(1)}% of it`}.`);
+    console.log(`  ETH required to hold: ${signed} × ${gwei(maxFeePerGas)} = ${(Number(signed * maxFeePerGas) / 1e18).toFixed(6)} ETH`);
+  }
+}
+
+main().catch((e) => {
+  console.error("probe failed:", e instanceof Error ? e.message : String(e));
+  process.exit(1);
+});

--- a/spikes/first-op-gas/reenable.ts
+++ b/spikes/first-op-gas/reenable.ts
@@ -1,0 +1,342 @@
+/**
+ * METHOD A — DIRECT MEASUREMENT OF A RENEWAL ON AN ALREADY-DEPLOYED ACCOUNT.
+ *
+ * PR #56 gates the elevated 12,000,000 ceiling behind
+ * `!accountLive && isFirstEnable(nonce)`. The worry is that the expensive thing
+ * is the PERMISSION-VALIDATOR ENABLE, which is one-time per SESSION KEY and not
+ * one-time per ACCOUNT — so a renewal on a live account pays the same ~7M while
+ * `!accountLive` is false and routes it through the 3,000,000 ceiling.
+ *
+ * Everything up to now has been arithmetic: the undeployed walled op (7,711,654)
+ * minus the sudo-only deploy. This script measures the deployed case DIRECTLY.
+ *
+ * HOW. Build a Kernel account object PINNED (createKernelAccount's `address`
+ * option, which skips CREATE2 derivation) to a REAL deployed Kernel v3.3 account
+ * on 4663, with a FRESH permission validator over a FRESH session key. Send it to
+ * Pimlico for `eth_estimateUserOperationGas` with NO factory/factoryData — so the
+ * bundler simulates an enable against an account that already has code.
+ *
+ * The one obstacle: Kernel's `_checkEnableSig` REVERTS if the owner's EIP-712
+ * enable signature does not verify, and the real owner's key is not mine and
+ * must never be touched. So the estimate carries a `stateDiff` override that
+ * points the ECDSAValidator's owner slot for that account at MY throwaway key.
+ * The slot formula (keccak256(abi.encode(account, uint256(0))) on the validator
+ * contract) is VERIFIED IN-SCRIPT against the contract's own
+ * ecdsaValidatorStorage(address) view before it is used — if they disagree the
+ * script says so and refuses to report a number.
+ *
+ * NOTHING IS SIGNED FOR BROADCAST AND NOTHING IS BROADCAST.
+ * eth_estimateUserOperationGas is a simulation; both overrides live only inside
+ * that RPC call. The owner key is generated here, never funded, never written to
+ * disk, and the only thing it signs is an EIP-712 blob that exists solely inside
+ * an estimation request. No real grant is read, re-signed or mutated. No
+ * transaction, no UserOperation, no funding, no deploy.
+ *
+ * Run: railway run --service orchestrator -- npx tsx spikes/first-op-gas/reenable.ts
+ */
+import {
+  createPublicClient, encodeAbiParameters, encodeFunctionData, erc20Abi, http,
+  keccak256, type Address, type Hex,
+} from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { getEntryPoint, KERNEL_V3_3 } from "@zerodev/sdk/constants";
+import { createKernelAccount } from "@zerodev/sdk";
+import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
+import { toPermissionValidator } from "@zerodev/permissions";
+import { toECDSASigner } from "@zerodev/permissions/signers";
+import {
+  buildWallPolicies, CASH, chainForId, pimlicoBundlerUrl, UNISWAP, WALL_POLICY_FLAG,
+} from "../../packages/core/src/index";
+
+const CHAIN_ID = 4663;
+const RPC = "https://rpc.mainnet.chain.robinhood.com";
+const CAPS = { perTradeUsdg: 50, dailyUsdg: 500, expiryDays: 14, maxDrawdownPct: 10, maxOpsPerDay: 48 };
+
+/** @zerodev/ecdsa-validator for kernel >=0.3.1, the root validator on 2,110 of
+ *  the 2,208 ZeroDev accounts on 4663 (phase 1). */
+const ECDSA_VALIDATOR = "0x845ADb2C711129d4f3966735eD98a9F09fC4cE57" as Address;
+
+/** REAL, already-deployed Kernel v3.3 accounts on 4663 (phase 1, impl-slot
+ *  verified). The first is merrymen's own; the second is the account whose
+ *  landed deploy+wall-enable signed 8,972,828 verification gas. */
+const TARGETS: Array<{ label: string; address: Address }> = [
+  { label: "merrymen's own account (deployed block 51,207,025)", address: "0x032Da6A0Ccf866474e45854E7fDEF9afd1509036" },
+  { label: "a second live v3.3 account (deployed block 51,847,124)", address: "0xa48cE91e2F3237E69660C1543042c007B8D33e75" },
+];
+
+/** The undeployed WALLED first op this whole question is anchored to. */
+const UNDEPLOYED_ANCHOR = { ver: 7_418_031n, pre: 243_443n, call: 50_180n, raw: 7_711_654n };
+
+// gas-limits.ts:118-129 — identical on GAS_BOUNDS and FIRST_ENABLE_GAS_BOUNDS.
+const CALL_BPS = 20_000n, VER_BPS = 12_500n, PRE_BPS = 12_500n;
+const bound = (call: bigint, ver: bigint, pre: bigint) =>
+  (call * CALL_BPS) / 10_000n + (ver * VER_BPS) / 10_000n + (pre * PRE_BPS) / 10_000n;
+
+type RpcOut = { result?: unknown; error?: { message?: string; code?: unknown; data?: unknown } };
+async function rpc(url: string, method: string, params: unknown[]): Promise<RpcOut> {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    try {
+      const r = await fetch(url, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      });
+      const j = (await r.json()) as RpcOut;
+      const msg = String(j.error?.message ?? "");
+      if (/too many requests|rate limit/i.test(msg) && attempt < 3) {
+        await new Promise((s) => setTimeout(s, 800 * 2 ** attempt));
+        continue;
+      }
+      return j;
+    } catch (e) {
+      if (attempt === 3) return { error: { message: e instanceof Error ? e.message : String(e) } };
+      await new Promise((s) => setTimeout(s, 800 * 2 ** attempt));
+    }
+  }
+  return { error: { message: "unreachable" } };
+}
+
+function errText(e: RpcOut["error"]): string {
+  return [e?.code !== undefined ? `code ${String(e.code)}` : "", e?.message ?? "",
+    typeof e?.data === "string" ? e.data : ""].filter(Boolean).join(" · ").slice(0, 300);
+}
+
+/** null means UNREAD — never "zero". */
+function read(r: RpcOut): { call: bigint; ver: bigint; pre: bigint; raw: bigint } | null {
+  const o = r.result as Record<string, string> | undefined;
+  if (!o) return null;
+  const n = (k: string) => (o[k] === undefined ? 0n : BigInt(o[k]));
+  const call = n("callGasLimit"), ver = n("verificationGasLimit"), pre = n("preVerificationGas");
+  return { call, ver, pre, raw: call + ver + pre };
+}
+
+const modeOf = (n: bigint) => `0x${((n >> 248n) & 0xffn).toString(16).padStart(2, "0")}`;
+const vTypeOf = (n: bigint) => `0x${((n >> 240n) & 0xffn).toString(16).padStart(2, "0")}`;
+
+async function main() {
+  const apiKey = process.env.MERRYMEN_BUNDLER_API_KEY;
+  if (!apiKey) { console.error("no MERRYMEN_BUNDLER_API_KEY — run under `railway run --service orchestrator --`"); process.exit(1); }
+  const bundler = pimlicoBundlerUrl(CHAIN_ID, apiKey);
+  const chain = chainForId(CHAIN_ID);
+  const publicClient = createPublicClient({ chain, transport: http(RPC) });
+  const entryPoint = getEntryPoint("0.7");
+  const ep = entryPoint.address;
+
+  const fees = await publicClient.estimateFeesPerGas().catch(() => null);
+  const maxFeePerGas = fees?.maxFeePerGas ?? 1_000_000_000n;
+  const maxPriorityFeePerGas = fees?.maxPriorityFeePerGas ?? 0n;
+  // Sized as the 12M branch would (executor.ts ~line 325). Deliberately generous:
+  // this script is measuring the OPERATION, not re-testing the prefund gate.
+  const BAL = 12_000_000n * maxFeePerGas * 4n;
+  console.log(`bundler host ${new URL(bundler).host} · chain ${CHAIN_ID} · maxFeePerGas ${maxFeePerGas} wei`);
+  console.log(`balance override used everywhere: ${BAL} wei (buys ${BAL / maxFeePerGas} gas)\n`);
+
+  const approveCall = {
+    to: CASH.USDG as Address, value: 0n,
+    data: encodeFunctionData({ abi: erc20Abi, functionName: "approve", args: [UNISWAP.swapRouter02 as Address, 5_000_000n] }),
+  };
+
+  // ── ONE throwaway owner key, reused for every arm ───────────────────────────
+  const ownerKey = generatePrivateKey();
+  const owner = privateKeyToAccount(ownerKey);
+  const ecdsa = await signerToEcdsaValidator(publicClient, { signer: owner, entryPoint, kernelVersion: KERNEL_V3_3 });
+  console.log(`throwaway owner ${owner.address} (generated here; never funded, never written to disk)\n`);
+
+  // ── STEP 0. VERIFY THE OWNER-SLOT FORMULA BEFORE RELYING ON IT ──────────────
+  console.log(`── STEP 0. owner-slot formula check on ${ECDSA_VALIDATOR} ──────────────`);
+  const slotOf = (acct: Address): Hex =>
+    keccak256(encodeAbiParameters([{ type: "address" }, { type: "uint256" }], [acct, 0n]));
+  const slotOk: Record<string, boolean> = {};
+  for (const t of TARGETS) {
+    const raw = await rpc(RPC, "eth_getStorageAt", [ECDSA_VALIDATOR, slotOf(t.address), "latest"]);
+    const view = await rpc(RPC, "eth_call", [
+      { to: ECDSA_VALIDATOR, data: ("0x20709efc" + t.address.slice(2).toLowerCase().padStart(64, "0")) as Hex },
+      "latest",
+    ]);
+    const rawOwner = typeof raw.result === "string" ? `0x${raw.result.slice(-40)}` : null;
+    const viewOwner = typeof view.result === "string" && view.result.length >= 66 ? `0x${view.result.slice(26, 66)}` : null;
+    if (rawOwner === null || viewOwner === null) {
+      console.log(`  ${t.address}  UNREAD (storage ${rawOwner === null ? "unread" : "ok"}, view ${viewOwner === null ? "unread" : "ok"}) — NOT "no owner"`);
+      slotOk[t.address] = false;
+      continue;
+    }
+    const agree = rawOwner.toLowerCase() === viewOwner.toLowerCase();
+    slotOk[t.address] = agree;
+    console.log(`  ${t.address}  slot ${slotOf(t.address)}`);
+    console.log(`     storage owner ${rawOwner} · view owner ${viewOwner} · ${agree ? "AGREE — formula good" : "DISAGREE — formula WRONG, will not report a number for this target"}`);
+  }
+  console.log();
+
+  // ══ CONTROL (b): THE SAME WALL ON AN UNDEPLOYED SYNTHETIC ACCOUNT ═══════════
+  console.log(`══ CONTROL (b): same wall, UNDEPLOYED synthetic account (must reproduce ~7,711,654) ══`);
+  const sudoOnlySynthetic = await createKernelAccount(publicClient, {
+    entryPoint, kernelVersion: KERNEL_V3_3, plugins: { sudo: ecdsa },
+  });
+  const synthPerm = await toPermissionValidator(publicClient, {
+    entryPoint, kernelVersion: KERNEL_V3_3,
+    signer: await toECDSASigner({ signer: privateKeyToAccount(generatePrivateKey()) }),
+    policies: buildWallPolicies({ caps: CAPS, smartAccount: sudoOnlySynthetic.address }).policies,
+    flag: WALL_POLICY_FLAG,
+  });
+  const synthAccount = await createKernelAccount(publicClient, {
+    entryPoint, kernelVersion: KERNEL_V3_3, plugins: { sudo: ecdsa, regular: synthPerm },
+  });
+  {
+    const sender = synthAccount.address as Address;
+    const code = await publicClient.getCode({ address: sender }).catch(() => "UNREAD" as const);
+    const factoryArgs = await synthAccount.getFactoryArgs();
+    const nonce = await synthAccount.getNonce();
+    const callData = await synthAccount.encodeCalls([approveCall]);
+    const stub = await synthAccount.getStubSignature({
+      sender, nonce, callData, callGasLimit: 0n, verificationGasLimit: 0n, preVerificationGas: 0n,
+      maxFeePerGas: 0n, maxPriorityFeePerGas: 0n, signature: "0x", ...factoryArgs,
+    } as never);
+    console.log(`  sender ${sender} · code ${code === "UNREAD" ? "UNREAD" : code && code !== "0x" ? `${(code.length - 2) / 2} bytes (UNEXPECTED)` : "none — counterfactual, as required"}`);
+    console.log(`  nonce mode ${modeOf(nonce)} vType ${vTypeOf(nonce)} · initCode ${String(factoryArgs.factoryData).length / 2 - 1} bytes · stub sig ${stub.length / 2 - 1} bytes`);
+    const r = await rpc(bundler, "eth_estimateUserOperationGas", [
+      {
+        sender, nonce: `0x${nonce.toString(16)}`, factory: factoryArgs.factory, factoryData: factoryArgs.factoryData,
+        callData, signature: stub,
+        maxFeePerGas: `0x${maxFeePerGas.toString(16)}`, maxPriorityFeePerGas: `0x${maxPriorityFeePerGas.toString(16)}`,
+      }, ep, { [sender]: { balance: `0x${BAL.toString(16)}` } },
+    ]);
+    const v = read(r);
+    if (!v) console.log(`  CONTROL (b) FAILED — no number came back: ${errText(r.error)}\n`);
+    else {
+      const drift = Number(v.raw - UNDEPLOYED_ANCHOR.raw) / Number(UNDEPLOYED_ANCHOR.raw);
+      console.log(`  verif ${v.ver} · preVerif ${v.pre} · call ${v.call} · RAW ${v.raw}`);
+      console.log(`  vs anchor 7,711,654 → drift ${(drift * 100).toFixed(2)}% · ${Math.abs(drift) < 0.05 ? "CONTROL (b) PASSES — harness matches probe.ts" : "CONTROL (b) FAILS — harness differs from probe.ts"}\n`);
+    }
+  }
+
+  // ══ THE MAIN MEASUREMENT, PER TARGET ════════════════════════════════════════
+  for (const t of TARGETS) {
+    console.log(`══════════════════════════════════════════════════════════════════════`);
+    console.log(`TARGET ${t.address}`);
+    console.log(`  ${t.label}`);
+    const code = await publicClient.getCode({ address: t.address }).catch(() => undefined);
+    if (!code || code === "0x") { console.log(`  code: none or UNREAD — skipping, this target is not usable\n`); continue; }
+    console.log(`  code ${(code.length - 2) / 2} bytes → isDeployed() would return TRUE (accountLive = true)`);
+
+    // ── CONTROL (a): the same deployed account, SUDO-ONLY ────────────────────
+    console.log(`\n  ── CONTROL (a): same deployed account, sudo-only (no permission validator) ──`);
+    const sudoPinned = await createKernelAccount(publicClient, {
+      entryPoint, kernelVersion: KERNEL_V3_3, plugins: { sudo: ecdsa }, address: t.address,
+    });
+    let controlAok = false;
+    {
+      const nonce = await sudoPinned.getNonce();
+      const callData = await sudoPinned.encodeCalls([approveCall]);
+      const stub = await sudoPinned.getStubSignature({
+        sender: t.address, nonce, callData, callGasLimit: 0n, verificationGasLimit: 0n, preVerificationGas: 0n,
+        maxFeePerGas: 0n, maxPriorityFeePerGas: 0n, signature: "0x",
+      } as never);
+      console.log(`     nonce ${nonce} → mode ${modeOf(nonce)} vType ${vTypeOf(nonce)} (expect 0x00 / 0x00) · stub sig ${stub.length / 2 - 1} bytes`);
+      const r = await rpc(bundler, "eth_estimateUserOperationGas", [
+        {
+          sender: t.address, nonce: `0x${nonce.toString(16)}`, callData, signature: stub,
+          maxFeePerGas: `0x${maxFeePerGas.toString(16)}`, maxPriorityFeePerGas: `0x${maxPriorityFeePerGas.toString(16)}`,
+        }, ep, { [t.address]: { balance: `0x${BAL.toString(16)}` } },
+      ]);
+      const v = read(r);
+      if (!v) console.log(`     CONTROL (a) FAILED — no number: ${errText(r.error)}\n     => the overrides/shape are wrong; treat the main number below as WORTHLESS`);
+      else {
+        controlAok = v.raw < 400_000n;
+        console.log(`     verif ${v.ver} · preVerif ${v.pre} · call ${v.call} · RAW ${v.raw}`);
+        console.log(`     ${controlAok ? "CONTROL (a) PASSES — cheap and clean on a live account" : "CONTROL (a) SUSPECT — not cheap (>400k); the main number below is doubtful"}`);
+      }
+    }
+
+    // ── THE RENEWAL: fresh session key, fresh wall, on this LIVE account ─────
+    console.log(`\n  ── THE RENEWAL: fresh session key + fresh 18-permission wall on this LIVE account ──`);
+    const sessionKey = generatePrivateKey();
+    const { policies } = buildWallPolicies({ caps: CAPS, smartAccount: t.address });
+    const permission = await toPermissionValidator(publicClient, {
+      entryPoint, kernelVersion: KERNEL_V3_3,
+      signer: await toECDSASigner({ signer: privateKeyToAccount(sessionKey) }),
+      policies, flag: WALL_POLICY_FLAG,
+    });
+    const renewAccount = await createKernelAccount(publicClient, {
+      entryPoint, kernelVersion: KERNEL_V3_3, plugins: { sudo: ecdsa, regular: permission }, address: t.address,
+    });
+    if ((renewAccount.address as string).toLowerCase() !== t.address.toLowerCase()) {
+      console.log(`     PINNING FAILED — account came back as ${renewAccount.address}; skipping target\n`);
+      continue;
+    }
+
+    // STEP 3 of the plan: the nonce alone, before any estimate, costs nothing.
+    const nonce = await renewAccount.getNonce();
+    console.log(`     permissionId ${permission.getIdentifier()}`);
+    console.log(`     nonce 0x${nonce.toString(16).padStart(64, "0")}`);
+    console.log(`     mode ${modeOf(nonce)} ${modeOf(nonce) === "0x01" ? "(ENABLE)" : "(NOT ENABLE)"} · vType ${vTypeOf(nonce)} ${vTypeOf(nonce) === "0x02" ? "(PERMISSION)" : ""}`);
+    const isFirstEnable = modeOf(nonce) === "0x01" && vTypeOf(nonce) === "0x02";
+    console.log(`     isFirstEnable(nonce) = ${isFirstEnable}   accountLive = true   =>  PR#56 firstEnable = ${!true && isFirstEnable}  =>  ceiling ${isFirstEnable ? "3,000,000 (GAS_BOUNDS)" : "3,000,000"}`);
+
+    const callData = await renewAccount.encodeCalls([approveCall]);
+    // getStubSignature builds the REAL enable blob: it signs the EIP-712 enable
+    // typed data with the throwaway owner (local signing only) and nests a dummy
+    // userOp signature. That is exactly the blob a renewal's first op carries.
+    const stub = await renewAccount.getStubSignature({
+      sender: t.address, nonce, callData, callGasLimit: 0n, verificationGasLimit: 0n, preVerificationGas: 0n,
+      maxFeePerGas: 0n, maxPriorityFeePerGas: 0n, signature: "0x",
+    } as never);
+    console.log(`     enable blob (stub signature) ${stub.length / 2 - 1} bytes · NO factory / NO factoryData sent`);
+
+    const op = {
+      sender: t.address, nonce: `0x${nonce.toString(16)}`, callData, signature: stub,
+      maxFeePerGas: `0x${maxFeePerGas.toString(16)}`, maxPriorityFeePerGas: `0x${maxPriorityFeePerGas.toString(16)}`,
+    };
+    const balOnly = { [t.address]: { balance: `0x${BAL.toString(16)}` } };
+    const ownerOverride = {
+      [t.address]: { balance: `0x${BAL.toString(16)}` },
+      [ECDSA_VALIDATOR]: { stateDiff: { [slotOf(t.address)]: `0x${owner.address.slice(2).toLowerCase().padStart(64, "0")}` } },
+    };
+
+    // NEGATIVE CONTROL: without the owner override the enable signature is not
+    // the real owner's, so Kernel must reject it. If this SUCCEEDS, the override
+    // is not what is making the main number possible and something is wrong.
+    console.log(`\n     NEGATIVE CONTROL: same op, balance override only (no owner override)`);
+    const neg = await rpc(bundler, "eth_estimateUserOperationGas", [op, ep, balOnly]);
+    const negV = read(neg);
+    console.log(`       ${negV ? `UNEXPECTEDLY SUCCEEDED: raw ${negV.raw} — the enable sig was not actually checked` : `refused (expected): ${errText(neg.error)}`}`);
+
+    if (!slotOk[t.address]) {
+      console.log(`\n     MAIN MEASUREMENT SKIPPED — the owner-slot formula did not verify for this target (step 0). Not a zero; unmeasured.\n`);
+      continue;
+    }
+    console.log(`\n     MAIN: same op + owner-slot stateDiff pointing at the throwaway key`);
+    const main = await rpc(bundler, "eth_estimateUserOperationGas", [op, ep, ownerOverride]);
+    const v = read(main);
+    if (!v) {
+      console.log(`       NO NUMBER — BLOCKED: ${errText(main.error)}`);
+      console.log(`       This is "I could not measure it", NOT "it costs nothing".\n`);
+      continue;
+    }
+    const b = bound(v.call, v.ver, v.pre);
+    console.log(`       verif ${v.ver} · preVerif ${v.pre} · call ${v.call} · RAW TOTAL ${v.raw}`);
+    console.log(`       bounded (2.0x call, 1.25x verif, 1.25x preVerif) = ${b}`);
+
+    // WHAT THE EXECUTOR ACTUALLY DOES. executor.ts sizes the estimate's balance
+    // override from the ceiling it already picked (bounds.absoluteMax x feeCeiling
+    // x 2). A renewal takes the 3M branch, so the simulation is handed 6,000,000
+    // gas' worth of imaginary ETH for an operation needing ~7.5M.
+    console.log(`\n     WHAT THE EXECUTOR'S OWN 3M-SIZED OVERRIDE PRODUCES (3,000,000 x feeCeiling x 2):`);
+    const smallBal = 3_000_000n * maxFeePerGas * 2n;
+    const smallOverride = {
+      [t.address]: { balance: `0x${smallBal.toString(16)}` },
+      [ECDSA_VALIDATOR]: { stateDiff: { [slotOf(t.address)]: `0x${owner.address.slice(2).toLowerCase().padStart(64, "0")}` } },
+    };
+    const small = await rpc(bundler, "eth_estimateUserOperationGas", [op, ep, smallOverride]);
+    const sv = read(small);
+    console.log(`       override ${smallBal} wei (buys ${smallBal / maxFeePerGas} gas)`);
+    console.log(`       ${sv ? `-> raw ${sv.raw} -> bounded ${bound(sv.call, sv.ver, sv.pre)} -> rule "gas-absurd"` : `-> REFUSED: ${errText(small.error)}\n       -> boundGas is handed null -> rule "gas-unreadable" (no gas figure ever logged)`}`);
+    console.log(`\n     ── VERDICT FOR THIS TARGET ──`);
+    console.log(`       deployed re-enable RAW   ${v.raw}`);
+    console.log(`       undeployed first op RAW  ${UNDEPLOYED_ANCHOR.raw}  (verif ${UNDEPLOYED_ANCHOR.ver} · preVerif ${UNDEPLOYED_ANCHOR.pre} · call ${UNDEPLOYED_ANCHOR.call})`);
+    console.log(`       delta                    ${v.raw - UNDEPLOYED_ANCHOR.raw}  (${((Number(v.raw) / Number(UNDEPLOYED_ANCHOR.raw)) * 100).toFixed(1)}% of the undeployed op)`);
+    console.log(`       vs GAS_BOUNDS 3,000,000            bounded ${b} => ${b > 3_000_000n ? "REFUSED (gas-absurd)" : "accepted"}   [what PR#56 gives a renewal]`);
+    console.log(`       vs FIRST_ENABLE_GAS_BOUNDS 12,000,000  bounded ${b} => ${b > 12_000_000n ? "REFUSED" : "accepted"}   [what it gives an undeployed first op]`);
+    console.log(`       control (a) status: ${controlAok ? "passed" : "NOT passed — discount this number"}\n`);
+  }
+}
+
+main().catch((e) => { console.error("reenable failed:", e instanceof Error ? e.message : String(e)); process.exit(1); });

--- a/spikes/first-op-gas/shape.ts
+++ b/spikes/first-op-gas/shape.ts
@@ -1,0 +1,504 @@
+/**
+ * METHOD C — MEASURE THE *SHAPE*, NOT THE COST.
+ *
+ * The claim under test has two halves:
+ *   (i)  a DEPLOYED account + a FRESH session key still produces an ENABLE-mode nonce
+ *   (ii) that operation is expensive
+ *
+ * (ii) needs a bundler. (i) does not — it is decided entirely by
+ * `isPluginEnabled(validator, id)` inside @zerodev/sdk, which is one eth_call.
+ * So this spike nails (i) exhaustively with pure RPC READS, and it also tests
+ * the two things nobody has tested yet:
+ *
+ *   THE CONVERSE. For an account where a permission validator IS already
+ *   installed, does the nonce drop back to mode 0x00? That is the steady-state
+ *   the 3,000,000 ceiling actually exists for, and any fix must keep it working.
+ *
+ *   THE FAILURE MODE. isPluginEnabled's on-chain read is wrapped in a
+ *   `try { … } catch { return false }`. So what does a transient RPC error do to
+ *   the nonce mode — claim ENABLE (fail-open, a cheap op gets the wide ceiling)
+ *   or claim DEFAULT (fail-closed, a real renewal gets refused by a blip)?
+ *   Proven here from source AND by surgical fault injection.
+ *
+ * READ-ONLY, ABSOLUTELY. Every chain call is eth_call or eth_getCode. Nothing is
+ * signed, nothing is broadcast, no grant is read or mutated, no account is
+ * funded, nothing is deployed. The sudo/session keys are generated per run,
+ * never funded, never written to disk — they exist only so the SDK will build a
+ * plugin manager we can interrogate. The fault injection is LOCAL: it makes our
+ * own client throw before the request leaves the process.
+ *
+ * A read that never succeeded prints UNREAD. "I could not read it" is never
+ * reported as "there is nothing there".
+ *
+ * Run: npx tsx spikes/first-op-gas/shape.ts        (no bundler key needed)
+ */
+import { createPublicClient, custom, http, toFunctionSelector, type Address, type Hex } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { getEntryPoint, KERNEL_V3_3 } from "@zerodev/sdk/constants";
+import { createKernelAccount } from "@zerodev/sdk";
+import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
+import { toPermissionValidator } from "@zerodev/permissions";
+import { toECDSASigner } from "@zerodev/permissions/signers";
+import { buildWallPolicies, buildCallPermissions, chainForId, WALL_POLICY_FLAG } from "../../packages/core/src/index";
+// The repo's OWN ceiling logic, imported rather than retyped, so section 5 is
+// the real verdict and not a reconstruction of one.
+import { boundGas, GAS_BOUNDS, FIRST_ENABLE_GAS_BOUNDS } from "../../worker/src/gas-limits";
+
+const RPC = "https://rpc.mainnet.chain.robinhood.com";
+const CAPS = { perTradeUsdg: 50, dailyUsdg: 500, expiryDays: 14, maxDrawdownPct: 10, maxOpsPerDay: 48 };
+const entryPoint = getEntryPoint("0.7");
+
+/** The exact PR #56 predicates, copied from worker/src/executor.ts:154-158 and :389-392. */
+const isFirstEnable = (n: bigint) => ((n >> 248n) & 0xffn) === 0x01n && ((n >> 240n) & 0xffn) === 0x02n;
+const GAS_ABS_MAX = 3_000_000n;
+const FIRST_ENABLE_ABS_MAX = 12_000_000n;
+
+const modeOf = (n: bigint) => Number((n >> 248n) & 0xffn);
+const vTypeOf = (n: bigint) => Number((n >> 240n) & 0xffn);
+const identOf = (n: bigint) => `0x${((n >> 80n) & ((1n << 160n) - 1n)).toString(16).padStart(40, "0")}`;
+const hx = (n: number) => `0x${n.toString(16).padStart(2, "0")}`;
+
+/** permissionConfig(bytes4) — the ONE call isPluginEnabled makes for a permission validator. */
+const PERMISSION_CONFIG_SELECTOR = toFunctionSelector("permissionConfig(bytes4)");
+
+/**
+ * The signer contract `isEnabled` compares the stored config against. Filled in
+ * at runtime from a real `toECDSASigner`, so it is literally
+ * `signer.signerContractAddress` — the same value toPermissionValidator.ts:154
+ * tests — rather than a constant retyped by hand here.
+ */
+let ECDSA_SIGNER_CONTRACT = "0x0000000000000000000000000000000000000000";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A transport we can count and, on demand, break — locally, before the wire.
+// ─────────────────────────────────────────────────────────────────────────────
+type Req = { method: string; params: unknown };
+let LOG: Req[] = [];
+/** When set, any request this returns a string for is thrown instead of sent. */
+let FAULT: ((r: Req) => string | null) | null = null;
+
+async function wire(method: string, params: unknown): Promise<unknown> {
+  let last = "";
+  for (let i = 0; i < 12; i++) {
+    try {
+      const r = await fetch(RPC, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      });
+      const j = (await r.json()) as { result?: unknown; error?: { message?: string } };
+      if (j.error) {
+        last = j.error.message ?? "rpc error";
+        if (/too many requests|rate/i.test(last)) {
+          await new Promise((s) => setTimeout(s, Math.min(700 * 2 ** i, 12_000)));
+          continue;
+        }
+        throw new Error(last);
+      }
+      return j.result;
+    } catch (e) {
+      last = String(e instanceof Error ? e.message : e).split("\n")[0]!.slice(0, 160);
+      if (!/fetch|network|too many|rate|timeout|ECONN/i.test(last)) throw e;
+      await new Promise((s) => setTimeout(s, Math.min(700 * 2 ** i, 12_000)));
+    }
+  }
+  throw new Error(`UNREAD after 12 attempts: ${method} — ${last}`);
+}
+
+const transport = custom(
+  {
+    async request({ method, params }: { method: string; params?: unknown }) {
+      const r: Req = { method, params };
+      LOG.push(r);
+      const f = FAULT?.(r);
+      if (f) throw new Error(f);
+      return wire(method, params);
+    },
+  },
+  { retryCount: 0 },
+);
+
+const publicClient = createPublicClient({ chain: chainForId(4663), transport });
+
+/** Did this request go to `to` with our permissionConfig selector? */
+function isPermissionConfigCall(r: Req, to?: Address): boolean {
+  if (r.method !== "eth_call") return false;
+  const p = (r.params as [{ to?: string; data?: string }] | undefined)?.[0];
+  if (!p?.data || !p.data.toLowerCase().startsWith(PERMISSION_CONFIG_SELECTOR.toLowerCase())) return false;
+  return to ? (p.to ?? "").toLowerCase() === to.toLowerCase() : true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Subjects
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * REAL, ALREADY-DEPLOYED accounts on 4663. Provenance: EntryPoint 0.7
+ * AccountDeployed logs, ERC-1967 impl slot read (spikes/first-op-gas/impl-sweep.mjs).
+ * The first is merrymen's own account.
+ */
+const DEPLOYED: { addr: Address; note: string }[] = [
+  { addr: "0x032da6a0ccf866474e45854e7fdef9afd1509036", note: "merrymen's own account, kernel v3.3, deployed block 51207025" },
+  { addr: "0x26e1b523189ec668654680178ad7ab07ff2c71ae", note: "kernel v3.3, deployed block 52240294" },
+  { addr: "0x4460f7926eb4979b27f171464691cf8374f02240", note: "kernel v3.3, deployed block 52456590" },
+  { addr: "0xfd58500678406d33293ecad9976c6c5ee653eca1", note: "kernel v3.3, deployed block 51367467" },
+];
+
+/**
+ * Accounts with a permission validator PROVABLY INSTALLED — each landed a
+ * successful mode 0x01 / vType 0x02 UserOperation carrying this permissionId
+ * (spikes/first-op-gas/perm-ops.json). The install is verified again on-chain
+ * below by reading permissionConfig directly.
+ */
+const INSTALLED: { addr: Address; pid: Hex; note: string }[] = [
+  { addr: "0xa48ce91e2f3237e69660c1543042c007b8d33e75", pid: "0x3ca1cec8", note: "kernel v3.3, enable landed block 51847124" },
+  { addr: "0x26e1b523189ec668654680178ad7ab07ff2c71ae", pid: "0xad16ecaa", note: "kernel v3.3, enable landed block 52240294" },
+  { addr: "0xd535491c7cf0e72ac9151b94a1feebd3942d8af7", pid: "0x39c384a8", note: "kernel v3.3, enable landed block 46988297" },
+  { addr: "0x4986995b4ca6fdc838a01a61967daa50d2b854e9", pid: "0xecd39ec5", note: "kernel v3.1, enable landed block 53045103 (most recent on chain)" },
+];
+
+/** Synthetic "owner-added token" addresses. Never called, never funded — they only widen the wall. */
+const FAKE_TOKEN = (i: number) => ({
+  symbol: `EX${i}`,
+  address: `0x${(0xe0000000000000000000000000000000000000n + BigInt(i)).toString(16).padStart(40, "0")}` as Address,
+  decimals: 18,
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log("METHOD C — SHAPE, NOT COST.  READ-ONLY: eth_call / eth_getCode only.");
+  console.log("Nothing signed. Nothing broadcast. No grant touched. No account funded.\n");
+  ECDSA_SIGNER_CONTRACT = (await toECDSASigner({ signer: privateKeyToAccount(generatePrivateKey()) })).signerContractAddress;
+  console.log(`permissionConfig(bytes4) selector = ${PERMISSION_CONFIG_SELECTOR}`);
+  console.log(`signer.signerContractAddress      = ${ECDSA_SIGNER_CONTRACT}  (read off a real toECDSASigner)\n`);
+
+  // one sudo validator, reused, to keep RPC load down
+  const ecdsa = await signerToEcdsaValidator(publicClient, {
+    signer: privateKeyToAccount(generatePrivateKey()),
+    entryPoint,
+    kernelVersion: KERNEL_V3_3,
+  });
+
+  const code = new Map<string, string | null>();
+  const getCode = async (a: Address) => {
+    const k = a.toLowerCase();
+    if (code.has(k)) return code.get(k)!;
+    try {
+      const c = (await wire("eth_getCode", [a, "latest"])) as string;
+      code.set(k, c);
+      return c;
+    } catch (e) {
+      console.log(`  UNREAD eth_getCode ${a}: ${String(e).slice(0, 120)}`);
+      code.set(k, null);
+      return null;
+    }
+  };
+
+  /**
+   * Build the account the WORKER would build against `addr`, with a given
+   * session key / wall / (optionally) an explicit permissionId, and read the
+   * nonce the SDK computes. Returns null only if a read failed.
+   */
+  const probe = async (opts: {
+    addr: Address;
+    sessionKey: Hex;
+    extraTokens?: { symbol: string; address: Address; decimals: number }[];
+    permissionId?: Hex;
+    now?: number;
+  }) => {
+    const signer = await toECDSASigner({ signer: privateKeyToAccount(opts.sessionKey) });
+    const { policies } = buildWallPolicies({
+      caps: CAPS,
+      smartAccount: opts.addr,
+      now: opts.now,
+      extraTokens: opts.extraTokens,
+    });
+    const permission = await toPermissionValidator(publicClient, {
+      entryPoint,
+      kernelVersion: KERNEL_V3_3,
+      signer,
+      policies,
+      flag: WALL_POLICY_FLAG,
+      ...(opts.permissionId ? { permissionId: opts.permissionId } : {}),
+    });
+    const account = await createKernelAccount(publicClient, {
+      entryPoint,
+      kernelVersion: KERNEL_V3_3,
+      address: opts.addr,
+      plugins: { sudo: ecdsa, regular: permission },
+    });
+    const pid = permission.getIdentifier();
+    const perms = buildCallPermissions(CAPS, opts.addr, { extraTokens: opts.extraTokens });
+    LOG = [];
+    const nonce = await account.getNonce();
+    const calls = LOG.filter((r) => isPermissionConfigCall(r, opts.addr)).length;
+    return { pid, nonce, permCalls: calls, nPermissions: perms.length, validatorAddress: permission.address as Address };
+  };
+
+  const verdict = (accountLive: boolean, nonce: bigint) => {
+    const first = isFirstEnable(nonce);
+    const pr56 = !accountLive && first;
+    return {
+      first,
+      pr56,
+      ceiling: pr56 ? FIRST_ENABLE_ABS_MAX : GAS_ABS_MAX,
+      boundsName: pr56 ? "FIRST_ENABLE_GAS_BOUNDS" : "GAS_BOUNDS",
+    };
+  };
+
+  const row = (label: string, live: boolean | null, pid: Hex, nonce: bigint, permCalls: number, nPerm: number) => {
+    const v = verdict(live === true, nonce);
+    console.log(
+      `  ${label.padEnd(46)} pId ${pid}  perms ${String(nPerm).padStart(2)}  ` +
+        `mode ${hx(modeOf(nonce))} vType ${hx(vTypeOf(nonce))}  ` +
+        `${modeOf(nonce) === 1 ? "ENABLE " : "DEFAULT"}  ` +
+        `permissionConfig calls ${permCalls}  ` +
+        `isFirstEnable ${String(v.first).padEnd(5)}  PR#56 firstEnable ${String(v.pr56).padEnd(5)}  ceiling ${v.ceiling.toLocaleString("en-US")}`,
+    );
+  };
+
+  // ═══ SECTION 1 ════════════════════════════════════════════════════════════
+  // DEPLOYED ACCOUNT + FRESH SESSION KEY. Vary the wall, the key, and repeat.
+  console.log("── 1. REAL DEPLOYED ACCOUNTS + A FRESH PERMISSION VALIDATOR ─────────────────\n");
+
+  const keyA = generatePrivateKey();
+  const keyB = generatePrivateKey();
+  const FIXED_NOW = 1_756_800_000; // pinned so "same key twice" is genuinely identical
+
+  for (const s of DEPLOYED) {
+    const c = await getCode(s.addr);
+    const live = c === null ? null : c !== "0x" && c.length > 2;
+    console.log(`${s.addr}  (${s.note})`);
+    console.log(`  code: ${c === null ? "UNREAD — not 'absent'" : `${(c.length - 2) / 2} bytes`}   isDeployed() would return: ${live === null ? "UNREAD" : live ? "TRUE" : "FALSE"}`);
+    if (live === null) {
+      console.log("  skipping the nonce probes for this account — its deployment state is UNREAD, not false.\n");
+      continue;
+    }
+
+    const cases: { label: string; o: Parameters<typeof probe>[0] }[] = [
+      { label: "full wall, session key A", o: { addr: s.addr, sessionKey: keyA, now: FIXED_NOW } },
+      { label: "full wall, session key A (repeat, identical)", o: { addr: s.addr, sessionKey: keyA, now: FIXED_NOW } },
+      { label: "full wall, session key B", o: { addr: s.addr, sessionKey: keyB, now: FIXED_NOW } },
+      { label: "SAME key A, grant 1 second later", o: { addr: s.addr, sessionKey: keyA, now: FIXED_NOW + 1 } },
+      { label: "wall +1 custom token, key A", o: { addr: s.addr, sessionKey: keyA, now: FIXED_NOW, extraTokens: [FAKE_TOKEN(1)] } },
+      { label: "wall +5 custom tokens, key A", o: { addr: s.addr, sessionKey: keyA, now: FIXED_NOW, extraTokens: [1, 2, 3, 4, 5].map(FAKE_TOKEN) } },
+      { label: "wall +20 custom tokens, key A", o: { addr: s.addr, sessionKey: keyA, now: FIXED_NOW, extraTokens: Array.from({ length: 20 }, (_, i) => FAKE_TOKEN(i + 1)) } },
+    ];
+    for (const cse of cases) {
+      try {
+        const r = await probe(cse.o);
+        row(cse.label, live, r.pid, r.nonce, r.permCalls, r.nPermissions);
+      } catch (e) {
+        console.log(`  ${cse.label.padEnd(46)} UNREAD: ${String(e instanceof Error ? e.message : e).slice(0, 120)}`);
+      }
+    }
+    console.log("");
+  }
+
+  // CONTROL: the same shapes against an account that is genuinely undeployed.
+  console.log("── 1b. CONTROL: a counterfactual (undeployed) account, same shapes ──────────\n");
+  {
+    // Derived on a PLAIN http client: getSenderAddress reads the address out of
+    // an EntryPoint revert, and our instrumented transport turns RPC errors into
+    // thrown Errors, which that path cannot parse. Purely a plumbing detail —
+    // the address is the same one the worker would derive.
+    const plain = createPublicClient({ chain: chainForId(4663), transport: http(RPC, { retryCount: 6, retryDelay: 1500, timeout: 30_000 }) });
+    const cfSudo = await createKernelAccount(plain, { entryPoint, kernelVersion: KERNEL_V3_3, plugins: { sudo: ecdsa } });
+    const addr = cfSudo.address as Address;
+    const c = await getCode(addr);
+    const live = c === null ? null : c !== "0x" && c.length > 2;
+    console.log(`${addr}  (counterfactual — derived, never deployed)`);
+    console.log(`  code: ${c === null ? "UNREAD" : `${(c.length - 2) / 2} bytes`}   isDeployed() would return: ${live === null ? "UNREAD" : live ? "TRUE" : "FALSE"}`);
+    if (live !== null) {
+      for (const [label, o] of [
+        ["full wall, session key A", { addr, sessionKey: keyA, now: FIXED_NOW }],
+        ["full wall, session key B", { addr, sessionKey: keyB, now: FIXED_NOW }],
+      ] as const) {
+        const r = await probe(o as Parameters<typeof probe>[0]);
+        row(label, live, r.pid, r.nonce, r.permCalls, r.nPermissions);
+      }
+    }
+    console.log("");
+  }
+
+  // ═══ SECTION 2 ════════════════════════════════════════════════════════════
+  // THE CONVERSE. An ALREADY-INSTALLED permission validator must give mode 0x00.
+  console.log("── 2. THE CONVERSE — permission validator ALREADY INSTALLED ─────────────────");
+  console.log("   (steady state: the case the 3,000,000 ceiling actually exists for)\n");
+  console.log("   Method: toPermissionValidator accepts an explicit `permissionId`");
+  console.log("   (toPermissionValidator.ts:71-73 short-circuits getPermissionId), so we can");
+  console.log("   point a validator at a pId this account PROVABLY installed and let the SDK");
+  console.log("   decide the mode by its own on-chain read. The signer contract still has to");
+  console.log("   match — isEnabled compares permissionConfig(pId).signer against");
+  console.log("   ECDSA_SIGNER_CONTRACT — so this is not a rubber stamp.\n");
+
+  for (const s of INSTALLED) {
+    const c = await getCode(s.addr);
+    const live = c === null ? null : c !== "0x" && c.length > 2;
+    console.log(`${s.addr}  pId ${s.pid}  (${s.note})`);
+    console.log(`  code: ${c === null ? "UNREAD" : `${(c.length - 2) / 2} bytes`}   isDeployed() would return: ${live === null ? "UNREAD" : live ? "TRUE" : "FALSE"}`);
+
+    // read permissionConfig ourselves so the install is a fact, not an assumption
+    try {
+      const data = (PERMISSION_CONFIG_SELECTOR + s.pid.slice(2).padEnd(64, "0")) as Hex;
+      const raw = (await wire("eth_call", [{ to: s.addr, data }, "latest"])) as string;
+      // Returns ONE struct { bytes2 permissionFlag; address signer; bytes22[] policyData }.
+      // policyData is dynamic, so the struct itself is dynamic: word 0 is the
+      // offset to it, word 1 is the flag, word 2 is the signer.
+      const words = raw.slice(2).match(/.{64}/g) ?? [];
+      const flag = words[1] ? `0x${words[1].slice(0, 4)}` : "?";
+      const signer = words[2] ? `0x${words[2].slice(24)}` : "?";
+      const installed = signer.toLowerCase() === ECDSA_SIGNER_CONTRACT.toLowerCase();
+      console.log(`  permissionConfig(${s.pid}): flag ${flag} signer ${signer}  -> ${installed ? "INSTALLED (signer == ECDSA_SIGNER_CONTRACT)" : "NOT the ECDSA signer"}`);
+    } catch (e) {
+      console.log(`  permissionConfig(${s.pid}): UNREAD — ${String(e instanceof Error ? e.message : e).slice(0, 120)}`);
+    }
+
+    if (live === null) {
+      console.log("  skipping nonce probes — deployment state UNREAD.\n");
+      continue;
+    }
+    try {
+      const r = await probe({ addr: s.addr, sessionKey: keyA, permissionId: s.pid, now: FIXED_NOW });
+      row("INSTALLED pId (steady state)", live, r.pid, r.nonce, r.permCalls, r.nPermissions);
+      const rc = await probe({ addr: s.addr, sessionKey: keyA, permissionId: "0xdeadbeef", now: FIXED_NOW });
+      row("CONTROL: bogus pId 0xdeadbeef", live, rc.pid, rc.nonce, rc.permCalls, rc.nPermissions);
+      const rf = await probe({ addr: s.addr, sessionKey: keyB, now: FIXED_NOW });
+      row("CONTROL: fresh key, derived pId (renewal)", live, rf.pid, rf.nonce, rf.permCalls, rf.nPermissions);
+    } catch (e) {
+      console.log(`  UNREAD: ${String(e instanceof Error ? e.message : e).slice(0, 140)}`);
+    }
+    console.log("");
+  }
+
+  // ═══ SECTION 3 ════════════════════════════════════════════════════════════
+  // Does isPluginEnabled make a real on-chain call, and what does a FAILED read do?
+  console.log("── 3. THE ON-CHAIN CALL, AND WHAT HAPPENS WHEN IT FAILS ─────────────────────\n");
+  console.log("   SOURCE (node_modules/@zerodev/sdk/accounts/utils/toKernelPluginManager.ts:390-393):");
+  console.log("     const validatorMode = !regular || (await isPluginEnabled(...)) ? DEFAULT : ENABLE");
+  console.log("   :175-180  isEnabled = (await regular_.isEnabled(...)) || (await isPluginInitialized(...))");
+  console.log("   node_modules/@zerodev/permissions/toPermissionValidator.ts:137-156");
+  console.log("     isEnabled: try { readContract permissionConfig(pId) … } catch (error) { return false }");
+  console.log("   toPermissionValidator.ts:86  address: zeroAddress   -> the isPluginInitialized");
+  console.log("     disjunct calls a codeless address, throws, and is caught to false as well");
+  console.log("     (isPluginInitialized.ts:11-23).");
+  console.log("   => BOTH disjuncts collapse to FALSE on any error, so a FAILED READ YIELDS ENABLE.\n");
+
+  const target = INSTALLED[0]!;
+  const tCode = await getCode(target.addr);
+  const tLive = tCode === null ? null : tCode !== "0x" && tCode.length > 2;
+  console.log(`   Subject: ${target.addr} (installed pId ${target.pid}, deployed: ${tLive === null ? "UNREAD" : tLive}).`);
+  console.log("   This account's steady-state nonce is mode 0x00 (section 2). Now break ONLY");
+  console.log("   its permissionConfig read — locally, inside our own transport, before the");
+  console.log("   request leaves the process — and read the nonce again.\n");
+
+  if (tLive !== null) {
+    // 3a: healthy — establish the baseline again, and count the calls
+    try {
+      const healthy = await probe({ addr: target.addr, sessionKey: keyA, permissionId: target.pid, now: FIXED_NOW });
+      row("3a healthy RPC", tLive, healthy.pid, healthy.nonce, healthy.permCalls, healthy.nPermissions);
+      console.log(`      ^ permissionConfig calls = ${healthy.permCalls} -> isPluginEnabled DOES hit the chain (${healthy.permCalls === 0 ? "NO — unexpected" : "yes, a real eth_call"})`);
+    } catch (e) {
+      console.log(`   3a UNREAD: ${String(e).slice(0, 140)}`);
+    }
+
+    // 3b: the permissionConfig read fails
+    FAULT = (r) => (isPermissionConfigCall(r, target.addr) ? "injected fault: permissionConfig read failed (simulated RPC error)" : null);
+    try {
+      const broken = await probe({ addr: target.addr, sessionKey: keyA, permissionId: target.pid, now: FIXED_NOW });
+      row("3b permissionConfig read FAILS", tLive, broken.pid, broken.nonce, broken.permCalls, broken.nPermissions);
+      const flipped = modeOf(broken.nonce) === 0x01;
+      console.log(
+        `      ^ VERDICT: a failed read makes the SDK claim ${flipped ? "ENABLE (0x01)" : "DEFAULT (0x00)"}. ` +
+          `${flipped ? "FAIL-TOWARD-ENABLE." : "FAIL-TOWARD-DEFAULT."}`,
+      );
+    } catch (e) {
+      console.log(`   3b threw instead of degrading: ${String(e instanceof Error ? e.message : e).slice(0, 200)}`);
+    } finally {
+      FAULT = null;
+    }
+
+    // 3b': the SAME fault on a RENEWAL (pId genuinely not installed). If the
+    // failure direction were DEFAULT, a blip would refuse a renewal. It is not.
+    FAULT = (r) => (isPermissionConfigCall(r, target.addr) ? "injected fault: permissionConfig read failed (simulated RPC error)" : null);
+    try {
+      const r = await probe({ addr: target.addr, sessionKey: keyB, now: FIXED_NOW });
+      row("3b' RENEWAL + permissionConfig read FAILS", tLive, r.pid, r.nonce, r.permCalls, r.nPermissions);
+      console.log("      ^ a renewal is ENABLE either way, so an RPC blip can never REFUSE one on this path.");
+      console.log("        The blip only ever moves a STEADY-STATE op from DEFAULT to ENABLE (3b).");
+    } catch (e) {
+      console.log(`   3b' UNREAD: ${String(e).slice(0, 140)}`);
+    } finally {
+      FAULT = null;
+    }
+
+    // 3c: EVERY read fails (whole RPC down) — does getNonce throw, or silently produce a nonce?
+    FAULT = () => "injected fault: RPC unreachable";
+    try {
+      const dead = await probe({ addr: target.addr, sessionKey: keyA, permissionId: target.pid, now: FIXED_NOW });
+      row("3c WHOLE RPC down", tLive, dead.pid, dead.nonce, dead.permCalls, dead.nPermissions);
+      console.log("      ^ getNonce returned a nonce with the RPC entirely down — that would be surprising.");
+    } catch (e) {
+      console.log(`   3c WHOLE RPC down: account.getNonce() THREW — ${String(e instanceof Error ? e.message : e).split("\n")[0]!.slice(0, 160)}`);
+      console.log("      ^ so a total outage is loud (the executor's estimate would fail anyway).");
+      console.log("        The dangerous case is 3b: the EntryPoint getNonce read succeeds while the");
+      console.log("        permissionConfig read fails, which is one flaky call, not an outage.");
+    } finally {
+      FAULT = null;
+    }
+  }
+
+  // ═══ SECTION 3d ═══════════════════════════════════════════════════════════
+  // DOES MERRYMEN ITSELF HAVE A DEPLOYED ACCOUNT WITH A LIVE WALL?
+  console.log("\n── 3d. DOES MERRYMEN HAVE A DEPLOYED ACCOUNT WITH A LIVE WALL? ──────────────\n");
+  console.log("   NO — and the section-2 subjects are therefore other people's accounts, not ours.");
+  console.log("   merrymen's own account 0x032da6a0…9036 has executed exactly ONE UserOperation in");
+  console.log("   its life: mode 0x00 / vType 0x00 (SUDO, DEFAULT), seq 0, block 51207025, success.");
+  console.log("   Source: per-sender UserOperationEvent scan over all 2,208 ZeroDev-factory accounts");
+  console.log("   on 4663 (spikes/first-op-gas/perm-ops.json, 0 accounts unreadable) — that account");
+  console.log("   appears exactly once and never with vType 0x02.");
+  console.log("   So no merrymen wall has ever been installed on chain, and the steady-state DEFAULT");
+  console.log("   branch is demonstrated on the closest available subjects: real Kernel v3.3 accounts");
+  console.log("   on the same chain whose permission validators DID land. That is a property of the");
+  console.log("   Kernel/SDK mechanism, not of who owns the account.\n");
+
+  // ═══ SECTION 4 ════════════════════════════════════════════════════════════
+  console.log("── 4. WHAT worker/src/executor.ts ON fix/first-enable-gas COMPUTES ──────────");
+  console.log("   const accountLive = await isDeployed();            // executor.ts:389");
+  console.log("   const nonce       = await account.getNonce();      // executor.ts:390");
+  console.log("   const firstEnable = !accountLive && isFirstEnable(nonce);  // :391");
+  console.log("   const bounds      = firstEnable ? FIRST_ENABLE_GAS_BOUNDS : GAS_BOUNDS;  // :392");
+  console.log("   (the tables above already print every one of those four values per case)\n");
+  console.log("   ALSO NOTE executor.ts ~:325 — the estimate's stateOverride balance is");
+  console.log("   `bounds.absoluteMax * feeCeiling * 2n`, i.e. sized FROM the chosen ceiling.");
+  console.log("   So the 3,000,000 branch also hands the bundler too little imaginary ETH,");
+  console.log("   and the refusal arrives as `gas-unreadable` (AA21) rather than `gas-absurd`.\n");
+
+  // ═══ SECTION 5 ════════════════════════════════════════════════════════════
+  // boundGas's ACTUAL verdict, from the repo's own function, on the measured op.
+  console.log("── 5. boundGas()'s VERDICT — the repo's own function, run here ──────────────\n");
+  console.log("   Gas inputs are the MEASURED walled first op on 4663, Pimlico, 2026-09-03");
+  console.log("   (spikes/first-op-gas/renewal-override.ts): verif 7,418,031 · preVerif 243,380 · call 50,180.");
+  console.log("   A deployed re-enable is the same op minus a ~360k deploy, so it is if anything");
+  console.log("   SMALLER — the verdict below does not depend on that difference.\n");
+  const MEASURED = { callGasLimit: 50_180n, verificationGasLimit: 7_418_031n, preVerificationGas: 243_380n };
+  const show = (label: string, v: ReturnType<typeof boundGas>) =>
+    console.log(
+      v.ok
+        ? `  ${label.padEnd(52)} ACCEPTED  signed total ${v.total.toLocaleString("en-US")}`
+        : `  ${label.padEnd(52)} REFUSED   rule "${v.rule}"\n      ${v.detail.slice(0, 300)}`,
+    );
+  show("undeployed first op -> FIRST_ENABLE_GAS_BOUNDS", boundGas(MEASURED, MEASURED, FIRST_ENABLE_GAS_BOUNDS, false));
+  show("renewal, estimate SUCCEEDS -> GAS_BOUNDS", boundGas(MEASURED, MEASURED, GAS_BOUNDS, false));
+  show("renewal, override too small -> estimate null", boundGas(null, null, GAS_BOUNDS, false));
+  show("steady-state op (mode 0x00) -> GAS_BOUNDS", boundGas({ callGasLimit: 60_000n, verificationGasLimit: 657_108n, preVerificationGas: 60_000n }, { callGasLimit: 60_000n, verificationGasLimit: 657_108n, preVerificationGas: 60_000n }, GAS_BOUNDS, false));
+  console.log("\n   (the steady-state row uses verificationGasLimit 657,108 — the SIGNED value on");
+  console.log("    0xa48ce91e…'s post-enable ops, tx 0x66e4f2d6…, decoded from handleOps calldata.");
+  console.log("    It is comfortably inside 3,000,000, which is what that ceiling is sized for.)\n");
+}
+
+main().catch((e) => {
+  console.error("shape probe failed:", e instanceof Error ? e.stack : String(e));
+  process.exit(1);
+});

--- a/spikes/first-op-gas/small-wall.ts
+++ b/spikes/first-op-gas/small-wall.ts
@@ -1,0 +1,88 @@
+/**
+ * MEASURE A SMALLER WALL, rather than extrapolating from the extras slope.
+ *
+ * The extras sweep gave ~342k gas per additional permitted token, consistently
+ * across two points. If that slope holds downward, trimming the tradeable set is
+ * the single largest lever on the ~7.06M enable cost. Extrapolation is not
+ * measurement, so this builds the call policy directly from a FILTERED
+ * permission list and estimates it.
+ *
+ * Nothing signed, nothing broadcast.
+ */
+import { createPublicClient, encodeFunctionData, erc20Abi, http, parseEther, type Address } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { getEntryPoint, KERNEL_V3_3 } from "@zerodev/sdk/constants";
+import { createKernelAccount } from "@zerodev/sdk";
+import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
+import { toPermissionValidator } from "@zerodev/permissions";
+import { toCallPolicy, toTimestampPolicy, CallPolicyVersion } from "@zerodev/permissions/policies";
+import { toECDSASigner } from "@zerodev/permissions/signers";
+import { buildCallPermissions, CASH, chainForId, pimlicoBundlerUrl, UNISWAP } from "../../packages/core/src/index";
+
+const CAPS = { perTradeUsdg: 50, dailyUsdg: 500, expiryDays: 14, maxDrawdownPct: 10, maxOpsPerDay: 48 };
+
+async function rpc(url: string, params: unknown[]) {
+  const r = await fetch(url, {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_estimateUserOperationGas", params }),
+  });
+  return (await r.json()) as { result?: Record<string, string>; error?: { message?: string; code?: unknown } };
+}
+
+async function main() {
+  const apiKey = process.env.MERRYMEN_BUNDLER_API_KEY;
+  if (!apiKey) { console.error("run under railway run"); process.exit(1); }
+  const bundler = pimlicoBundlerUrl(4663, apiKey);
+  const publicClient = createPublicClient({ chain: chainForId(4663), transport: http("https://rpc.mainnet.chain.robinhood.com") });
+  const entryPoint = getEntryPoint("0.7");
+  const fees = await publicClient.estimateFeesPerGas().catch(() => null);
+  const maxFee = fees?.maxFeePerGas ?? 1_000_000_000n;
+  console.log(`maxFeePerGas ${(Number(maxFee) / 1e9).toFixed(6)} gwei\n`);
+
+  const owner = privateKeyToAccount(generatePrivateKey());
+  const ecdsa = await signerToEcdsaValidator(publicClient, { signer: owner, entryPoint, kernelVersion: KERNEL_V3_3 });
+  const sudoOnly = await createKernelAccount(publicClient, { entryPoint, kernelVersion: KERNEL_V3_3, plugins: { sudo: ecdsa } });
+
+  const all = buildCallPermissions(CAPS, sudoOnly.address, {});
+  console.log(`full wall: ${all.length} permissions`);
+
+  const now = Math.floor(Date.now() / 1000);
+  for (const keep of [all.length, 8, 5, 3, 2]) {
+    const perms = all.slice(0, keep);
+    const policies = [
+      toTimestampPolicy({ validAfter: now, validUntil: now + 14 * 86400 }),
+      toCallPolicy({ policyVersion: CallPolicyVersion.V0_0_4, permissions: perms as never }),
+    ];
+    const sess = await toECDSASigner({ signer: privateKeyToAccount(generatePrivateKey()) });
+    const pv = await toPermissionValidator(publicClient, { entryPoint, kernelVersion: KERNEL_V3_3, signer: sess, policies, flag: "0x0002" });
+    const account = await createKernelAccount(publicClient, { entryPoint, kernelVersion: KERNEL_V3_3, plugins: { sudo: ecdsa, regular: pv } });
+
+    const sender = account.address as Address;
+    const callData = await account.encodeCalls([{
+      to: CASH.USDG as Address, value: 0n,
+      data: encodeFunctionData({ abi: erc20Abi, functionName: "approve", args: [UNISWAP.swapRouter02 as Address, 5_000_000n] }),
+    }]);
+    const fa = await account.getFactoryArgs();
+    const nonce = await account.getNonce();
+    const stub = await account.getStubSignature({
+      sender, nonce, callData, callGasLimit: 0n, verificationGasLimit: 0n, preVerificationGas: 0n,
+      maxFeePerGas: 0n, maxPriorityFeePerGas: 0n, signature: "0x", ...fa,
+    } as never);
+    const r = await rpc(bundler, [
+      { sender, nonce: `0x${nonce.toString(16)}`, factory: fa.factory, factoryData: fa.factoryData, callData, signature: stub,
+        maxFeePerGas: `0x${maxFee.toString(16)}`, maxPriorityFeePerGas: `0x${(fees?.maxPriorityFeePerGas ?? 0n).toString(16)}` },
+      entryPoint.address,
+      { [sender]: { balance: `0x${parseEther("1").toString(16)}` } },
+    ]);
+    if (r.error) { console.log(`  ${String(keep).padStart(2)} permissions  REFUSED — ${String(r.error.code)} ${r.error.message?.slice(0, 60)}`); continue; }
+    const o = r.result!;
+    const n = (k: string) => BigInt(o[k] ?? "0x0");
+    const raw = n("callGasLimit") + n("verificationGasLimit") + n("preVerificationGas");
+    console.log(
+      `  ${String(keep).padStart(2)} permissions  verif ${String(n("verificationGasLimit")).padStart(9)} · raw ${String(raw).padStart(9)} · ` +
+      `×2 ${String(raw * 2n).padStart(10)} · ${(Number(raw * 2n * maxFee) / 1e18).toFixed(6)} ETH · stub ${stub.length / 2 - 1}B` +
+      `${raw * 2n <= 8_000_000n ? "   <= UNDER the 8M ceiling" : ""}`,
+    );
+  }
+}
+main().catch((e) => { console.error(String(e).slice(0, 300)); process.exit(1); });

--- a/spikes/first-op-gas/states.ts
+++ b/spikes/first-op-gas/states.ts
@@ -1,0 +1,240 @@
+/**
+ * WHICH EXECUTION STATE COSTS THE 7.7M, AND WHAT DRIVES IT?
+ *
+ * The first probe established that a merrymen agent's first UserOperation
+ * estimates at 7,711,654 raw gas, of which 7,059,814 is the permission-validator
+ * plugin-enable. This one answers the two questions that decide what to do about
+ * it:
+ *
+ *   1. Is the cost ONE-OFF (only the first op of a session key) or does every
+ *      trade carry it? That decides whether we need a separate first-op ceiling
+ *      or a higher ceiling everywhere.
+ *   2. What inside the enable actually costs the gas — the number of call
+ *      permissions, the two ONE_OF address lists, or the plugin install itself?
+ *      That decides whether the wall can be made cheaper without weakening it.
+ *
+ * Everything here is `eth_estimateUserOperationGas`, which is a simulation.
+ * NOTHING IS SIGNED AND NOTHING IS BROADCAST. Keys are generated per run, used
+ * for nothing else, never written to disk and never funded. The balance
+ * override exists only inside the estimation RPC call.
+ *
+ * Run: railway run --service orchestrator -- npx tsx spikes/first-op-gas/states.ts
+ */
+import { createPublicClient, encodeFunctionData, erc20Abi, http, parseEther, type Address } from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { getEntryPoint, KERNEL_V3_3 } from "@zerodev/sdk/constants";
+import { createKernelAccount } from "@zerodev/sdk";
+import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
+import { toPermissionValidator } from "@zerodev/permissions";
+import { toECDSASigner } from "@zerodev/permissions/signers";
+import {
+  buildWallPolicies,
+  CASH,
+  chainForId,
+  pimlicoBundlerUrl,
+  STOCK_TOKENS,
+  TRADEABLE_SYMBOLS,
+  UNISWAP,
+} from "../../packages/core/src/index";
+
+const CHAIN_ID = 4663;
+const RPC = "https://rpc.mainnet.chain.robinhood.com";
+const CAPS = { perTradeUsdg: 50, dailyUsdg: 500, expiryDays: 14, maxDrawdownPct: 10, maxOpsPerDay: 48 };
+
+async function rpc(url: string, method: string, params: unknown[]) {
+  const r = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  return (await r.json()) as { result?: Record<string, string>; error?: { message?: string; code?: unknown } };
+}
+
+interface Gas {
+  call: bigint;
+  ver: bigint;
+  pre: bigint;
+  raw: bigint;
+}
+const read = (r: { result?: Record<string, string> }): Gas | null => {
+  const o = r.result;
+  if (!o) return null;
+  const n = (k: string) => (o[k] === undefined ? 0n : BigInt(o[k]));
+  const call = n("callGasLimit");
+  const ver = n("verificationGasLimit");
+  const pre = n("preVerificationGas");
+  return { call, ver, pre, raw: call + ver + pre };
+};
+
+async function main() {
+  const apiKey = process.env.MERRYMEN_BUNDLER_API_KEY;
+  if (!apiKey) {
+    console.error("run under: railway run --service orchestrator --");
+    process.exit(1);
+  }
+  const bundler = pimlicoBundlerUrl(CHAIN_ID, apiKey);
+  const chain = chainForId(CHAIN_ID);
+  const publicClient = createPublicClient({ chain, transport: http(RPC) });
+  const entryPoint = getEntryPoint("0.7");
+  const ep = entryPoint.address;
+
+  const fees = await publicClient.estimateFeesPerGas().catch(() => null);
+  const maxFeePerGas = fees?.maxFeePerGas ?? 1_000_000_000n;
+  const eth = (gas: bigint) => (Number(gas * maxFeePerGas) / 1e18).toFixed(6);
+  console.log(`chain ${CHAIN_ID} · maxFeePerGas ${(Number(maxFeePerGas) / 1e9).toFixed(6)} gwei\n`);
+
+  /** Build an account, optionally with the wall, optionally with a trimmed token set. */
+  async function build(opts: { wall: boolean; symbols?: readonly string[]; extraTokens?: number }) {
+    const owner = privateKeyToAccount(generatePrivateKey());
+    const ecdsa = await signerToEcdsaValidator(publicClient, {
+      signer: owner,
+      entryPoint,
+      kernelVersion: KERNEL_V3_3,
+    });
+    const sudoOnly = await createKernelAccount(publicClient, {
+      entryPoint,
+      kernelVersion: KERNEL_V3_3,
+      plugins: { sudo: ecdsa },
+    });
+    if (!opts.wall) return { account: sudoOnly, stubBytes: 65 };
+
+    const sessionSigner = await toECDSASigner({ signer: privateKeyToAccount(generatePrivateKey()) });
+    // Extra tokens widen the ONE_OF lists exactly as a tenant's customTokens do.
+    const extras = Array.from({ length: opts.extraTokens ?? 0 }, (_, i) => ({
+      // isValidCustomToken requires exactly {symbol, address, decimals} — my
+      // first attempt passed the STOCK_TOKENS shape (name/chainlinkFeed/kind,
+      // no decimals) and every entry was silently dropped, which made the sweep
+      // look like the wall size did not matter when it had never been varied.
+      symbol: `X${i}`,
+      address: `0x${(i + 0x1000).toString(16).padStart(40, "0")}` as Address,
+      decimals: 18,
+    }));
+    const { policies } = buildWallPolicies({
+      caps: CAPS,
+      smartAccount: sudoOnly.address,
+      ...(extras.length ? { extraTokens: extras as never } : {}),
+    });
+    const permission = await toPermissionValidator(publicClient, {
+      entryPoint,
+      kernelVersion: KERNEL_V3_3,
+      signer: sessionSigner,
+      policies,
+      flag: "0x0002",
+    });
+    const account = await createKernelAccount(publicClient, {
+      entryPoint,
+      kernelVersion: KERNEL_V3_3,
+      plugins: { sudo: ecdsa, regular: permission },
+    });
+    return { account, stubBytes: 0 };
+  }
+
+  /** Estimate one op. `deployed` drops the factory, as a deployed account would. */
+  async function estimate(
+    account: Awaited<ReturnType<typeof build>>["account"],
+    label: string,
+    deployed: boolean,
+  ): Promise<{ gas: Gas | null; stubBytes: number; err?: string }> {
+    const sender = account.address as Address;
+    const approve = await account.encodeCalls([
+      {
+        to: CASH.USDG as Address,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: erc20Abi,
+          functionName: "approve",
+          args: [UNISWAP.swapRouter02 as Address, 5_000_000n],
+        }),
+      },
+    ]);
+    const factoryArgs = await account.getFactoryArgs();
+    const nonce = await account.getNonce();
+    const stub = await account.getStubSignature({
+      sender,
+      nonce,
+      callData: approve,
+      callGasLimit: 0n,
+      verificationGasLimit: 0n,
+      preVerificationGas: 0n,
+      maxFeePerGas: 0n,
+      maxPriorityFeePerGas: 0n,
+      signature: "0x",
+      ...factoryArgs,
+    } as never);
+    const op: Record<string, unknown> = {
+      sender,
+      nonce: `0x${nonce.toString(16)}`,
+      callData: approve,
+      signature: stub,
+      maxFeePerGas: `0x${maxFeePerGas.toString(16)}`,
+      maxPriorityFeePerGas: `0x${(fees?.maxPriorityFeePerGas ?? 0n).toString(16)}`,
+    };
+    if (!deployed) {
+      op.factory = factoryArgs.factory;
+      op.factoryData = factoryArgs.factoryData;
+    }
+    const r = await rpc(bundler, "eth_estimateUserOperationGas", [
+      op,
+      ep,
+      { [sender]: { balance: `0x${parseEther("1").toString(16)}` } },
+    ]);
+    const stubBytes = stub.length / 2 - 1;
+    if (r.error) return { gas: null, stubBytes, err: `${String(r.error.code)} ${r.error.message ?? ""}`.slice(0, 120) };
+    return { gas: read(r), stubBytes };
+  }
+
+  const row = (label: string, g: Gas | null, stub: number, err?: string) => {
+    if (!g) {
+      console.log(`  ${label.padEnd(46)} REFUSED — ${err ?? ""}`);
+      return;
+    }
+    const signed = g.raw * 2n;
+    console.log(
+      `  ${label.padEnd(46)} verif ${String(g.ver).padStart(9)} · preVerif ${String(g.pre).padStart(7)} · ` +
+        `call ${String(g.call).padStart(6)} · raw ${String(g.raw).padStart(9)} · ×2 ${String(signed).padStart(10)} · ` +
+        `${eth(signed).padStart(9)} ETH · stub ${String(stub).padStart(6)}B`,
+    );
+  };
+
+  // ── THE FOUR EXECUTION STATES ──────────────────────────────────────────
+  console.log("── THE FOUR EXECUTION STATES (callData = one ERC-20 approve, held constant) ──");
+  const wall = await build({ wall: true });
+  const sudo = await build({ wall: false });
+
+  const s1 = await estimate(wall.account, "1. undeployed + wall enable + call", false);
+  row("1. undeployed + wall enable + call", s1.gas, s1.stubBytes, s1.err);
+
+  const s2 = await estimate(sudo.account, "2a. undeployed, sudo only (no wall)", false);
+  row("2a. undeployed, sudo only (no wall)", s2.gas, s2.stubBytes, s2.err);
+
+  // "Deployed" is simulated by dropping the factory. The bundler then treats the
+  // sender as an existing account; with a balance override and no code the
+  // validation will fail, which is itself the answer for whether this state is
+  // measurable without actually deploying.
+  const s3 = await estimate(sudo.account, "3. deployed sudo, ordinary call", true);
+  row("3. deployed sudo, ordinary call", s3.gas, s3.stubBytes, s3.err);
+
+  const s4 = await estimate(wall.account, "4. deployed + wall, ordinary session op", true);
+  row("4. deployed + wall, ordinary session op", s4.gas, s4.stubBytes, s4.err);
+
+  if (s1.gas && s2.gas) {
+    console.log(`\n  >>> WALL ENABLE COSTS: verif +${s1.gas.ver - s2.gas.ver} · preVerif +${s1.gas.pre - s2.gas.pre} · raw +${s1.gas.raw - s2.gas.raw}`);
+  }
+
+  // ── OPTION C: WHAT DRIVES THE ENABLE COST ──────────────────────────────
+  console.log("\n── OPTION C: does the wall's SIZE drive it? (extra tokens widen both ONE_OF lists) ──");
+  console.log(`  baseline TRADEABLE_SYMBOLS: ${TRADEABLE_SYMBOLS.length} · STOCK_TOKENS: ${STOCK_TOKENS.length}`);
+  for (const extra of [0, 5, 15, 40]) {
+    const b = await build({ wall: true, extraTokens: extra });
+    const r = await estimate(b.account, `+${extra} tokens`, false);
+    row(`wall with +${extra} extra token(s)`, r.gas, r.stubBytes, r.err);
+  }
+
+  console.log("\n── ANCHOR: the two real landed deploys on 4663 (sudo-only, decoded from handleOps) ──");
+  console.log("  verif 358,217 · preVerif 54,538 · call 50,180 · signed 462,935 · ACTUALLY USED 359,497 (77.7%)");
+}
+
+main().catch((e) => {
+  console.error("failed:", e instanceof Error ? e.message : String(e));
+  process.exit(1);
+});

--- a/spikes/first-op-gas/synth-deployed.ts
+++ b/spikes/first-op-gas/synth-deployed.ts
@@ -1,0 +1,365 @@
+/**
+ * METHOD B — MEASURE THE RENEWAL DIRECTLY, ON A SYNTHETICALLY *DEPLOYED* ACCOUNT.
+ *
+ * Method A could never estimate the case that matters. A renewal is an ENABLE-mode
+ * op sent from an account that ALREADY HAS CODE, and you cannot estimate one
+ * against a real merrymen account without that account's real owner key. So
+ * method A measured the UNDEPLOYED enable and subtracted a deploy, i.e. inferred.
+ *
+ * THIS SCRIPT DOES NOT SUBTRACT ANYTHING. It manufactures a deployed Kernel v3.3
+ * account whose owner key I generated myself, using eth state overrides:
+ *
+ *   on the ACCOUNT address S:  code      = the real 61-byte Kernel ERC-1967 proxy
+ *                                          runtime, cloned from a live v3.3 account
+ *                              stateDiff = ERC-1967 impl slot -> the real v3.3 impl
+ *                                          kernel.v3.validation base+0 -> rootValidator
+ *                              balance   = enough to clear the prefund check
+ *   on the shared ECDSAValidator: stateDiff = ecdsaValidatorStorage[S] -> MY owner EOA
+ *
+ * S then behaves, to the EVM, exactly like a deployed merrymen account that has
+ * never installed a permission validator — which is precisely the renewal state.
+ * No factory, no initCode, real code, empty permissionConfig.
+ *
+ * TWO INDEPENDENT GAS ORACLES, so the answer does not rest on one estimator:
+ *   ORACLE 1  Pimlico  eth_estimateUserOperationGas   (same oracle as method A,
+ *                                                      but a state it never reached)
+ *   ORACLE 2  the chain node  eth_estimateGas of EntryPoint -> S.validateUserOp(...)
+ *             This is the bundler-free measurement. It prices the verification
+ *             phase directly on a Nitro node, with no Pimlico heuristics at all.
+ *
+ * CONTROL MATRIX (every arm is printed, including the ones that must fail):
+ *   2x2 factorial   {undeployed, synthetically deployed} x {sudo-only, walled}
+ *   negative controls: drop the code override / drop the owner override / drop the
+ *   rootValidator word -> each must break, or the synthetic deployment is a fiction.
+ *
+ * READ-ONLY. eth_call, eth_estimateGas, eth_getCode, eth_getStorageAt and
+ * eth_estimateUserOperationGas are all simulations. No transaction and no
+ * UserOperation is ever broadcast. The keys are generated in this process, never
+ * funded, never written to disk. The overrides live only inside the RPC calls.
+ *
+ * Run: railway run --service orchestrator -- npx tsx spikes/first-op-gas/synth-deployed.ts
+ */
+import {
+  createPublicClient, encodeAbiParameters, encodeFunctionData, erc20Abi, http, keccak256,
+  pad, type Address, type Hex,
+} from "viem";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { getUserOperationHash, toPackedUserOperation } from "viem/account-abstraction";
+import { getEntryPoint, KERNEL_V3_3 } from "@zerodev/sdk/constants";
+import { createKernelAccount } from "@zerodev/sdk";
+import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
+import { toPermissionValidator } from "@zerodev/permissions";
+import { toECDSASigner } from "@zerodev/permissions/signers";
+import {
+  buildWallPolicies, CASH, chainForId, pimlicoBundlerUrl, UNISWAP, WALL_POLICY_FLAG,
+} from "../../packages/core/src/index";
+
+const CHAIN_ID = 4663;
+const RPC = "https://rpc.mainnet.chain.robinhood.com";
+const CAPS = { perTradeUsdg: 50, dailyUsdg: 500, expiryDays: 14, maxDrawdownPct: 10, maxOpsPerDay: 48 };
+
+/** Cloned from live Kernel v3.3 accounts on 4663 (0x032Da6A0… and 0xa48cE91e… — byte-identical). */
+const KERNEL_PROXY_RUNTIME =
+  "0x363d3d373d3d363d7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc545af43d6000803e6038573d6000fd5b3d6000f3" as Hex;
+const IMPL_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc" as Hex;
+const IMPL_V33 = "0x000000000000000000000000d6cedde84be40893d153be9d467cd6ad37875b28" as Hex;
+/** keccak256("kernel.v3.validation") - 1. base+0 = rootValidator(21B) | currentNonce | validNonceFrom */
+const VAL_BASE = "0x7bcaa2ced2a71450ed5a9a1b4848e8e5206dbc3f06011e595f7f55428cc6f84f" as Hex;
+const VAL_BASE0_LIVE = "0x000000000000000000000101845adb2c711129d4f3966735ed98a9f09fc4ce57" as Hex;
+const ECDSA_VALIDATOR = "0x845ADb2C711129d4f3966735eD98a9F09fC4cE57" as Address;
+
+const VALIDATE_USER_OP_ABI = [
+  {
+    type: "function",
+    name: "validateUserOp",
+    stateMutability: "payable",
+    inputs: [
+      {
+        name: "userOp", type: "tuple",
+        components: [
+          { name: "sender", type: "address" }, { name: "nonce", type: "uint256" },
+          { name: "initCode", type: "bytes" }, { name: "callData", type: "bytes" },
+          { name: "accountGasLimits", type: "bytes32" }, { name: "preVerificationGas", type: "uint256" },
+          { name: "gasFees", type: "bytes32" }, { name: "paymasterAndData", type: "bytes" },
+          { name: "signature", type: "bytes" },
+        ],
+      },
+      { name: "userOpHash", type: "bytes32" },
+      { name: "missingAccountFunds", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;
+
+const ROOT_VALIDATOR_ABI = [
+  { type: "function", name: "rootValidator", stateMutability: "view", inputs: [], outputs: [{ type: "bytes21" }] },
+] as const;
+const ECDSA_STORAGE_ABI = [
+  { type: "function", name: "ecdsaValidatorStorage", stateMutability: "view", inputs: [{ type: "address" }], outputs: [{ type: "address" }] },
+] as const;
+
+type Ov = Record<string, { balance?: Hex; code?: Hex; stateDiff?: Record<string, Hex> }>;
+
+async function rpc(url: string, method: string, params: unknown[]) {
+  for (let i = 0; i < 4; i++) {
+    try {
+      const r = await fetch(url, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      });
+      const j = (await r.json()) as { result?: unknown; error?: { message?: string; code?: unknown; data?: unknown } };
+      // Only retry transport-ish failures; a real revert is an answer, not a flake.
+      if (j.error && /Too Many Requests|rate|timeout|502|503/i.test(String(j.error.message))) {
+        await new Promise((s) => setTimeout(s, 1500 * (i + 1)));
+        continue;
+      }
+      return j;
+    } catch (e) {
+      if (i === 3) return { error: { message: `transport: ${e instanceof Error ? e.message : String(e)}` } };
+      await new Promise((s) => setTimeout(s, 1500 * (i + 1)));
+    }
+  }
+  return { error: { message: "exhausted retries — UNREAD, not empty" } };
+}
+
+function err(e: unknown): string {
+  const o = e as { message?: string; data?: unknown; code?: unknown } | null | undefined;
+  if (!o) return "unknown";
+  return [o.code !== undefined ? `code ${String(o.code)}` : "", o.message ?? "", typeof o.data === "string" ? o.data : ""]
+    .filter(Boolean).join(" · ").slice(0, 220);
+}
+
+const readEst = (r: { result?: unknown }) => {
+  const o = r.result as Record<string, string> | undefined;
+  if (!o || o.verificationGasLimit === undefined) return null;
+  const n = (k: string) => (o[k] === undefined ? 0n : BigInt(o[k]));
+  const call = n("callGasLimit"), ver = n("verificationGasLimit"), pre = n("preVerificationGas");
+  return { call, ver, pre, total: call + ver + pre };
+};
+const fmt = (n: bigint) => n.toLocaleString("en-US");
+
+async function main() {
+  const apiKey = process.env.MERRYMEN_BUNDLER_API_KEY;
+  const bundler = apiKey ? pimlicoBundlerUrl(CHAIN_ID, apiKey) : null;
+  console.log(`bundler: ${bundler ? `${new URL(bundler).host} (key present, ${apiKey!.length} chars)` : "NO KEY — oracle 1 will be skipped and reported as UNREAD"}`);
+
+  const chain = chainForId(CHAIN_ID);
+  const publicClient = createPublicClient({ chain, transport: http(RPC) });
+  const entryPoint = getEntryPoint("0.7");
+  const ep = entryPoint.address as Address;
+
+  // ── the account under test: throwaway owner, real merrymen wall shape ──────
+  const owner = privateKeyToAccount(generatePrivateKey());
+  const ecdsa = await signerToEcdsaValidator(publicClient, { signer: owner, entryPoint, kernelVersion: KERNEL_V3_3 });
+  console.log(`\nECDSAValidator in use: ${ecdsa.address}  ${ecdsa.address.toLowerCase() === ECDSA_VALIDATOR.toLowerCase() ? "== the one live on 4663 (2,110 accounts)" : "!! DIFFERS from the chain's — overrides below would be aimed at the wrong contract"}`);
+
+  const sudoOnly = await createKernelAccount(publicClient, { entryPoint, kernelVersion: KERNEL_V3_3, plugins: { sudo: ecdsa } });
+  const sessionSigner = await toECDSASigner({ signer: privateKeyToAccount(generatePrivateKey()) });
+  const { policies } = buildWallPolicies({ caps: CAPS, smartAccount: sudoOnly.address });
+  const permission = await toPermissionValidator(publicClient, {
+    entryPoint, kernelVersion: KERNEL_V3_3, signer: sessionSigner, policies, flag: WALL_POLICY_FLAG,
+  });
+  const account = await createKernelAccount(publicClient, {
+    entryPoint, kernelVersion: KERNEL_V3_3, plugins: { sudo: ecdsa, regular: permission },
+  });
+  const S = account.address as Address;
+  console.log(`wall: ${policies.length} policies · permissionId ${permission.getIdentifier()}`);
+  console.log(`account S = ${S}   (sudo-only derivation ${sudoOnly.address} — ${sudoOnly.address === S ? "SAME address, as merrymen asserts" : "DIFFERENT (unexpected)"})`);
+
+  const realCode = await publicClient.getCode({ address: S }).catch(() => "UNREAD" as const);
+  console.log(`S on chain: ${realCode === "UNREAD" ? "UNREAD (getCode failed)" : realCode && realCode !== "0x" ? `${(realCode.length - 2) / 2} bytes (UNEXPECTED)` : "no code — counterfactual, as required"}`);
+
+  // ── the synthetic deployment ──────────────────────────────────────────────
+  const ownerSlot = keccak256(encodeAbiParameters([{ type: "address" }, { type: "uint256" }], [S, 0n]));
+  const bigBalance = `0x${(10n ** 18n).toString(16)}` as Hex;
+  const accountOv = {
+    balance: bigBalance,
+    code: KERNEL_PROXY_RUNTIME,
+    stateDiff: { [IMPL_SLOT]: IMPL_V33, [VAL_BASE]: VAL_BASE0_LIVE },
+  };
+  const validatorOv = { stateDiff: { [ownerSlot]: pad(owner.address) as Hex } };
+  const DEPLOYED: Ov = { [S]: accountOv, [ECDSA_VALIDATOR]: validatorOv };
+  const UNDEPLOYED: Ov = { [S]: { balance: bigBalance } };
+
+  console.log(`\n── THE SYNTHETIC DEPLOYMENT ──────────────────────────────────`);
+  console.log(`  S.code            <- ${(KERNEL_PROXY_RUNTIME.length - 2) / 2}-byte Kernel ERC-1967 proxy, cloned from 0x032Da6A0… / 0xa48cE91e…`);
+  console.log(`  S[implSlot]       <- ${IMPL_V33}`);
+  console.log(`  S[valBase+0]      <- ${VAL_BASE0_LIVE}  (rootValidator 0x01||${ECDSA_VALIDATOR})`);
+  console.log(`  validator[${ownerSlot.slice(0, 12)}…] <- ${owner.address}  (ecdsaValidatorStorage[S] = my throwaway owner)`);
+
+  // ── CONTROLS ON THE CLONE ITSELF (chain node, eth_call) ───────────────────
+  console.log(`\n── CONTROL A: does the clone actually behave like a Kernel? ──`);
+  const callOv = async (to: Address, data: Hex, ov: Ov | null) =>
+    rpc(RPC, "eth_call", ov ? [{ to, data }, "latest", ov] : [{ to, data }, "latest"]);
+
+  const rootData = encodeFunctionData({ abi: ROOT_VALIDATOR_ABI, functionName: "rootValidator" });
+  const a1 = await callOv(S, rootData, DEPLOYED);
+  console.log(`  S.rootValidator() WITH overrides   -> ${a1.error ? `ERR ${err(a1.error)}` : a1.result}`);
+  const a2 = await callOv(S, rootData, null);
+  console.log(`  S.rootValidator() WITHOUT (control)-> ${a2.error ? `ERR ${err(a2.error)}` : `${a2.result} ${a2.result === "0x" ? "(empty — no code, as expected)" : ""}`}`);
+  const a3 = await callOv(S, rootData, { [S]: { balance: bigBalance, code: KERNEL_PROXY_RUNTIME, stateDiff: { [VAL_BASE]: VAL_BASE0_LIVE } } });
+  console.log(`  …code but NO impl slot (control)   -> ${a3.error ? `ERR ${err(a3.error)}` : `${a3.result} ${a3.result === "0x" ? "(delegatecall to 0x0 — clone is impl-driven, good)" : ""}`}`);
+
+  const ownerData = encodeFunctionData({ abi: ECDSA_STORAGE_ABI, functionName: "ecdsaValidatorStorage", args: [S] });
+  const b1 = await callOv(ECDSA_VALIDATOR, ownerData, DEPLOYED);
+  console.log(`  validator.ecdsaValidatorStorage(S) WITH   -> ${b1.error ? `ERR ${err(b1.error)}` : b1.result}  ${typeof b1.result === "string" && b1.result.toLowerCase().endsWith(owner.address.slice(2).toLowerCase()) ? "== my owner ✓" : "!! not my owner"}`);
+  const b2 = await callOv(ECDSA_VALIDATOR, ownerData, null);
+  console.log(`  …WITHOUT overrides (control)             -> ${b2.error ? `ERR ${err(b2.error)}` : `${b2.result} ${/^0x0*$/.test(String(b2.result)) ? "(zero — S is a stranger to the real validator, as expected)" : ""}`}`);
+
+  // ── the operation. approve-only callData, exactly as probe.ts section 5. ──
+  const approveCall = {
+    to: CASH.USDG as Address, value: 0n,
+    data: encodeFunctionData({ abi: erc20Abi, functionName: "approve", args: [UNISWAP.swapRouter02 as Address, 5_000_000n] }),
+  };
+  const walledCallData = await account.encodeCalls([approveCall]);
+  const sudoCallData = await sudoOnly.encodeCalls([approveCall]);
+
+  const fees = await publicClient.estimateFeesPerGas().catch(() => null);
+  const maxFeePerGas = fees?.maxFeePerGas ?? 1_000_000_000n;
+  const maxPriorityFeePerGas = fees?.maxPriorityFeePerGas ?? 0n;
+
+  const walledNonce = await account.getNonce();
+  const sudoNonce = await sudoOnly.getNonce();
+  const factoryArgs = await account.getFactoryArgs();
+  const sudoFactoryArgs = await sudoOnly.getFactoryArgs();
+
+  const hx = (n: bigint) => `0x${n.toString(16)}`;
+  const nonceHex = hx(walledNonce);
+  const mode = `0x${(walledNonce >> 248n).toString(16).padStart(2, "0")}`;
+  const vType = `0x${((walledNonce >> 240n) & 0xffn).toString(16).padStart(2, "0")}`;
+  console.log(`\n── THE OPERATION ────────────────────────────────────────────`);
+  console.log(`  walled nonce ${nonceHex}`);
+  console.log(`  mode ${mode} ${mode === "0x01" ? "(ENABLE)" : "(NOT enable!)"} · vType ${vType} ${vType === "0x02" ? "(PERMISSION)" : ""}  -> isFirstEnable(nonce) = ${mode === "0x01" && vType === "0x02"}`);
+  console.log(`  sudo   nonce ${hx(sudoNonce)}  mode 0x${(sudoNonce >> 248n).toString(16).padStart(2, "0")}`);
+
+  const walledStub = await account.getStubSignature({
+    sender: S, nonce: walledNonce, callData: walledCallData,
+    callGasLimit: 0n, verificationGasLimit: 0n, preVerificationGas: 0n,
+    maxFeePerGas: 0n, maxPriorityFeePerGas: 0n, signature: "0x", ...factoryArgs,
+  } as never);
+  const sudoStub = await sudoOnly.getStubSignature({
+    sender: S, nonce: sudoNonce, callData: sudoCallData,
+    callGasLimit: 0n, verificationGasLimit: 0n, preVerificationGas: 0n,
+    maxFeePerGas: 0n, maxPriorityFeePerGas: 0n, signature: "0x", ...sudoFactoryArgs,
+  } as never);
+  console.log(`  walled stub signature ${(walledStub.length - 2) / 2} bytes (the plugin-enable blob) · sudo stub ${(sudoStub.length - 2) / 2} bytes`);
+
+  // ═══ ORACLE 1 — Pimlico, 2x2 factorial ═══════════════════════════════════
+  console.log(`\n═══ ORACLE 1 · Pimlico eth_estimateUserOperationGas · 2x2 ════`);
+  const base = { maxFeePerGas: hx(maxFeePerGas), maxPriorityFeePerGas: hx(maxPriorityFeePerGas), sender: S };
+  const arms: Record<string, { op: Record<string, unknown>; ov: Ov | null; must: string }> = {
+    "U-S  undeployed · sudo-only": {
+      op: { ...base, nonce: hx(sudoNonce), factory: sudoFactoryArgs.factory, factoryData: sudoFactoryArgs.factoryData, callData: sudoCallData, signature: sudoStub },
+      ov: UNDEPLOYED, must: "succeed",
+    },
+    "U-W  undeployed · WALLED": {
+      op: { ...base, nonce: nonceHex, factory: factoryArgs.factory, factoryData: factoryArgs.factoryData, callData: walledCallData, signature: walledStub },
+      ov: UNDEPLOYED, must: "succeed",
+    },
+    "D-S  synth-deployed · sudo-only": {
+      op: { ...base, nonce: hx(sudoNonce), callData: sudoCallData, signature: sudoStub },
+      ov: DEPLOYED, must: "succeed (proves the clone is a working account)",
+    },
+    "D-W  synth-deployed · WALLED  <<< THE RENEWAL": {
+      op: { ...base, nonce: nonceHex, callData: walledCallData, signature: walledStub },
+      ov: DEPLOYED, must: "succeed",
+    },
+    "N1   synth-deployed · WALLED · NO code override": {
+      op: { ...base, nonce: nonceHex, callData: walledCallData, signature: walledStub },
+      ov: UNDEPLOYED, must: "FAIL — no code, no factory",
+    },
+    "N2   synth-deployed · sudo-only · NO owner override": {
+      op: { ...base, nonce: hx(sudoNonce), callData: sudoCallData, signature: sudoStub },
+      ov: { [S]: accountOv }, must: "FAIL or differ — validator does not know S's owner",
+    },
+    "N3   synth-deployed · WALLED · NO rootValidator word": {
+      op: { ...base, nonce: nonceHex, callData: walledCallData, signature: walledStub },
+      ov: { [S]: { balance: bigBalance, code: KERNEL_PROXY_RUNTIME, stateDiff: { [IMPL_SLOT]: IMPL_V33 } }, [ECDSA_VALIDATOR]: validatorOv },
+      must: "FAIL — enable sig has no root validator to check against",
+    },
+  };
+  const o1: Record<string, ReturnType<typeof readEst>> = {};
+  for (const [label, { op, ov, must }] of Object.entries(arms)) {
+    if (!bundler) { console.log(`  ${label.padEnd(48)} UNREAD (no bundler key)`); continue; }
+    const r = await rpc(bundler, "eth_estimateUserOperationGas", ov ? [op, ep, ov] : [op, ep]);
+    const v = readEst(r);
+    o1[label] = v;
+    console.log(`  ${label}`);
+    console.log(`      expect: ${must}`);
+    console.log(v
+      ? `      verif ${fmt(v.ver).padStart(11)} · preVerif ${fmt(v.pre).padStart(9)} · call ${fmt(v.call).padStart(8)} · RAW ${fmt(v.total)}`
+      : `      REFUSED: ${err(r.error)}`);
+  }
+
+  // ═══ ORACLE 2 — the chain node, no bundler at all ════════════════════════
+  // eth_estimateGas of EntryPoint -> S.validateUserOp(op, hash, 0). This prices
+  // the verification phase directly: the enable (installValidations + every
+  // policy's onInstall) plus the signature checks. Nothing Pimlico-shaped in it.
+  console.log(`\n═══ ORACLE 2 · chain node · eth_estimateGas(EntryPoint -> S.validateUserOp) ══`);
+  const packFor = (nonce: bigint, callData: Hex, signature: Hex) => {
+    const uo = {
+      sender: S, nonce, callData, signature,
+      callGasLimit: 200_000n, verificationGasLimit: 20_000_000n, preVerificationGas: 300_000n,
+      maxFeePerGas, maxPriorityFeePerGas,
+    } as never;
+    const hash = getUserOperationHash({ chainId: CHAIN_ID, entryPointAddress: ep, entryPointVersion: "0.7", userOperation: uo });
+    const packed = toPackedUserOperation(uo);
+    return { data: encodeFunctionData({ abi: VALIDATE_USER_OP_ABI, functionName: "validateUserOp", args: [packed as never, hash, 0n] }), hash };
+  };
+
+  const g = async (label: string, nonce: bigint, callData: Hex, signature: Hex, ov: Ov | null, must: string) => {
+    const { data } = packFor(nonce, callData, signature);
+    const r = await rpc(RPC, "eth_estimateGas", ov ? [{ from: ep, to: S, data }, "latest", ov] : [{ from: ep, to: S, data }, "latest"]);
+    const val = typeof r.result === "string" ? BigInt(r.result) : null;
+    console.log(`  ${label}`);
+    console.log(`      expect: ${must}`);
+    console.log(val === null ? `      REFUSED: ${err(r.error)}` : `      gas ${fmt(val)}`);
+    return val;
+  };
+
+  const gWalledDeployed = await g("E1  synth-deployed · WALLED validateUserOp  <<< the enable, priced alone", walledNonce, walledCallData, walledStub, DEPLOYED, "succeed — this is the renewal's verification work");
+  const gSudoDeployed = await g("E2  synth-deployed · sudo-only validateUserOp (baseline)", sudoNonce, sudoCallData, sudoStub, DEPLOYED, "succeed — root-validator path, no enable");
+  await g("E3  CONTROL · WALLED validateUserOp · NO code override", walledNonce, walledCallData, walledStub, UNDEPLOYED, "FAIL — S has no code");
+  await g("E4  CONTROL · WALLED validateUserOp · NO owner override", walledNonce, walledCallData, walledStub, { [S]: accountOv }, "FAIL or cheaper — enable sig cannot verify");
+  await g("E5  CONTROL · caller is NOT the EntryPoint", walledNonce, walledCallData, walledStub, DEPLOYED, "FAIL — Kernel gates validateUserOp on msg.sender")
+    .catch(() => null);
+  {
+    const { data } = packFor(walledNonce, walledCallData, walledStub);
+    const r = await rpc(RPC, "eth_estimateGas", [{ from: "0x000000000000000000000000000000000000dEaD", to: S, data }, "latest", DEPLOYED]);
+    console.log(`  E5b from 0x…dEaD instead of the EntryPoint -> ${typeof r.result === "string" ? `gas ${fmt(BigInt(r.result))} (UNEXPECTED — no gate?)` : `REFUSED: ${err(r.error)} (correct)`}`);
+  }
+
+  // ── VERDICT ───────────────────────────────────────────────────────────────
+  console.log(`\n═══ VERDICT ════════════════════════════════════════════════`);
+  const dW = o1["D-W  synth-deployed · WALLED  <<< THE RENEWAL"];
+  const uW = o1["U-W  undeployed · WALLED"];
+  const dS = o1["D-S  synth-deployed · sudo-only"];
+  const uS = o1["U-S  undeployed · sudo-only"];
+  if (dW && uW) {
+    console.log(`  RENEWAL (deployed + enable)  RAW ${fmt(dW.total)}   verif ${fmt(dW.ver)}`);
+    console.log(`  FIRST OP (undeployed+enable) RAW ${fmt(uW.total)}   verif ${fmt(uW.ver)}`);
+    console.log(`  deployment saves only ${fmt(uW.total - dW.total)} raw gas (${((Number(uW.total - dW.total) / Number(uW.total)) * 100).toFixed(1)}% of the first op)`);
+  } else console.log(`  one of the walled arms is UNREAD — see above; not treating that as zero`);
+  if (dW && dS) console.log(`  enable premium ON A DEPLOYED ACCOUNT (oracle 1): raw +${fmt(dW.total - dS.total)} · verif +${fmt(dW.ver - dS.ver)}`);
+  if (uW && uS) console.log(`  enable premium on an UNDEPLOYED account (oracle 1): raw +${fmt(uW.total - uS.total)} · verif +${fmt(uW.ver - uS.ver)}`);
+  if (gWalledDeployed !== null && gSudoDeployed !== null)
+    console.log(`  enable premium ON A DEPLOYED ACCOUNT (oracle 2, bundler-free): +${fmt(gWalledDeployed - gSudoDeployed)} gas  (E1 ${fmt(gWalledDeployed)} − E2 ${fmt(gSudoDeployed)})`);
+
+  // boundGas, applied exactly as worker/src/gas-limits.ts does.
+  const bound = (v: { call: bigint; ver: bigint; pre: bigint }) =>
+    (v.call * 20_000n) / 10_000n + (v.ver * 12_500n) / 10_000n + (v.pre * 12_500n) / 10_000n;
+  if (dW) {
+    const b = bound(dW);
+    console.log(`\n  boundGas(renewal) = ${fmt(b)}`);
+    console.log(`    vs GAS_BOUNDS.absoluteMax        3,000,000  -> ${b > 3_000_000n ? `REFUSED, ${(Number(b) / 3e6).toFixed(2)}x over` : "accepted"}`);
+    console.log(`    vs FIRST_ENABLE_GAS_BOUNDS      12,000,000  -> ${b > 12_000_000n ? "REFUSED" : `accepted, ${((Number(b) / 12e6) * 100).toFixed(1)}% of ceiling`}`);
+    const feeCeiling = maxFeePerGas;
+    console.log(`  and PR #56 hands a renewal a balance override of 3,000,000 x ${feeCeiling} x 2 = ${fmt(3_000_000n * feeCeiling * 2n)} wei,`);
+    console.log(`  which buys ${fmt((3_000_000n * feeCeiling * 2n) / feeCeiling)} gas for an op needing ${fmt(dW.total)} -> the estimate itself cannot complete.`);
+  }
+}
+
+main().catch((e) => {
+  console.error("synth-deployed failed:", e instanceof Error ? (e.stack ?? e.message) : String(e));
+  process.exit(1);
+});

--- a/spikes/first-op-gas/verify-gate-facts.mjs
+++ b/spikes/first-op-gas/verify-gate-facts.mjs
@@ -1,0 +1,119 @@
+/**
+ * Three facts the new ceiling gate rests on, checked directly rather than taken
+ * on report. Plain RPC only — no SDK, no bundler, no key, nothing signed.
+ *
+ *   1. The permission id really is bytes 2..5 of the nonce, i.e. (n >> 208) & 0xffffffff.
+ *   2. permissionConfig(pId) on the ACCOUNT distinguishes installed from absent,
+ *      and answers EMPTY (not zero) for an address with no code.
+ *   3. The EntryPoint's sequence for a landed enable key is 1, and 0 for one that
+ *      never landed — so "sequence == 0" really does mean "never included".
+ *
+ * Run: node spikes/first-op-gas/verify-gate-facts.mjs
+ */
+const RPC = "https://rpc.mainnet.chain.robinhood.com";
+const ENTRYPOINT = "0x0000000071727De22E5E9d8BAf0edAc6f37da032";
+
+let id = 0;
+async function rpc(method, params) {
+  const r = await fetch(RPC, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: ++id, method, params }),
+  });
+  const j = await r.json();
+  if (j.error) return { error: j.error.message ?? JSON.stringify(j.error) };
+  return { result: j.result };
+}
+
+const hex = (n, bytes) => n.toString(16).padStart(bytes * 2, "0");
+
+/** key = mode(1) ‖ vType(1) ‖ identifier(20) ‖ nonceKey(2) — 24 bytes, uint192. */
+function nonceKey(mode, vType, identifier20) {
+  return BigInt(`0x${hex(mode, 1)}${hex(vType, 1)}${identifier20.replace(/^0x/, "")}0000`);
+}
+
+async function getNonce(sender, key) {
+  // getNonce(address,uint192) -> 0x35567e1a
+  const data = `0x35567e1a${sender.replace(/^0x/, "").toLowerCase().padStart(64, "0")}${hex(key, 32)}`;
+  const { result, error } = await rpc("eth_call", [{ to: ENTRYPOINT, data }, "latest"]);
+  return error ? { error } : { nonce: BigInt(result) };
+}
+
+async function permissionConfig(account, pId4) {
+  // permissionConfig(bytes4) -> 0xc3e58978, bytes4 is LEFT-aligned in its word
+  const data = `0xc3e58978${pId4.replace(/^0x/, "")}${"0".repeat(56)}`;
+  const { result, error } = await rpc("eth_call", [{ to: account, data }, "latest"]);
+  return error ? { error } : { raw: result };
+}
+
+const ACCOUNTS = {
+  // merrymen's own live account: one UserOperation ever, a sudo deploy.
+  merrymen: "0x032Da6A0Ccf866474e45854E7fDEF9afd1509036",
+  // A live Kernel v3.3 account whose permission validator DID land.
+  walled: "0xa48cE91e2F3237E69660C1543042c007B8D33e75",
+  // No code at all.
+  codeless: "0x000000000000000000000000000000000000c0de",
+};
+const LANDED_PID = "0x3ca1cec8"; // reported as installed on `walled`
+const NEVER_PID = "0xdeadbeef";
+
+async function main() {
+  console.log("FACT 2 — permissionConfig(pId) is keyed by (account, permissionId)\n");
+  for (const [who, addr] of Object.entries(ACCOUNTS)) {
+    const { result: code } = await rpc("eth_getCode", [addr, "latest"]);
+    for (const pid of [LANDED_PID, NEVER_PID]) {
+      const r = await permissionConfig(addr, pid);
+      const raw = r.raw ?? `ERROR ${r.error}`;
+      // Struct is dynamic: word0 = offset, word1 = flag, word2 = signer.
+      let read = "empty returndata";
+      if (typeof raw === "string" && raw.length >= 2 + 64 * 3) {
+        const flag = "0x" + raw.slice(2 + 64, 2 + 64 + 64).slice(0, 8);
+        const signer = "0x" + raw.slice(2 + 128 + 24, 2 + 192);
+        read =
+          BigInt("0x" + raw.slice(2 + 128, 2 + 192)) === 0n
+            ? "NOT installed (signer 0x0)"
+            : `INSTALLED flag ${flag} signer ${signer}`;
+      } else if (raw.startsWith("ERROR")) {
+        read = raw;
+      }
+      console.log(
+        `  ${who.padEnd(9)} code ${String((code ?? "0x").length / 2 - 1).padStart(3)}B · ${pid} -> ${read}`,
+      );
+    }
+  }
+
+  console.log("\nFACT 1 — the permission id is bytes 2..5 of the nonce\n");
+  // Build the ENABLE key for a known pId and read the nonce back; then extract
+  // the id from that nonce with the shift the gate will use and require a match.
+  const ident = LANDED_PID.replace(/^0x/, "") + "0".repeat(32); // pId(4) + 16 zero bytes
+  const key = nonceKey(0x01, 0x02, ident);
+  const { nonce, error } = await getNonce(ACCOUNTS.walled, key);
+  if (error) {
+    console.log(`  COULD NOT READ: ${error}`);
+  } else {
+    const extracted = "0x" + (((nonce >> 208n) & 0xffffffffn).toString(16).padStart(8, "0"));
+    const wrong = "0x" + (((nonce >> 224n) & 0xffffffffn).toString(16).padStart(8, "0"));
+    console.log(`  nonce            0x${hex(nonce, 32)}`);
+    console.log(`  >> 208 (correct) ${extracted}   ${extracted === LANDED_PID ? "MATCHES" : "MISMATCH"}`);
+    console.log(`  >> 224 (the trap) ${wrong}   <- mode+vType glued to the id`);
+    console.log(`  mode ${"0x" + hex((nonce >> 248n) & 0xffn, 1)} · vType ${"0x" + hex((nonce >> 240n) & 0xffn, 1)}`);
+  }
+
+  console.log("\nFACT 3 — sequence 0 means the enable was never included\n");
+  const cases = [
+    ["walled  · landed enable key", ACCOUNTS.walled, 0x01, 0x02, LANDED_PID],
+    ["walled  · default key      ", ACCOUNTS.walled, 0x00, 0x02, LANDED_PID],
+    ["walled  · never-used id    ", ACCOUNTS.walled, 0x01, 0x02, NEVER_PID],
+    ["merrymen· same id, never   ", ACCOUNTS.merrymen, 0x01, 0x02, LANDED_PID],
+  ];
+  for (const [label, addr, mode, vType, pid] of cases) {
+    const k = nonceKey(mode, vType, pid.replace(/^0x/, "") + "0".repeat(32));
+    const { nonce: n, error: e } = await getNonce(addr, k);
+    console.log(`  ${label} -> ${e ? `COULD NOT READ: ${e}` : `sequence ${n & 0xffffffffffffffffn}`}`);
+  }
+}
+
+main().catch((e) => {
+  console.error(String(e).slice(0, 400));
+  process.exit(1);
+});

--- a/worker/src/executor.ts
+++ b/worker/src/executor.ts
@@ -22,7 +22,7 @@ import { deserializeFlaggedPermissionAccount } from "./session-account";
 import { WALL_POLICY_FLAG } from "../../packages/core/src/index";
 import { userOpGasConfig } from "./gas";
 import { getUserOperationHash } from "viem/account-abstraction";
-import { boundGas, DEPLOY_GAS_BOUNDS, GAS_BOUNDS, totalGas, type UserOpGas } from "./gas-limits";
+import { boundGas, FIRST_ENABLE_GAS_BOUNDS, GAS_BOUNDS, totalGas, type UserOpGas } from "./gas-limits";
 
 export interface Call {
   to: `0x${string}`;
@@ -130,6 +130,33 @@ export class GasRefused extends Error {
   }
 }
 
+/**
+ * DOES THIS OPERATION CARRY A PERMISSION-VALIDATOR ENABLE?
+ *
+ * Asked of the operation itself, not of the account. "The account has no code"
+ * is a fact about an address and admits every shape an undeployed account could
+ * send; the elevated first-enable ceiling must be reachable only by the one
+ * shape that earns it.
+ *
+ * Kernel v3 packs the answer into the nonce. The 32-byte nonce is
+ * `key(24) ‖ seq(8)`, and the key is `mode(1) ‖ vType(1) ‖ validator(20) ‖ id(2)`
+ * — so the top two bytes of the nonce are the mode and the validator type.
+ * @zerodev/sdk sets VALIDATOR_MODE.ENABLE (0x01) exactly when the regular
+ * validator is not yet enabled on-chain, and VALIDATOR_TYPE.PERMISSION is 0x02.
+ *
+ * Measured on 4663, 2026-09-03:
+ *   sudo-only account   0x0000845adb2c…  mode 0x00 (DEFAULT)  -> not an enable
+ *   walled account      0x0102630974640…  mode 0x01, type 0x02 -> IS an enable
+ *
+ * Both bytes are required. Mode alone would also admit an enable of some other
+ * validator type, which is not the operation this ceiling was measured for.
+ */
+export function isFirstEnable(nonce: bigint): boolean {
+  const mode = (nonce >> 248n) & 0xffn;
+  const vType = (nonce >> 240n) & 0xffn;
+  return mode === 0x01n && vType === 0x02n;
+}
+
 /** How many times the RECEIPT is re-read. Never the send — see execute(). */
 const RECEIPT_ATTEMPTS = 3;
 
@@ -215,14 +242,20 @@ export async function createAgentExecutor(opts: {
    * Asked here rather than passed in, because the answer CHANGES and the caller
    * reads it once at arm: an `accountDeployed: false` threaded down from arm
    * time would still say false for every later op of that arm, leaving them all
-   * under the wide deploy ceiling. That is a guard turning itself off silently.
+   * under the wide first-enable ceiling. That is a guard turning itself off
+   * silently.
    *
    * One read, memoised, and only on the first execute of a process that has an
    * executor at all. A FAILED READ ANSWERS "not deployed", which is the safe
    * direction here and the opposite of the rule elsewhere in this repo: being
    * wrong that way widens a pre-sign ceiling for one operation, while being
-   * wrong the other way refuses the operation outright. The bound still holds —
-   * DEPLOY_GAS_BOUNDS is a ceiling, not an exemption.
+   * wrong the other way refuses the operation outright.
+   *
+   * And since Stage E this answer is no longer sufficient on its own. The wide
+   * ceiling needs BOTH this and isFirstEnable(nonce) — so a failed read cannot
+   * widen anything by itself; the operation still has to prove out of its own
+   * nonce that it carries a permission-validator enable. FIRST_ENABLE_GAS_BOUNDS
+   * remains a ceiling either way, not an exemption.
    */
   let deployed: boolean | null = null;
   const isDeployed = async (): Promise<boolean> => {
@@ -264,6 +297,36 @@ export async function createAgentExecutor(opts: {
             // gas, so the three limits we bound would be measured against a
             // different operation than the one that gets signed.
             ...(opts.sponsor ? { paymaster: opts.sponsor.estimateOnly } : {}),
+            // ── A BALANCE THAT EXISTS ONLY INSIDE THIS SIMULATION ──────────
+            //
+            // viem sends the estimate with no gas limits at all, so the bundler
+            // substitutes its own for the simulation — and the EntryPoint's
+            // prefund check then runs against the account's REAL balance,
+            // against limits nobody chose. On 4663, where the block gas limit is
+            // 1.125e15, that produced "AA21 didn't pay prefund" on twenty-four
+            // consecutive live attempts and no gas figure at all: boundGas never
+            // received a number, so every refusal was "gas-unreadable".
+            //
+            // Proven, 2026-09-03: without this the same operation is AA21; with
+            // it the simulation runs through validation into execution; and
+            // overriding an UNRELATED address is AA21 again, so the override is
+            // genuinely applied rather than ignored. The estimate is identical
+            // at 0.01, 0.05, 0.2 and 1 ETH, so it is not a search artefact.
+            //
+            // WHAT THIS CANNOT DO. It is a parameter of one RPC call.
+            // A state override is not part of a UserOperation, so it cannot reach
+            // what is signed, what is broadcast, the calldata, the prefund the
+            // EntryPoint actually charges, any policy check, or any on-chain
+            // state. The account's real balance is checked separately below, and
+            // a genuinely underfunded account is still refused.
+            //
+            // Sized from OUR OWN CEILING rather than a round number, so the
+            // simulation is never handed more room than we would ever sign for.
+            // Doubled because the bundler simulates with limits of its own
+            // choosing, which are not ours to predict.
+            stateOverride: [
+              { address: account.address, balance: bounds.absoluteMax * feeCeiling * 2n },
+            ],
           })) as Partial<UserOpGas>;
           if (
             typeof g.callGasLimit !== "bigint" ||
@@ -276,6 +339,15 @@ export async function createAgentExecutor(opts: {
             callGasLimit: g.callGasLimit,
             verificationGasLimit: g.verificationGasLimit,
             preVerificationGas: g.preVerificationGas,
+            // Carried so boundGas can count them against the ceiling — the
+            // EntryPoint's prefund does — and so an unexpected paymaster on a
+            // self-paying operation is refused rather than invisible.
+            ...(typeof g.paymasterVerificationGasLimit === "bigint"
+              ? { paymasterVerificationGasLimit: g.paymasterVerificationGasLimit }
+              : {}),
+            ...(typeof g.paymasterPostOpGasLimit === "bigint"
+              ? { paymasterPostOpGasLimit: g.paymasterPostOpGasLimit }
+              : {}),
           };
         } catch (e) {
           // A refusal to quote, NOT a quote of zero — boundGas is told null and
@@ -299,16 +371,56 @@ export async function createAgentExecutor(opts: {
           return null;
         }
       };
+      // The fee the override is priced at. Read once, and generously: this
+      // number never reaches a signature — it only decides how much imaginary
+      // balance the simulation is handed — so erring high costs nothing and
+      // erring low reintroduces the AA21 this whole block exists to remove.
+      const feeCeiling = await publicClient
+        .estimateFeesPerGas()
+        .then((f) => f.maxFeePerGas)
+        .catch(() => 5_000_000_000n); // 5 gwei, ~10x the observed 4663 rate
+
+      // WHICH CEILING, DECIDED BEFORE THE ESTIMATE because the override is sized
+      // from it. Both conditions are required: the account has never operated,
+      // AND the operation proves out of its own nonce that it carries a
+      // permission-validator enable. Undeployed alone is not enough — that is a
+      // fact about an address, and every other shape an undeployed account could
+      // send gets the ordinary ceiling.
+      const accountLive = await isDeployed();
+      const nonce = await account.getNonce();
+      const firstEnable = !accountLive && isFirstEnable(nonce);
+      const bounds = firstEnable ? FIRST_ENABLE_GAS_BOUNDS : GAS_BOUNDS;
+
       const first = await estimate();
       // Only probe a second time when the first succeeded: a null first is
       // already a refusal, and asking again would just be slower.
       const second = first ? await estimate() : null;
-      // WHICH CEILING APPLIES DEPENDS ON WHETHER THIS ACCOUNT EXISTS YET.
-      // See DEPLOY_GAS_BOUNDS: the first op also deploys the account and enables
-      // the permission validator, and the steady-state ceiling would refuse it.
-      const accountLive = await isDeployed();
-      const bounds = accountLive ? GAS_BOUNDS : DEPLOY_GAS_BOUNDS;
-      const bounded = boundGas(first, second, bounds);
+      const bounded = boundGas(first, second, bounds, !!opts.sponsor);
+
+      // ── AND THE REAL BALANCE, WHICH THE OVERRIDE DID NOT CHANGE ──────────
+      //
+      // The simulation was handed an imaginary balance so it would produce a
+      // number instead of AA21. The chain will not be. So before anything is
+      // signed, ask what the account actually holds against what the EntryPoint
+      // will actually require, and say so in words if it is short.
+      //
+      // This is the check that keeps the override honest: without it, the patch
+      // would convert an opaque AA21 at estimation into an opaque AA21 at
+      // submission, having spent a signature on the way.
+      if (bounded.ok && !opts.sponsor) {
+        const required = bounded.total * feeCeiling;
+        const held = await publicClient.getBalance({ address: account.address }).catch(() => null);
+        if (held !== null && held < required) {
+          throw new GasRefused(
+            "prefund-short",
+            `this operation needs ${bounded.total} gas, which the EntryPoint requires the account to ` +
+              `HOLD as ${required} wei at ${feeCeiling} wei/gas. It holds ${held} wei — short by ` +
+              `${required - held}. Nothing was signed. The account is charged only for gas USED, but ` +
+              `it must hold the full amount up front, so this is a funding shortfall and not a refusal ` +
+              `by the chain.`,
+          );
+        }
+      }
 
       // SAY WHAT THE NUMBERS WERE.
       //
@@ -326,7 +438,8 @@ export async function createAgentExecutor(opts: {
           ? "unreadable"
           : `call ${g.callGasLimit} + verif ${g.verificationGasLimit} + preVerif ${g.preVerificationGas} = ${totalGas(g)}`;
       console.log(
-        `[gas] account ${accountLive ? "deployed" : "NOT deployed"} · ceiling ${bounds.absoluteMax} · ` +
+        `[gas] account ${accountLive ? "deployed" : "NOT deployed"} · ` +
+          `${firstEnable ? "FIRST-ENABLE" : "ordinary"} ceiling ${bounds.absoluteMax} · ` +
           `estimate1 ${fmt(first)} · estimate2 ${fmt(second)} · ` +
           `signed ${bounded.ok ? totalGas(bounded.gas) : "refused"}` +
           `${bounded.ok ? "" : ` (${bounded.rule})`}`,

--- a/worker/src/executor.ts
+++ b/worker/src/executor.ts
@@ -139,10 +139,10 @@ export class GasRefused extends Error {
  * shape that earns it.
  *
  * Kernel v3 packs the answer into the nonce. The 32-byte nonce is
- * `key(24) ‖ seq(8)`, and the key is `mode(1) ‖ vType(1) ‖ validator(20) ‖ id(2)`
+ * `key(24) ‖ seq(8)`, and the key is `mode(1) ‖ vType(1) ‖ identifier(20) ‖ id(2)`
  * — so the top two bytes of the nonce are the mode and the validator type.
  * @zerodev/sdk sets VALIDATOR_MODE.ENABLE (0x01) exactly when the regular
- * validator is not yet enabled on-chain, and VALIDATOR_TYPE.PERMISSION is 0x02.
+ * validator is not yet enabled ON CHAIN, and VALIDATOR_TYPE.PERMISSION is 0x02.
  *
  * Measured on 4663, 2026-09-03:
  *   sudo-only account   0x0000845adb2c…  mode 0x00 (DEFAULT)  -> not an enable
@@ -150,11 +150,146 @@ export class GasRefused extends Error {
  *
  * Both bytes are required. Mode alone would also admit an enable of some other
  * validator type, which is not the operation this ceiling was measured for.
+ *
+ * NECESSARY, NOT SUFFICIENT. This says the operation is SHAPED like an enable.
+ * It does not say the enable is one anybody needs — the SDK computes this mode
+ * from a read that fails toward ENABLE, so a single flaky eth_call can produce
+ * this shape for an operation whose validator is already installed. readEnableState
+ * below is what turns the shape into a justification.
  */
 export function isFirstEnable(nonce: bigint): boolean {
   const mode = (nonce >> 248n) & 0xffn;
   const vType = (nonce >> 240n) & 0xffn;
   return mode === 0x01n && vType === 0x02n;
+}
+
+/**
+ * The permission id this operation is enabling — bytes 2..5 of the nonce.
+ *
+ * The 20-byte identifier field holds the VALIDATOR for a sudo op and the
+ * 4-byte PERMISSION ID, left-aligned, for a permission op. Verified against a
+ * landed enable on 4663: nonce
+ * 0x01023ca1cec8…0001 yields 0x3ca1cec8, which is the id that transaction
+ * installed. Shifting by 224 instead — the obvious off-by-two — returns
+ * 0x01023ca1: the mode and type bytes glued to half the id, an id no operation
+ * will ever present, which would make every lookup below answer "absent" and
+ * turn the check into a no-op that always passes.
+ */
+export function noncePermissionId(nonce: bigint): `0x${string}` {
+  return `0x${(((nonce >> 208n) & 0xffffffffn).toString(16).padStart(8, "0"))}` as `0x${string}`;
+}
+
+/** The low 8 bytes. The EntryPoint owns these; nothing local chooses them. */
+export function nonceSequence(nonce: bigint): bigint {
+  return nonce & 0xffffffffffffffffn;
+}
+
+/** `permissionConfig(bytes4)`, read straight off the account. */
+const PERMISSION_CONFIG_SELECTOR = "0xc3e58978";
+
+/**
+ * WHY THIS OPERATION IS EXPENSIVE, OR WHY WE WILL NOT ASSUME IT IS.
+ *
+ * The elevated ceiling exists for one operation: the one that installs a session
+ * key's whole policy wall inside validation. Getting the gate wrong in either
+ * direction is expensive, and both directions have now been measured.
+ *
+ * TOO NARROW WAS THE FIRST BUG. This condition was `!accountLive && isFirstEnable(nonce)`,
+ * on the belief that a validator enable is one-time per ACCOUNT. It is one-time
+ * per SESSION KEY. Measured on 4663, 2026-09-03, on two real deployed accounts
+ * and a third synthesised one, a renewal on an account that already has code
+ * costs 7,401,680 / 7,530,220 / 7,569,825 raw — 96-98% of the undeployed first
+ * op's 7,711,654. Deployment is worth 141,823-309,974 gas, a rounding error
+ * against the enable. Every one-click renewal would have been refused.
+ *
+ * TOO WIDE IS THE HAZARD THE FIX INTRODUCES, and this function is why it does
+ * not. @zerodev's isPluginEnabled catches EVERY read error to `false` (both
+ * disjuncts do), so one flaky eth_call makes the SDK build an ENABLE-shaped
+ * operation for a validator that is already installed. Measured by fault
+ * injection: healthy read -> mode 0x00, one broken read -> mode 0x01, same
+ * account, same id. On the nonce alone that operation would have been handed
+ * 12,000,000 for work nobody needs.
+ *
+ * So the shape is checked against the chain, and the chain is asked about the
+ * exact id the operation names. Three things must all hold:
+ *
+ *   1. the nonce is enable-shaped                        (isFirstEnable)
+ *   2. its sequence is 0, so this enable has never been INCLUDED. The EntryPoint
+ *      increments only on inclusion, so a rejected or retried enable stays at 0
+ *      while a landed one is 1 forever. Measured: a landed enable key reads 1
+ *      and its account's traffic has moved to the default key; an id that never
+ *      landed reads 0. Nothing in this process can choose these bytes.
+ *   3. permissionConfig(id) on the account is empty. Measured to be keyed by
+ *      (account, id): the same id reads INSTALLED on one live account and absent
+ *      on another, and a codeless address answers with empty returndata rather
+ *      than zeros.
+ *
+ * AND IT FAILS CLOSED, which INVERTS the rule isDeployed uses twenty lines up.
+ * There, a failed read answers "not deployed" because being wrong that way only
+ * widened a ceiling. Here "no code" is a reason to widen, so a read we could not
+ * make must never be allowed to manufacture one. Unreadable is its own answer
+ * and it refuses. A refusal costs nothing and the next tick retries; a wrongly
+ * widened ceiling is a safety check that turned itself off.
+ */
+export type EnableState =
+  | { kind: "not-an-enable" }
+  | { kind: "fresh-enable"; permissionId: `0x${string}` }
+  | { kind: "replayed-enable"; permissionId: `0x${string}`; sequence: bigint }
+  | { kind: "already-installed"; permissionId: `0x${string}`; signer: `0x${string}` }
+  | { kind: "unreadable"; permissionId: `0x${string}`; detail: string };
+
+export async function readEnableState(
+  client: {
+    getCode(a: { address: `0x${string}` }): Promise<`0x${string}` | undefined>;
+    call(a: { to: `0x${string}`; data: `0x${string}` }): Promise<{ data?: `0x${string}` }>;
+  },
+  address: `0x${string}`,
+  nonce: bigint,
+): Promise<EnableState> {
+  if (!isFirstEnable(nonce)) return { kind: "not-an-enable" };
+  const permissionId = noncePermissionId(nonce);
+
+  const sequence = nonceSequence(nonce);
+  if (sequence !== 0n) return { kind: "replayed-enable", permissionId, sequence };
+
+  let code: `0x${string}` | undefined;
+  try {
+    code = await client.getCode({ address });
+  } catch (e) {
+    return { kind: "unreadable", permissionId, detail: `getCode failed: ${String(e).slice(0, 160)}` };
+  }
+  // Nothing can be installed on an account that does not exist yet. This is the
+  // ONE place "no code" is allowed to be an answer, and it is a positive one:
+  // the account is absent, so the id provably is too.
+  if (code === undefined || code === "0x") return { kind: "fresh-enable", permissionId };
+
+  let data: `0x${string}` | undefined;
+  try {
+    const r = await client.call({
+      to: address,
+      data: `${PERMISSION_CONFIG_SELECTOR}${permissionId.slice(2)}${"0".repeat(56)}` as `0x${string}`,
+    });
+    data = r.data;
+  } catch (e) {
+    return { kind: "unreadable", permissionId, detail: `permissionConfig failed: ${String(e).slice(0, 160)}` };
+  }
+  // The struct is dynamic — word0 is an offset, word1 the flag, word2 the signer.
+  // Anything shorter is not an answer we can read, and an account WITH code that
+  // returns nothing is stranger than one that returns zeros.
+  if (typeof data !== "string" || data.length < 2 + 64 * 3) {
+    return {
+      kind: "unreadable",
+      permissionId,
+      detail: `permissionConfig returned ${data ? `${data.length / 2 - 1} bytes` : "nothing"}, too short to read`,
+    };
+  }
+  const signerWord = data.slice(2 + 128, 2 + 192);
+  if (BigInt(`0x${signerWord}`) === 0n) return { kind: "fresh-enable", permissionId };
+  return {
+    kind: "already-installed",
+    permissionId,
+    signer: `0x${signerWord.slice(24)}` as `0x${string}`,
+  };
 }
 
 /** How many times the RECEIPT is re-read. Never the send — see execute(). */
@@ -241,21 +376,20 @@ export async function createAgentExecutor(opts: {
    *
    * Asked here rather than passed in, because the answer CHANGES and the caller
    * reads it once at arm: an `accountDeployed: false` threaded down from arm
-   * time would still say false for every later op of that arm, leaving them all
-   * under the wide first-enable ceiling. That is a guard turning itself off
-   * silently.
+   * time would still say false for every later op of that arm.
    *
-   * One read, memoised, and only on the first execute of a process that has an
-   * executor at all. A FAILED READ ANSWERS "not deployed", which is the safe
-   * direction here and the opposite of the rule elsewhere in this repo: being
-   * wrong that way widens a pre-sign ceiling for one operation, while being
-   * wrong the other way refuses the operation outright.
+   * A LABEL NOW, NOT A GUARD. This used to be half the first-enable gate, and
+   * that was the defect: a permission-validator enable is one-time per SESSION
+   * KEY, so every renewal is an enable on an account that already has code, and
+   * requiring the account to be absent refused every renewal at 3,000,000. The
+   * ceiling is chosen by readEnableState from the operation's own nonce and a
+   * confirming read of the chain; this answers only the question the [gas] line
+   * asks — was that an arm or a renewal — which the gas figures cannot answer
+   * for themselves, being within 3% of each other.
    *
-   * And since Stage E this answer is no longer sufficient on its own. The wide
-   * ceiling needs BOTH this and isFirstEnable(nonce) — so a failed read cannot
-   * widen anything by itself; the operation still has to prove out of its own
-   * nonce that it carries a permission-validator enable. FIRST_ENABLE_GAS_BOUNDS
-   * remains a ceiling either way, not an exemption.
+   * Which is also why A FAILED READ MAY STILL ANSWER "not deployed" here. It
+   * mislabels a log line and nothing more. readEnableState does its own getCode
+   * and fails CLOSED, because there "no code" is a reason to widen.
    */
   let deployed: boolean | null = null;
   const isDeployed = async (): Promise<boolean> => {
@@ -381,15 +515,53 @@ export async function createAgentExecutor(opts: {
         .catch(() => 5_000_000_000n); // 5 gwei, ~10x the observed 4663 rate
 
       // WHICH CEILING, DECIDED BEFORE THE ESTIMATE because the override is sized
-      // from it. Both conditions are required: the account has never operated,
-      // AND the operation proves out of its own nonce that it carries a
-      // permission-validator enable. Undeployed alone is not enough — that is a
-      // fact about an address, and every other shape an undeployed account could
-      // send gets the ordinary ceiling.
+      // from it. That ordering is also why a refusal here cannot be salvaged by
+      // retrying wider: the 3,000,000 branch hands the simulation ~6M gas of
+      // imaginary ETH for an operation needing ~7.5M, so a wrongly-narrowed
+      // ceiling does not come back absurd — it does not come back at all, and
+      // the owner is told "gas-unreadable" with no number in it.
+      //
+      // THE DEPLOY STATE DOES NOT VOTE. It is read for the log line below and
+      // nothing else; see readEnableState for what replaced it and why.
       const accountLive = await isDeployed();
       const nonce = await account.getNonce();
-      const firstEnable = !accountLive && isFirstEnable(nonce);
+      const enable = await readEnableState(publicClient, account.address, nonce);
+      const firstEnable = enable.kind === "fresh-enable";
       const bounds = firstEnable ? FIRST_ENABLE_GAS_BOUNDS : GAS_BOUNDS;
+
+      // An enable-shaped operation we cannot justify is refused BY NAME, before
+      // the estimate and long before a signature. Letting these fall through to
+      // the ordinary ceiling would refuse them too — but as "gas-unreadable",
+      // which says only that we failed to get a number and would send whoever
+      // reads it looking for an RPC fault that isn't there.
+      if (enable.kind === "replayed-enable") {
+        throw new GasRefused(
+          "enable-replayed",
+          `this operation enables permission ${enable.permissionId}, but the EntryPoint's sequence ` +
+            `for that key is ${enable.sequence}, not 0 — which it only reaches by being INCLUDED. ` +
+            "That enable has already landed, so this one would install a wall that is already there. " +
+            "Nothing was signed.",
+        );
+      }
+      if (enable.kind === "already-installed") {
+        throw new GasRefused(
+          "enable-redundant",
+          `this operation enables permission ${enable.permissionId}, but the account already has it ` +
+            `installed with signer ${enable.signer}. The bundler's own enable check would revert it ` +
+            "(AA23), and it is shaped this way because the SDK's plugin-enable read failed open, not " +
+            "because anything needs enabling. Nothing was signed.",
+        );
+      }
+      if (enable.kind === "unreadable") {
+        throw new GasRefused(
+          "enable-unverified",
+          `this operation is shaped like an enable of permission ${enable.permissionId}, which would ` +
+            `raise its gas ceiling to ${FIRST_ENABLE_GAS_BOUNDS.absoluteMax} — but the chain could not ` +
+            `be asked whether that enable is needed: ${enable.detail}. A ceiling widened on a read we ` +
+            "could not make is a check that turned itself off, so this refuses instead. Nothing was " +
+            "signed, and the next tick will ask again.",
+        );
+      }
 
       const first = await estimate();
       // Only probe a second time when the first succeeded: a null first is
@@ -439,7 +611,7 @@ export async function createAgentExecutor(opts: {
           : `call ${g.callGasLimit} + verif ${g.verificationGasLimit} + preVerif ${g.preVerificationGas} = ${totalGas(g)}`;
       console.log(
         `[gas] account ${accountLive ? "deployed" : "NOT deployed"} · ` +
-          `${firstEnable ? "FIRST-ENABLE" : "ordinary"} ceiling ${bounds.absoluteMax} · ` +
+          `${firstEnable ? `ENABLE ${noncePermissionId(nonce)}` : "ordinary"} ceiling ${bounds.absoluteMax} · ` +
           `estimate1 ${fmt(first)} · estimate2 ${fmt(second)} · ` +
           `signed ${bounded.ok ? totalGas(bounded.gas) : "refused"}` +
           `${bounded.ok ? "" : ` (${bounded.rule})`}`,

--- a/worker/src/executor.ts
+++ b/worker/src/executor.ts
@@ -22,7 +22,14 @@ import { deserializeFlaggedPermissionAccount } from "./session-account";
 import { WALL_POLICY_FLAG } from "../../packages/core/src/index";
 import { userOpGasConfig } from "./gas";
 import { getUserOperationHash } from "viem/account-abstraction";
-import { boundGas, FIRST_ENABLE_GAS_BOUNDS, GAS_BOUNDS, totalGas, type UserOpGas } from "./gas-limits";
+import {
+  boundGas,
+  checkPrefund,
+  FIRST_ENABLE_GAS_BOUNDS,
+  GAS_BOUNDS,
+  totalGas,
+  type UserOpGas,
+} from "./gas-limits";
 
 export interface Call {
   to: `0x${string}`;
@@ -292,6 +299,27 @@ export async function readEnableState(
   };
 }
 
+/**
+ * What the estimation override is priced at when the fee read fails.
+ *
+ * 5 gwei, about eleven times the ~0.45 gwei base fee observed on 4663. Generous
+ * ON PURPOSE and safe to be: it sizes an imaginary balance inside one simulation
+ * and can never reach a signature, a broadcast or a refusal. checkPrefund will
+ * not accept it — that path takes its fee from the prepared operation or refuses.
+ */
+const SIMULATION_FEE_FALLBACK = 5_000_000_000n;
+
+/** The one EntryPoint method this file reads: the sender's staked deposit. */
+const ENTRYPOINT_BALANCE_OF_ABI = [
+  {
+    inputs: [{ name: "account", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+] as const;
+
 /** How many times the RECEIPT is re-read. Never the send — see execute(). */
 const RECEIPT_ATTEMPTS = 3;
 
@@ -459,7 +487,7 @@ export async function createAgentExecutor(opts: {
             // Doubled because the bundler simulates with limits of its own
             // choosing, which are not ours to predict.
             stateOverride: [
-              { address: account.address, balance: bounds.absoluteMax * feeCeiling * 2n },
+              { address: account.address, balance: bounds.absoluteMax * simulationFee * 2n },
             ],
           })) as Partial<UserOpGas>;
           if (
@@ -505,14 +533,23 @@ export async function createAgentExecutor(opts: {
           return null;
         }
       };
-      // The fee the override is priced at. Read once, and generously: this
-      // number never reaches a signature — it only decides how much imaginary
-      // balance the simulation is handed — so erring high costs nothing and
-      // erring low reintroduces the AA21 this whole block exists to remove.
-      const feeCeiling = await publicClient
+      // THE SIMULATION'S FEE, AND NOTHING ELSE'S.
+      //
+      // This number never reaches a signature. Its only job is to decide how much
+      // imaginary balance the estimation override hands the bundler, so erring
+      // high costs nothing and erring low reintroduces the AA21 this block exists
+      // to remove — which is why the fallback is deliberately about eleven times
+      // the live rate on 4663.
+      //
+      // IT MUST NOT PRICE A REFUSAL. It used to do both jobs, and the fallback
+      // that makes it safe here would have demanded roughly ten times the ETH a
+      // real operation needs, reporting funded accounts as short. What the
+      // EntryPoint will actually require is priced further down, from the
+      // PREPARED operation's own maxFeePerGas — see checkPrefund.
+      const simulationFee = await publicClient
         .estimateFeesPerGas()
-        .then((f) => f.maxFeePerGas)
-        .catch(() => 5_000_000_000n); // 5 gwei, ~10x the observed 4663 rate
+        .then((fees) => fees.maxFeePerGas)
+        .catch(() => SIMULATION_FEE_FALLBACK);
 
       // WHICH CEILING, DECIDED BEFORE THE ESTIMATE because the override is sized
       // from it. That ordering is also why a refusal here cannot be salvaged by
@@ -568,31 +605,6 @@ export async function createAgentExecutor(opts: {
       // already a refusal, and asking again would just be slower.
       const second = first ? await estimate() : null;
       const bounded = boundGas(first, second, bounds, !!opts.sponsor);
-
-      // ── AND THE REAL BALANCE, WHICH THE OVERRIDE DID NOT CHANGE ──────────
-      //
-      // The simulation was handed an imaginary balance so it would produce a
-      // number instead of AA21. The chain will not be. So before anything is
-      // signed, ask what the account actually holds against what the EntryPoint
-      // will actually require, and say so in words if it is short.
-      //
-      // This is the check that keeps the override honest: without it, the patch
-      // would convert an opaque AA21 at estimation into an opaque AA21 at
-      // submission, having spent a signature on the way.
-      if (bounded.ok && !opts.sponsor) {
-        const required = bounded.total * feeCeiling;
-        const held = await publicClient.getBalance({ address: account.address }).catch(() => null);
-        if (held !== null && held < required) {
-          throw new GasRefused(
-            "prefund-short",
-            `this operation needs ${bounded.total} gas, which the EntryPoint requires the account to ` +
-              `HOLD as ${required} wei at ${feeCeiling} wei/gas. It holds ${held} wei — short by ` +
-              `${required - held}. Nothing was signed. The account is charged only for gas USED, but ` +
-              `it must hold the full amount up front, so this is a funding shortfall and not a refusal ` +
-              `by the chain.`,
-          );
-        }
-      }
 
       // SAY WHAT THE NUMBERS WERE.
       //
@@ -671,6 +683,49 @@ export async function createAgentExecutor(opts: {
       // It now runs against the operation we are ABOUT to send rather than a
       // second preparation of it, which is strictly the stronger claim.
       if (opts.sponsor) assertBoundsHeld(bounded.gas, prepared);
+
+      // ── AND THE REAL BALANCE, WHICH THE OVERRIDE DID NOT CHANGE ──────────
+      //
+      // The simulation was handed an imaginary balance so it would produce a
+      // number instead of AA21. The chain will not be. Without this, the override
+      // would only move an opaque AA21 from estimation to submission, having
+      // spent a signature on the way.
+      //
+      // HERE, AND NOT EARLIER, BECAUSE HERE THE FEE IS THE SIGNED FEE. `prepared`
+      // carries the maxFeePerGas this operation will actually be broadcast with —
+      // from the Pimlico oracle or gas.ts's chain fallback, whichever answered —
+      // so the requirement computed from it is the requirement, not an estimate
+      // of one made from a different reading a moment earlier. It also costs no
+      // extra fee call. Still before signUserOperation: nothing is signed by a
+      // check that refuses.
+      //
+      // Sponsored operations are skipped: the paymaster pays, and the account's
+      // own balance is not what the EntryPoint looks at.
+      if (!opts.sponsor) {
+        const preparedFee = prepared.maxFeePerGas;
+        const [balance, deposit] = await Promise.all([
+          publicClient.getBalance({ address: account.address }).catch(() => null),
+          // The deposit is half the answer. An account that has pre-deposited is
+          // not short, and a check that read only the balance would refuse an
+          // operation the EntryPoint would have accepted.
+          publicClient
+            .readContract({
+              address: entryPoint.address,
+              abi: ENTRYPOINT_BALANCE_OF_ABI,
+              functionName: "balanceOf",
+              args: [account.address],
+            })
+            .catch(() => null),
+        ]);
+
+        const prefund = checkPrefund({
+          gas: bounded.ok ? bounded.gas : null,
+          maxFeePerGas: typeof preparedFee === "bigint" ? preparedFee : null,
+          balance,
+          deposit: typeof deposit === "bigint" ? deposit : null,
+        });
+        if (!prefund.ok) throw new GasRefused(prefund.rule, prefund.detail);
+      }
 
       const signature = await account.signUserOperation(prepared as never);
       const signed = { ...prepared, signature };

--- a/worker/src/gas-limits.test.ts
+++ b/worker/src/gas-limits.test.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { readFileSync } from "node:fs";
-import { DEPLOY_GAS_BOUNDS, GAS_BOUNDS, boundGas, totalGas, type UserOpGas } from "./gas-limits";
+import {
+  FIRST_ENABLE_GAS_BOUNDS,
+  GAS_BOUNDS,
+  boundGas,
+  totalGas,
+  type UserOpGas,
+} from "./gas-limits";
+import { isFirstEnable } from "./executor";
 
 /**
  * The gap this closes was total: no floor, no ceiling, whatever the bundler
@@ -21,11 +28,19 @@ test("headroom is applied to every field, not just the call", () => {
   // op also carries enable data and account deployment — the most expensive
   // verification this account will ever do, and the one we care most about
   // not clipping.
+  //
+  // Every field still gets headroom. What changed in Stage E is HOW MUCH: the
+  // blanket 2x below was measured to be the entire reason a real first
+  // operation was refused, and the per-field figures are justified on
+  // GAS_BOUNDS. The invariant this test defends — no field goes unpadded — is
+  // unchanged.
   const v = boundGas(NORMAL, null);
   assert.ok(v.ok);
-  assert.deepEqual(v.gas, est(360_000n, 180_000n, 110_000n));
-  assert.equal(v.total, 650_000n);
-  assert.equal(totalGas(NORMAL) * 2n, v.total);
+  assert.deepEqual(v.gas, est(360_000n, 112_500n, 68_750n));
+  assert.equal(v.total, 541_250n);
+  for (const [field, raw] of Object.entries(NORMAL) as [keyof UserOpGas, bigint][]) {
+    assert.ok(v.gas[field]! > raw, `${field} must be padded, not passed through`);
+  }
 });
 
 test("being generous is FREE and being tight is total — so the bound is one-sided", () => {
@@ -70,7 +85,10 @@ test("a normal spread between two estimates is fine, and bounds against the HIGH
   const b = boundGas(hi, lo);
   assert.ok(a.ok && b.ok);
   assert.deepEqual(a.gas, b.gas, "order must not matter");
-  assert.equal(a.total, totalGas(hi) * 2n);
+  // The higher estimate, padded per field: 300,000 + 93,750 + 37,500.
+  assert.equal(a.total, 431_250n);
+  assert.ok(a.total > totalGas(hi), "and it is the higher one that was padded");
+  assert.ok(a.total > totalGas(lo) * 2n, "not merely the lower one doubled");
 });
 
 test("instability is judged on the TOTAL, because the fields trade off", () => {
@@ -107,14 +125,19 @@ test("the disagreement check is SKIPPED, never assumed, when there is one estima
   // simply unreachable, rather than silently satisfied.
   const v = boundGas(est(100_000n, 50_000n, 25_000n), null);
   assert.ok(v.ok);
-  assert.equal(v.total, 350_000n);
+  assert.equal(v.total, 293_750n); // 200,000 + 62,500 + 31,250
 });
 
 test("the bounds are the numbers the comments claim", () => {
-  assert.equal(GAS_BOUNDS.headroomBps, 20_000, "2x");
+  assert.equal(GAS_BOUNDS.callHeadroomBps, 20_000, "2x");
+  assert.equal(GAS_BOUNDS.verificationHeadroomBps, 12_500, "1.25x");
+  assert.equal(GAS_BOUNDS.preVerificationHeadroomBps, 12_500, "1.25x");
   assert.equal(GAS_BOUNDS.disagreementBps, 40_000, "4x");
   assert.equal(GAS_BOUNDS.absoluteMax, 3_000_000n);
-  assert.ok(GAS_BOUNDS.disagreementBps > GAS_BOUNDS.headroomBps, "a refusal must be looser than the headroom it guards");
+  assert.ok(
+    GAS_BOUNDS.disagreementBps > GAS_BOUNDS.callHeadroomBps,
+    "a refusal must be looser than the widest headroom it guards",
+  );
 });
 
 test("REGRESSION: a zero field in the SECOND estimate is caught too", () => {
@@ -148,58 +171,235 @@ test("REGRESSION: the zero check runs BEFORE the disagreement math", () => {
   assert.equal(v.rule, "gas-unreadable", "not 'gas-unstable'");
 });
 
-test("THE DEPLOY CEILING: the op that creates the account is not the steady state", () => {
-  // GAS_BOUNDS.absoluteMax reasons about "an approve plus an exactInputSingle",
-  // which is a fair description of every operation EXCEPT the first one. That
-  // one also carries the Kernel factory initCode, the permission validator's
-  // plugin-enable (~960 bytes of ONE_OF lists on its own) and the verification
-  // of the enable signature.
-  //
-  // boundGas REFUSES rather than clamps, so applying the steady-state ceiling to
-  // the deploy presents as a flat pre-sign refusal on the one operation in an
-  // account's life that has to succeed — and it would refuse with the words "the
-  // operation is not the one it is meant to be", which would be exactly wrong.
-  //
-  // Sized so the ×2 headroom on a plausible deploy estimate clears it.
-  const deploy = est(400_000n, 1_100_000n, 250_000n); // ×2 = 3.5M
-  const narrow = boundGas(deploy, deploy);
-  assert.equal(narrow.ok, false, "the steady-state ceiling refuses a deploy");
-  assert.equal(narrow.ok === false ? narrow.rule : null, "gas-absurd");
+// ────────────────────────────────────────────────────────────────────────────
+// STAGE E. The first operation of a merrymen account installs the entire policy
+// wall inside validation, and the blanket 2x headroom turned a 7,711,654-gas
+// operation into a 15,423,308-gas refusal — on the one operation in an
+// account's life that has to succeed. These pin what changed and what did not.
+// ────────────────────────────────────────────────────────────────────────────
 
-  const wide = boundGas(deploy, deploy, DEPLOY_GAS_BOUNDS);
-  assert.equal(wide.ok, true, "the deploy ceiling admits it");
-  assert.equal(totalGas((wide as { gas: UserOpGas }).gas), 3_500_000n);
+/** The measured first-enable estimate. Pimlico, chain 4663, 2026-09-03. */
+const MEASURED_WALL = est(50_180n, 7_418_031n, 243_443n);
+
+test("callGasLimit gets 2x, and it is the only field that does", () => {
+  // The asymmetry is the point. callGasLimit too low OOGs the call, success is
+  // false, and THE ACCOUNT PAYS IN FULL. The other two fail during validation,
+  // before the op enters a bundle, and cost nothing.
+  const v = boundGas(est(100_000n, 200_000n, 40_000n), null);
+  assert.ok(v.ok);
+  assert.equal(v.gas.callGasLimit, 200_000n, "2x");
 });
 
-test("the deploy ceiling is a CEILING, not an exemption", () => {
-  // The check still has to catch an operation that is not the one we think it
-  // is. A deploy plus an enable plus an approve plus a swap has a real upper
-  // bound; anything past it is as suspect as it would be later.
-  const absurd = est(3_000_000n, 3_000_000n, 3_000_000n); // ×2 = 18M
-  const v = boundGas(absurd, absurd, DEPLOY_GAS_BOUNDS);
+test("verification and preVerification get 1.25x, not 2x", () => {
+  const v = boundGas(est(100_000n, 200_000n, 40_000n), null);
+  assert.ok(v.ok);
+  assert.equal(v.gas.verificationGasLimit, 250_000n, "1.25x");
+  assert.equal(v.gas.preVerificationGas, 50_000n, "1.25x");
+  // Pinned as a comparison too, so an edit that sets all three equal fails here
+  // rather than quietly restoring the bug.
+  assert.ok(
+    GAS_BOUNDS.verificationHeadroomBps < GAS_BOUNDS.callHeadroomBps,
+    "verification is deterministic given fixed calldata; the call is not",
+  );
+});
+
+test("THE 18-PERMISSION WALL PASSES. This is the operation that was refused.", () => {
+  const v = boundGas(MEASURED_WALL, MEASURED_WALL, FIRST_ENABLE_GAS_BOUNDS);
+  assert.equal(v.ok, true, "the measured full wall must be signable");
+  assert.ok(v.ok);
+  assert.equal(v.gas.callGasLimit, 100_360n);
+  assert.equal(v.gas.verificationGasLimit, 9_272_538n);
+  assert.equal(v.gas.preVerificationGas, 304_303n);
+  assert.equal(v.total, 9_677_201n, "the arithmetic in the constant's comment");
+
+  // The same estimate under the OLD blanket 2x is still refused, so the
+  // per-field headroom did the work — not the ceiling on its own.
+  const blanket2x = totalGas(MEASURED_WALL) * 2n;
+  assert.equal(blanket2x, 15_423_308n);
+  assert.ok(blanket2x > FIRST_ENABLE_GAS_BOUNDS.absoluteMax, "15.4M is past 12M");
+});
+
+test("THE FIRST-ENABLE CEILING IS DERIVED, not chosen", () => {
+  // Every term of the comment, recomputed. Widen the ceiling without widening
+  // the justification and this fails.
+  const bounded = 9_677_201n; // asserted above
+  const perExtraToken = 462_874n; // measured ~370,299 raw x 1.25
+  const withMargin = bounded + 5n * perExtraToken;
+  assert.equal(withMargin, 11_991_571n);
+  assert.equal(FIRST_ENABLE_GAS_BOUNDS.absoluteMax, 12_000_000n);
+  assert.ok(
+    FIRST_ENABLE_GAS_BOUNDS.absoluteMax >= withMargin,
+    "the ceiling must cover the margin it claims",
+  );
+  assert.ok(
+    FIRST_ENABLE_GAS_BOUNDS.absoluteMax - withMargin < perExtraToken,
+    "and must not quietly exceed it by another token's worth",
+  );
+  // ONLY the ceiling moved. A first op gets the same headroom as any other.
+  assert.equal(FIRST_ENABLE_GAS_BOUNDS.callHeadroomBps, GAS_BOUNDS.callHeadroomBps);
+  assert.equal(FIRST_ENABLE_GAS_BOUNDS.verificationHeadroomBps, GAS_BOUNDS.verificationHeadroomBps);
+  assert.equal(
+    FIRST_ENABLE_GAS_BOUNDS.preVerificationHeadroomBps,
+    GAS_BOUNDS.preVerificationHeadroomBps,
+  );
+  assert.equal(FIRST_ENABLE_GAS_BOUNDS.disagreementBps, GAS_BOUNDS.disagreementBps);
+});
+
+test("THE ORDINARY CEILING DID NOT MOVE. A deployed account cannot reach 12M.", () => {
+  assert.equal(GAS_BOUNDS.absoluteMax, 3_000_000n, "unchanged by Stage E");
+  // The same measured wall, offered the ordinary bounds, is refused.
+  const v = boundGas(MEASURED_WALL, MEASURED_WALL);
   assert.equal(v.ok, false);
-  assert.equal(v.rule, "gas-absurd");
-  // And it is the only field that moved.
-  assert.equal(DEPLOY_GAS_BOUNDS.headroomBps, GAS_BOUNDS.headroomBps);
-  assert.equal(DEPLOY_GAS_BOUNDS.disagreementBps, GAS_BOUNDS.disagreementBps);
-  assert.equal(DEPLOY_GAS_BOUNDS.absoluteMax > GAS_BOUNDS.absoluteMax, true);
+  assert.equal(v.ok === false ? v.rule : null, "gas-absurd");
 });
 
-test("THE CALL SITE: the executor picks the ceiling by whether the account exists", () => {
-  // A constant nothing reads is worth nothing, and the bug next door — a grant
-  // detected as dead and then armed anyway — was exactly a correct fact with no
-  // consequence. Pin that the wide ceiling is reached only when the account has
-  // no code, and that it stops applying once an op has been accepted.
+test("the first-enable ceiling is a CEILING, not an exemption", () => {
+  // 12M is not "safe because it is large". An operation past it is as suspect
+  // on the first op as on the thousandth.
+  const absurd = est(3_000_000n, 8_000_000n, 3_000_000n);
+  const v = boundGas(absurd, absurd, FIRST_ENABLE_GAS_BOUNDS);
+  assert.equal(v.ok, false);
+  assert.equal(v.ok === false ? v.rule : null, "gas-absurd");
+});
+
+test("PAYMASTER GAS CANNOT WALK UNDER THE CEILING", () => {
+  // paymaster.ts allows up to 500,000 in each of these, and totalGas counted
+  // neither — so up to a million gas of prefund sat outside every bound in this
+  // file. The EntryPoint's prefund counts them; now so do we.
+  const withPm: UserOpGas = {
+    ...est(400_000n, 600_000n, 100_000n), // bounded: 800k + 750k + 125k = 1.675M
+    paymasterVerificationGasLimit: 500_000n,
+    paymasterPostOpGasLimit: 500_000n,
+  };
+  assert.equal(totalGas(withPm), 2_100_000n, "totalGas sees the paymaster fields");
+
+  // Sponsored: admitted, counted, and NOT multiplied — they are the sponsor's
+  // numbers, bounded by paymaster.ts, and inflating them is not ours to do.
+  const ok = boundGas(withPm, withPm, GAS_BOUNDS, true);
+  assert.ok(ok.ok);
+  assert.equal(ok.gas.paymasterVerificationGasLimit, 500_000n, "carried, never inflated");
+  assert.equal(ok.gas.paymasterPostOpGasLimit, 500_000n);
+  assert.equal(ok.total, 2_675_000n, "1.675M of ours plus 1M of theirs");
+
+  // And the ceiling is enforced against the total INCLUDING them: the same
+  // three fields alone clear 3M, and refuse once the sponsor's are counted.
+  const ours = est(600_000n, 800_000n, 160_000n); // bounded 1.2M + 1M + 200k = 2.4M
+  assert.equal(boundGas(ours, ours).ok, true, "2.4M alone clears the 3M ceiling");
+  const big: UserOpGas = {
+    ...ours,
+    paymasterVerificationGasLimit: 500_000n,
+    paymasterPostOpGasLimit: 500_000n,
+  };
+  const refused = boundGas(big, big, GAS_BOUNDS, true);
+  assert.equal(refused.ok, false, "3.4M does not");
+  assert.equal(refused.ok === false ? refused.rule : null, "gas-absurd");
+});
+
+test("a paymaster on a SELF-PAYING operation is refused, not ignored", () => {
+  // The other half of "include them or prove they are absent". If nobody asked
+  // a sponsor to pay and the estimate returns paymaster gas, the operation
+  // being priced is not the operation about to be signed.
+  const withPm: UserOpGas = {
+    ...est(100_000n, 100_000n, 40_000n),
+    paymasterVerificationGasLimit: 1n,
+  };
+  const v = boundGas(withPm, withPm);
+  assert.equal(v.ok, false);
+  assert.equal(v.ok === false ? v.rule : null, "gas-paymaster-unexpected");
+  // The default is the strict reading, so a caller that forgets to say gets it.
+  assert.equal(boundGas(withPm, withPm, GAS_BOUNDS, true).ok, true, "sponsored is fine");
+});
+
+// ── FAIL CLOSED ON EXECUTION STATE ──────────────────────────────────────────
+
+test("isFirstEnable reads the operation's own nonce, and needs BOTH bytes", () => {
+  // Kernel v3 packs mode(1) vType(1) validator(20) id(2) seq(8). Measured on
+  // 4663: a walled account's first nonce is 0x0102…, a sudo-only one 0x0000….
+  const walled = 0x0102630974640000000000000000000000000000000000000000000000000000n;
+  const sudoOnly = 0x0000845adb2c0000000000000000000000000000000000000000000000000000n;
+  assert.equal(isFirstEnable(walled), true, "mode ENABLE, type PERMISSION");
+  assert.equal(isFirstEnable(sudoOnly), false, "mode DEFAULT is not an enable");
+
+  // Mode alone is not enough: an enable of some OTHER validator type is not the
+  // operation this ceiling was measured for.
+  const enableOfSudo = 0x0100000000000000000000000000000000000000000000000000000000000000n;
+  assert.equal(isFirstEnable(enableOfSudo), false, "an enable, but not of a permission validator");
+  // And an ALREADY-INSTALLED permission validator — mode DEFAULT, type
+  // PERMISSION — is the steady state, every op after the first.
+  const installed = 0x0002000000000000000000000000000000000000000000000000000000000000n;
+  assert.equal(isFirstEnable(installed), false, "installed is not enabling");
+  // The sequence bytes must not change the answer either way.
+  assert.equal(isFirstEnable(walled + 7n), true, "the sequence is not consulted");
+});
+
+test("THE CALL SITE: undeployed alone does NOT buy the elevated ceiling", () => {
+  // A constant nothing reads is worth nothing, and this codebase has already
+  // shipped the bug where a correct fact had no consequence. Pin that BOTH
+  // conditions gate the ceiling and that the ordinary one is the fallback.
   const src = readFileSync(new URL("./executor.ts", import.meta.url), "utf8");
-  // Pinned on the PROPERTY, not the phrasing. This asserted one exact
-  // expression and broke when the same logic was split across two lines so the
-  // gas numbers could be logged — a test that fails on a rename while the
-  // behaviour is intact teaches the next person to stop reading it.
   assert.match(src, /await isDeployed\(\)/, "the deploy state must be consulted");
   assert.match(
     src,
-    /\? GAS_BOUNDS : DEPLOY_GAS_BOUNDS/,
-    "deployed picks the steady-state ceiling, undeployed the wider one",
+    /!accountLive && isFirstEnable\(/,
+    "undeployed AND proven-enable, never undeployed alone",
   );
-  assert.match(src, /deployed = true;/, "a landed send must retire the deploy ceiling");
+  assert.match(
+    src,
+    /firstEnable \? FIRST_ENABLE_GAS_BOUNDS : GAS_BOUNDS/,
+    "anything else gets the ordinary ceiling",
+  );
+  assert.match(src, /deployed = true;/, "a landed send must retire the first-enable ceiling");
+  assert.doesNotMatch(src, /DEPLOY_GAS_BOUNDS/, "the undeployed-only ceiling is gone");
+});
+
+// ── THE OVERRIDE IS A PARAMETER OF ONE RPC CALL ─────────────────────────────
+
+test("stateOverride appears ONLY on the estimation request", () => {
+  const src = readFileSync(new URL("./executor.ts", import.meta.url), "utf8");
+  assert.equal([...src.matchAll(/stateOverride:/g)].length, 1, "exactly one use");
+
+  // And it is inside the estimate call's own argument object.
+  const at = src.indexOf("estimateUserOperationGas({");
+  assert.ok(at > 0, "the estimate call is where we think it is");
+  const call = src.slice(at, src.indexOf("})) as Partial<UserOpGas>", at));
+  assert.match(call, /stateOverride:/, "the override is an argument of the estimate");
+
+  // Nowhere near the send. If it ever migrates there, this fails.
+  const sendAt = src.indexOf("sendUserOperation(");
+  assert.ok(sendAt > at, "the send comes after the estimate");
+  assert.doesNotMatch(src.slice(sendAt), /stateOverride/, "never on the send");
+});
+
+test("the balance override cannot reach the UserOperation, signed or otherwise", () => {
+  // A state override is a parameter of eth_estimateUserOperationGas — it is not
+  // a field of a UserOperation, so it cannot be signed, hashed or broadcast.
+  // What is provable here is that our own code never lets the value travel.
+  const src = readFileSync(new URL("./executor.ts", import.meta.url), "utf8");
+  assert.match(src, /balance: bounds\.absoluteMax \* feeCeiling \* 2n/, "computed in one place");
+  assert.doesNotMatch(
+    src,
+    /const\s+\w*[Bb]alance\w*\s*=\s*bounds\.absoluteMax/,
+    "the override balance is not hoisted into a variable that could travel",
+  );
+  // feeCeiling exists to size the override and to price the prefund CHECK. It
+  // must never appear in what we sign.
+  const send = src.slice(src.indexOf("sendUserOperation("));
+  assert.doesNotMatch(send, /feeCeiling/, "the override's fee never prices the real op");
+  assert.doesNotMatch(send, /bounds\.absoluteMax/, "nor does the ceiling");
+});
+
+test("an underfunded account is told so, in words, AFTER the estimate", () => {
+  // The override buys a number instead of an opaque AA21. It must not buy a
+  // signature on an operation the chain will reject for the same reason — so
+  // the REAL balance is checked against the bounded total before signing.
+  const src = readFileSync(new URL("./executor.ts", import.meta.url), "utf8");
+  const boundAt = src.indexOf("const bounded = boundGas(");
+  const checkAt = src.indexOf('"prefund-short"');
+  const signAt = src.indexOf("sendUserOperation(");
+  assert.ok(boundAt > 0 && checkAt > 0 && signAt > 0, "all three exist");
+  assert.ok(checkAt > boundAt, "the check is priced from the bounded total");
+  assert.ok(checkAt < signAt, "and happens before anything is signed");
+  assert.match(src, /getBalance\(\{ address: account\.address \}\)/, "the REAL balance");
+  assert.match(src, /short by/, "the message says how short, not merely that it failed");
+  assert.match(src, /Nothing was signed/, "and that nothing was spent");
 });

--- a/worker/src/gas-limits.test.ts
+++ b/worker/src/gas-limits.test.ts
@@ -5,6 +5,7 @@ import {
   FIRST_ENABLE_GAS_BOUNDS,
   GAS_BOUNDS,
   boundGas,
+  checkPrefund,
   totalGas,
   type UserOpGas,
 } from "./gas-limits";
@@ -518,7 +519,7 @@ test("the balance override cannot reach the UserOperation, signed or otherwise",
   // a field of a UserOperation, so it cannot be signed, hashed or broadcast.
   // What is provable here is that our own code never lets the value travel.
   const src = readFileSync(new URL("./executor.ts", import.meta.url), "utf8");
-  assert.match(src, /balance: bounds\.absoluteMax \* feeCeiling \* 2n/, "computed in one place");
+  assert.match(src, /balance: bounds\.absoluteMax \* simulationFee \* 2n/, "computed in one place");
   assert.doesNotMatch(
     src,
     /const\s+\w*[Bb]alance\w*\s*=\s*bounds\.absoluteMax/,
@@ -527,22 +528,152 @@ test("the balance override cannot reach the UserOperation, signed or otherwise",
   // feeCeiling exists to size the override and to price the prefund CHECK. It
   // must never appear in what we sign.
   const send = src.slice(src.indexOf("sendUserOperation("));
-  assert.doesNotMatch(send, /feeCeiling/, "the override's fee never prices the real op");
+  assert.doesNotMatch(send, /simulationFee/, "the override's fee never prices the real op");
   assert.doesNotMatch(send, /bounds\.absoluteMax/, "nor does the ceiling");
 });
 
-test("an underfunded account is told so, in words, AFTER the estimate", () => {
-  // The override buys a number instead of an opaque AA21. It must not buy a
-  // signature on an operation the chain will reject for the same reason — so
-  // the REAL balance is checked against the bounded total before signing.
-  const src = readFileSync(new URL("./executor.ts", import.meta.url), "utf8");
-  const boundAt = src.indexOf("const bounded = boundGas(");
-  const checkAt = src.indexOf('"prefund-short"');
-  const signAt = src.indexOf("sendUserOperation(");
-  assert.ok(boundAt > 0 && checkAt > 0 && signAt > 0, "all three exist");
-  assert.ok(checkAt > boundAt, "the check is priced from the bounded total");
-  assert.ok(checkAt < signAt, "and happens before anything is signed");
-  assert.match(src, /getBalance\(\{ address: account\.address \}\)/, "the REAL balance");
-  assert.match(src, /short by/, "the message says how short, not merely that it failed");
-  assert.match(src, /Nothing was signed/, "and that nothing was spent");
+// ── THE PREFUND CHECK, AND THE FEE THAT PRICES IT ───────────────────────────
+//
+// One variable used to size the estimation override AND price this refusal. The
+// fallback that makes the override safe — 5 gwei, about 11x the live rate on
+// 4663 — would have demanded roughly ten times the ETH an operation needs, and
+// reported funded accounts as short.
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Measured on 4663, 2026-09-03: base 0.4516 gwei, so a signed fee near 0.9033. */
+const REAL_FEE = 903_284_000n;
+const FALLBACK_FEE = 5_000_000_000n; // what the SIMULATION may use, and this may not
+const WALL_GAS = est(100_360n, 9_272_538n, 304_303n); // the bounded first enable
+const REQUIRED_AT_REAL = totalGas(WALL_GAS) * REAL_FEE;
+
+test("THE SPLIT: a funded account is not refused merely because the SIMULATION fee is generous", () => {
+  // The case that made this change necessary. The account holds enough for the
+  // fee its operation will actually carry, and nowhere near enough for the
+  // conservative fallback. Pricing the refusal from the fallback rejects it.
+  const held = REQUIRED_AT_REAL + 1n;
+
+  const honest = checkPrefund({ gas: WALL_GAS, maxFeePerGas: REAL_FEE, balance: held, deposit: 0n });
+  assert.equal(honest.ok, true, "the operation it is about to sign is affordable");
+
+  // And the arithmetic of what the old shared variable would have demanded.
+  const wouldHaveDemanded = totalGas(WALL_GAS) * FALLBACK_FEE;
+  assert.ok(wouldHaveDemanded > held * 5n, "the fallback demands over 5x what the account holds");
+  const cruel = checkPrefund({ gas: WALL_GAS, maxFeePerGas: FALLBACK_FEE, balance: held, deposit: 0n });
+  assert.equal(cruel.ok, false, "priced from the fallback, the same account is 'short'");
 });
+
+test("A FAILED FEE RPC DOES NOT PRODUCE A prefund-short", () => {
+  // The specific failure the split is for. When the fee cannot be known, the
+  // honest answer is that WE could not check — not that the ACCOUNT is short.
+  // A wealthy account must not be slandered by our own broken read.
+  const rich = checkPrefund({
+    gas: WALL_GAS,
+    maxFeePerGas: null,
+    balance: 10n ** 21n, // 1000 ETH
+    deposit: 0n,
+  });
+  assert.equal(rich.ok, false);
+  assert.equal(rich.ok === false ? rich.rule : null, "prefund-unverified");
+  assert.notEqual(rich.ok === false ? rich.rule : null, "prefund-short");
+  assert.match(rich.ok === false ? rich.detail : "", /could demand many times/);
+
+  // Zero is not a fee either — at 0 wei/gas everything is affordable.
+  const zero = checkPrefund({ gas: WALL_GAS, maxFeePerGas: 0n, balance: 0n, deposit: 0n });
+  assert.equal(zero.ok === false ? zero.rule : null, "prefund-unverified", "a zero fee is not free gas");
+});
+
+test("THE SIMULATION KEEPS ITS GENEROUS FALLBACK — the two fees are separate variables", () => {
+  const src = readFileSync(new URL("./executor.ts", import.meta.url), "utf8");
+  // The override is still sized generously, and still from its own number.
+  assert.match(src, /const SIMULATION_FEE_FALLBACK = 5_000_000_000n;/, "the conservative fallback stays");
+  assert.match(
+    src,
+    /balance: bounds\.absoluteMax \* simulationFee \* 2n/,
+    "and it is what sizes the override",
+  );
+  // The refusal is priced from the PREPARED operation, never from that number.
+  assert.match(src, /maxFeePerGas: typeof preparedFee === "bigint" \? preparedFee : null/);
+  assert.doesNotMatch(src, /feeCeiling/, "the shared variable is gone");
+  // The two must never be the same identifier again.
+  const check = src.slice(src.indexOf("const prefund = checkPrefund("), src.indexOf("const signature ="));
+  assert.doesNotMatch(check, /simulationFee|SIMULATION_FEE_FALLBACK/, "the simulation fee cannot price a refusal");
+});
+
+test("the check runs AFTER prepare and BEFORE any signature", () => {
+  // Its whole value is the fee being the signed fee, which only exists after
+  // prepareUserOperation — and its whole safety is running before signing.
+  const src = readFileSync(new URL("./executor.ts", import.meta.url), "utf8");
+  const prepareAt = src.indexOf("await client.prepareUserOperation(");
+  const checkAt = src.indexOf("const prefund = checkPrefund(");
+  const signAt = src.indexOf("await account.signUserOperation(");
+  const sendAt = src.indexOf("await client.sendUserOperation(");
+  assert.ok(prepareAt > 0 && checkAt > 0 && signAt > 0 && sendAt > 0, "all four exist");
+  assert.ok(checkAt > prepareAt, "priced from the prepared operation");
+  assert.ok(checkAt < signAt, "and nothing is signed by a check that refuses");
+  assert.ok(signAt < sendAt);
+});
+
+test("A DEPOSIT COUNTS. An account that pre-funded the EntryPoint is not short.", () => {
+  // The EntryPoint charges the sender's DEPOSIT and only pulls from the balance
+  // for the shortfall. Reading the balance alone would refuse an operation the
+  // chain would have accepted.
+  const onDeposit = checkPrefund({
+    gas: WALL_GAS,
+    maxFeePerGas: REAL_FEE,
+    balance: 0n,
+    deposit: REQUIRED_AT_REAL,
+  });
+  assert.equal(onDeposit.ok, true, "fully deposited, empty wallet, still fine");
+
+  const split = checkPrefund({
+    gas: WALL_GAS,
+    maxFeePerGas: REAL_FEE,
+    balance: REQUIRED_AT_REAL / 2n,
+    deposit: REQUIRED_AT_REAL - REQUIRED_AT_REAL / 2n,
+  });
+  assert.equal(split.ok, true, "and the two halves add up");
+});
+
+test("a genuinely short account is told BY HOW MUCH, and that it is liquidity not price", () => {
+  // 0.000445 ETH — what 0x032Da6A0… actually held on 2026-09-03.
+  const held = 445_000_000_000_000n;
+  const short = checkPrefund({ gas: WALL_GAS, maxFeePerGas: REAL_FEE, balance: held, deposit: 0n });
+  assert.ok(short.ok === false && short.rule === "prefund-short", "genuinely short");
+  assert.equal(short.required, REQUIRED_AT_REAL);
+  assert.equal(short.covered, held);
+  assert.ok(short.detail.includes(String(REQUIRED_AT_REAL - held)), "the exact shortfall, in wei");
+  assert.match(
+    short.detail,
+    /charged only for the gas it USES/,
+    "an owner must not read this as the cost of a trade",
+  );
+});
+
+test("AN UNREADABLE BALANCE OR DEPOSIT FAILS CLOSED, and says which it could not read", () => {
+  // "Could not read" is never "is zero" — a zero balance would be reported as a
+  // shortfall against an account that may be perfectly funded.
+  for (const [balance, deposit, word] of [
+    [null, 0n, /balance could not be read/],
+    [0n, null, /deposit could not be read/],
+    [null, null, /balance and deposit could not be read/],
+  ] as [bigint | null, bigint | null, RegExp][]) {
+    const v = checkPrefund({ gas: WALL_GAS, maxFeePerGas: REAL_FEE, balance, deposit });
+    assert.equal(v.ok, false);
+    assert.equal(v.ok === false ? v.rule : null, "prefund-unverified");
+    assert.match(v.ok === false ? v.detail : "", word);
+  }
+});
+
+test("no gas figures means nothing to price — refused, not waved through", () => {
+  const v = checkPrefund({ gas: null, maxFeePerGas: REAL_FEE, balance: 0n, deposit: 0n });
+  assert.equal(v.ok, false);
+  assert.equal(v.ok === false ? v.rule : null, "prefund-unverified");
+});
+
+test("the requirement counts the PAYMASTER fields too, because the EntryPoint does", () => {
+  const withPm: UserOpGas = { ...WALL_GAS, paymasterVerificationGasLimit: 500_000n, paymasterPostOpGasLimit: 500_000n };
+  const v = checkPrefund({ gas: withPm, maxFeePerGas: REAL_FEE, balance: REQUIRED_AT_REAL, deposit: 0n });
+  assert.ok(v.ok === false && v.rule === "prefund-short", "a million gas of sponsor limits is a million gas of prefund");
+  assert.equal(v.required, (totalGas(WALL_GAS) + 1_000_000n) * REAL_FEE);
+});
+

--- a/worker/src/gas-limits.test.ts
+++ b/worker/src/gas-limits.test.ts
@@ -8,7 +8,13 @@ import {
   totalGas,
   type UserOpGas,
 } from "./gas-limits";
-import { isFirstEnable } from "./executor";
+import {
+  isFirstEnable,
+  nonceSequence,
+  noncePermissionId,
+  readEnableState,
+  type EnableState,
+} from "./executor";
 
 /**
  * The gap this closes was total: no floor, no ceiling, whatever the bundler
@@ -245,7 +251,7 @@ test("THE FIRST-ENABLE CEILING IS DERIVED, not chosen", () => {
   assert.equal(FIRST_ENABLE_GAS_BOUNDS.disagreementBps, GAS_BOUNDS.disagreementBps);
 });
 
-test("THE ORDINARY CEILING DID NOT MOVE. A deployed account cannot reach 12M.", () => {
+test("THE ORDINARY CEILING DID NOT MOVE. An op that is not an enable cannot reach 12M.", () => {
   assert.equal(GAS_BOUNDS.absoluteMax, 3_000_000n, "unchanged by Stage E");
   // The same measured wall, offered the ordinary bounds, is refused.
   const v = boundGas(MEASURED_WALL, MEASURED_WALL);
@@ -332,24 +338,161 @@ test("isFirstEnable reads the operation's own nonce, and needs BOTH bytes", () =
   assert.equal(isFirstEnable(walled + 7n), true, "the sequence is not consulted");
 });
 
-test("THE CALL SITE: undeployed alone does NOT buy the elevated ceiling", () => {
-  // A constant nothing reads is worth nothing, and this codebase has already
-  // shipped the bug where a correct fact had no consequence. Pin that BOTH
-  // conditions gate the ceiling and that the ordinary one is the fallback.
+// ── A RENEWAL IS AN ENABLE ON AN ACCOUNT THAT ALREADY HAS CODE ──────────────
+//
+// The gate was '!accountLive && isFirstEnable(nonce)', on the belief that a
+// validator enable is one-time per ACCOUNT. It is one-time per SESSION KEY.
+// Measured on 4663, 2026-09-03: a renewal on a deployed account costs 96-98% of
+// the undeployed first op, so every one-click renewal was routed through the
+// 3,000,000 ceiling and refused.
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Measured nonces. Real ids, so no fixture can stand in for another. */
+const FIRST_ARM = 0x0102acff75890000000000000000000000000000000000000000000000000000n;
+const RENEWAL = 0x01023ca1cec80000000000000000000000000000000000000000000000000000n;
+const LANDED_ENABLE = 0x01023ca1cec80000000000000000000000000000000000000000000000000001n;
+const STEADY_STATE = 0x00023ca1cec80000000000000000000000000000000000000000000000000004n;
+
+/** Measured on the deployed accounts, in raw bundler figures. */
+const MEASURED_RENEWAL = est(50_180n, 7_279_603n, 240_042n);
+const MEASURED_RENEWAL_CHEAPEST = est(50_180n, 7_111_512n, 239_988n);
+
+const ADDR = "0x032Da6A0Ccf866474e45854E7fDEF9afd1509036" as `0x${string}`;
+
+/** A fake chain. word0 offset, word1 flag, word2 signer — the real layout. */
+function chain(opts: { code?: string; signer?: string; codeThrows?: boolean; callThrows?: boolean; short?: boolean }) {
+  return {
+    async getCode() {
+      if (opts.codeThrows) throw new Error("connection reset");
+      return (opts.code ?? "0x") as `0x${string}` | undefined;
+    },
+    async call() {
+      if (opts.callThrows) throw new Error("429 Rate Limit Hit");
+      if (opts.short) return { data: "0x1234" as `0x${string}` };
+      const signer = (opts.signer ?? "0x" + "0".repeat(40)).slice(2).padStart(64, "0");
+      return { data: ("0x" + "20".padStart(64, "0") + "2".padStart(64, "0") + signer) as `0x${string}` };
+    },
+  };
+}
+
+test("THE RENEWAL CASE: a deployed account enabling a NEW key gets the wide ceiling", async () => {
+  // The account has code and the id is absent — which is exactly a renewal.
+  const state = await readEnableState(chain({ code: "0x" + "ef".repeat(61) }), ADDR, RENEWAL);
+  assert.equal(state.kind, "fresh-enable");
+
+  // And the measured renewal fits. Under GAS_BOUNDS it would not have.
+  const wide = boundGas(MEASURED_RENEWAL, MEASURED_RENEWAL, FIRST_ENABLE_GAS_BOUNDS);
+  assert.equal(wide.ok, true, "a renewal must be signable");
+  assert.ok(wide.ok);
+  assert.equal(wide.total, 9_499_915n);
+  const narrow = boundGas(MEASURED_RENEWAL, MEASURED_RENEWAL);
+  assert.equal(narrow.ok, false, "the old gate sent it here");
+  assert.equal(narrow.ok === false ? narrow.rule : null, "gas-absurd");
+
+  // Both measured deployed accounts, not just the dearest.
+  const cheap = boundGas(MEASURED_RENEWAL_CHEAPEST, MEASURED_RENEWAL_CHEAPEST, FIRST_ENABLE_GAS_BOUNDS);
+  assert.equal(cheap.ok, true);
+});
+
+test("the renewal is CHEAPER than the first arm, so 12M still binds on the first arm", () => {
+  // The constant was derived from the undeployed case. This proves that is the
+  // larger of the two, which is why the derivation did not have to change.
+  const arm = boundGas(MEASURED_WALL, null, FIRST_ENABLE_GAS_BOUNDS);
+  const renew = boundGas(MEASURED_RENEWAL, null, FIRST_ENABLE_GAS_BOUNDS);
+  assert.ok(arm.ok && renew.ok);
+  assert.ok(renew.total < arm.total, "deployment is worth something, just not much");
+  assert.ok(arm.total - renew.total < 200_000n, "and what it is worth is a rounding error");
+  assert.equal(arm.total, 9_677_201n, "the number in the constant's comment");
+});
+
+test("THE STEADY STATE IS UNTOUCHED: an installed validator is not an enable", async () => {
+  // Mode 0x00. The wide ceiling is not even considered, which is the property
+  // that makes dropping '!accountLive' safe.
+  assert.equal(isFirstEnable(STEADY_STATE), false);
+  const state = await readEnableState(chain({ code: "0xef" }), ADDR, STEADY_STATE);
+  assert.equal(state.kind, "not-an-enable");
+});
+
+test("FAIL CLOSED: an enable we cannot verify is REFUSED, never widened", async () => {
+  // @zerodev's isPluginEnabled catches every read error to false, so one flaky
+  // eth_call produces an ENABLE-shaped op for an already-installed validator.
+  // On the nonce alone that would have been handed 12,000,000.
+  const installed = await readEnableState(
+    chain({ code: "0xef", signer: "0x6a6f069e2a08c2468e7724ab3250cdbfba14d4ff" }),
+    ADDR,
+    RENEWAL,
+  );
+  assert.equal(installed.kind, "already-installed");
+
+  // A read we could not make is its own answer, and it is not "fresh".
+  for (const broken of [chain({ code: "0xef", callThrows: true }), chain({ codeThrows: true }), chain({ code: "0xef", short: true })]) {
+    const state = await readEnableState(broken, ADDR, RENEWAL);
+    assert.equal(state.kind, "unreadable", "an unreadable chain must not widen a ceiling");
+  }
+
+  // This INVERTS isDeployed's rule, deliberately: there a failed read answers
+  // "not deployed" because that only ever narrowed. Here "no code" widens.
   const src = readFileSync(new URL("./executor.ts", import.meta.url), "utf8");
-  assert.match(src, /await isDeployed\(\)/, "the deploy state must be consulted");
-  assert.match(
-    src,
-    /!accountLive && isFirstEnable\(/,
-    "undeployed AND proven-enable, never undeployed alone",
-  );
-  assert.match(
-    src,
-    /firstEnable \? FIRST_ENABLE_GAS_BOUNDS : GAS_BOUNDS/,
-    "anything else gets the ordinary ceiling",
-  );
-  assert.match(src, /deployed = true;/, "a landed send must retire the first-enable ceiling");
-  assert.doesNotMatch(src, /DEPLOY_GAS_BOUNDS/, "the undeployed-only ceiling is gone");
+  assert.match(src, /INVERTS the rule isDeployed uses/, "and the inversion is explained where it happens");
+});
+
+test("an enable that already LANDED is refused, and the EntryPoint is the witness", async () => {
+  // The sequence is the one part of the nonce nothing local chooses — the
+  // EntryPoint increments it only on INCLUSION. Measured on 4663: a landed
+  // enable key reads 1 forever; one that never landed reads 0.
+  assert.equal(nonceSequence(LANDED_ENABLE), 1n);
+  assert.equal(nonceSequence(RENEWAL), 0n);
+  const state = await readEnableState(chain({ code: "0xef" }), ADDR, LANDED_ENABLE);
+  assert.equal(state.kind, "replayed-enable");
+  // So the wide ceiling admits at most ONE included operation per (account, id),
+  // without any ledger to go stale.
+});
+
+test("an UNDEPLOYED first arm still gets the wide ceiling — the fix did not trade one for the other", async () => {
+  const state = await readEnableState(chain({ code: "0x" }), ADDR, FIRST_ARM);
+  assert.equal(state.kind, "fresh-enable");
+  assert.equal(state.kind === "fresh-enable" ? state.permissionId : null, "0xacff7589");
+});
+
+test("THE PERMISSION ID IS BYTES 2..5, and the off-by-two would be a no-op gate", () => {
+  // Verified against a landed enable on 4663: nonce 0x01023ca1cec8…0001 is the
+  // operation that installed 0x3ca1cec8.
+  assert.equal(noncePermissionId(LANDED_ENABLE), "0x3ca1cec8");
+  // Shifting by 224 returns the mode and type bytes glued to half the id — an id
+  // no operation will ever present, so permissionConfig would answer "absent"
+  // for everything and the check would always pass. Pin the trap.
+  const trap = "0x" + (((LANDED_ENABLE >> 224n) & 0xffffffffn).toString(16).padStart(8, "0"));
+  assert.equal(trap, "0x01023ca1");
+  assert.notEqual(noncePermissionId(LANDED_ENABLE), trap);
+});
+
+test("THE CALL SITE: the ceiling is keyed on the OPERATION, and the deploy state does not vote", () => {
+  const src = readFileSync(new URL("./executor.ts", import.meta.url), "utf8");
+  assert.match(src, /const enable = await readEnableState\(/, "the chain is asked");
+  assert.match(src, /const firstEnable = enable\.kind === "fresh-enable";/, "and only one answer widens");
+  assert.match(src, /firstEnable \? FIRST_ENABLE_GAS_BOUNDS : GAS_BOUNDS/, "anything else gets the ordinary ceiling");
+  // Asserted against CODE, not prose. The comment above readEnableState names
+  // the old condition on purpose — a fix that erases the record of what it fixed
+  // invites the next person to reinstate it.
+  const code = src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  assert.doesNotMatch(code, /!accountLive/, "the deploy state must not gate the ceiling");
+  assert.doesNotMatch(code, /accountLive &&|&& accountLive/, "nor in any conjunction");
+  assert.doesNotMatch(code, /DEPLOY_GAS_BOUNDS/, "the undeployed-only ceiling is gone");
+  assert.match(src, /!accountLive && isFirstEnable\(nonce\)/, "and the old gate is on the record");
+
+  // THE STRONG FORM: every READ of accountLive must be inside the log line.
+  // Counting occurrences would pin the wrong thing and break on a reword; this
+  // breaks only if the deploy state starts deciding something again.
+  const at = src.indexOf("[gas] account");
+  const log = src.slice(src.lastIndexOf("console.log(", at), src.indexOf(");", at) + 2);
+  const outside = src.replace(log, "");
+  assert.doesNotMatch(outside.slice(outside.indexOf("const accountLive")+20), /accountLive/, "accountLive is a label, not a guard");
+
+  // And each refusal exists by name, so a renewal never presents as an RPC fault.
+  for (const rule of ["enable-replayed", "enable-redundant", "enable-unverified"]) {
+    assert.ok(src.includes('"' + rule + '"'), rule + " must be a named refusal");
+  }
+  assert.match(src, /deployed = true;/, "a landed send must still retire the memo");
 });
 
 // ── THE OVERRIDE IS A PARAMETER OF ONE RPC CALL ─────────────────────────────

--- a/worker/src/gas-limits.ts
+++ b/worker/src/gas-limits.ts
@@ -139,6 +139,12 @@ export const GAS_BOUNDS: GasBounds = {
  * validation. Measured, that is +7,059,814 verification gas over the same deploy
  * without the wall.
  *
+ * ONE-TIME PER SESSION KEY, NOT PER ACCOUNT. The operation that earns this is
+ * every key's first, not every account's first: a renewal on an account that has
+ * been live for months pays it again, because Kernel keys the install on
+ * (account, permissionId) and a renewed key is a new permissionId. See
+ * readEnableState in executor.ts, which is what decides that this applies.
+ *
  * THE ARITHMETIC, from measurement rather than from a round number:
  *
  *   measured, Pimlico on 4663, 2026-09-03, the full 18-permission wall:
@@ -155,16 +161,30 @@ export const GAS_BOUNDS: GasBounds = {
  *
  *   => 12,000,000
  *
- * That is 1.24x the base operation. It is deliberately NOT generous: at ~16
- * custom tokens the estimate exceeds it and the op is refused, and beyond ~40
- * the grant provably cannot validate at all (AA23, measured) — so refusing
- * early is the kinder failure. Capping the token count at signing time is a
- * separate change; this ceiling only declines to sign what it cannot justify.
+ * AND IT COVERS THE RENEWAL A FORTIORI. A renewal is the same enable minus the
+ * initCode and the CREATE2, so it is strictly CHEAPER. Measured on 4663 the same
+ * day, on two real deployed accounts and a synthesised third:
+ *     0x032Da6A0…  raw 7,530,220 -> bounded 9,450,410
+ *     0xa48cE91e…  raw 7,401,680 -> bounded 9,289,735
+ *     synthetic    raw 7,569,825 -> bounded 9,499,915
+ * All three sit under the 9,677,201 this constant was derived from, so the
+ * undeployed first arm remains the binding case and the margin below is intact.
  *
- * NOT REACHABLE BY BEING UNDEPLOYED. See isFirstEnable in executor.ts: the
- * operation has to PROVE it carries a permission-validator enable, out of its
- * own nonce, before this applies. An undeployed account running any other shape
- * gets GAS_BOUNDS.
+ * That is 1.24x the base operation, and it is deliberately NOT generous: each
+ * custom token adds ~512 bytes of enable blob and ~358,884 raw gas, so the
+ * estimate crosses 12,000,000 at SIX of them — matching the five-token margin
+ * above rather than contradicting it. (An earlier draft of this comment said
+ * "~16", which was wrong by roughly 3x and would have told a tenant a 16-token
+ * wall works. Measured: it is refused at six.) Beyond ~40 the grant provably
+ * cannot validate at all (AA23, measured), so refusing early is the kinder
+ * failure. Capping the token count at signing time is a separate change (#57);
+ * this ceiling only declines to sign what it cannot justify.
+ *
+ * NOT REACHABLE BY BEING UNDEPLOYED, AND NOT BY SHAPE ALONE. readEnableState in
+ * executor.ts requires the operation to name a permission id out of its own
+ * nonce, at sequence 0, that the CHAIN confirms is not installed — and refuses
+ * outright if it cannot ask. An undeployed account running any other shape gets
+ * GAS_BOUNDS.
  */
 export const FIRST_ENABLE_GAS_BOUNDS: GasBounds = {
   ...GAS_BOUNDS,

--- a/worker/src/gas-limits.ts
+++ b/worker/src/gas-limits.ts
@@ -43,20 +43,39 @@ export interface UserOpGas {
   callGasLimit: bigint;
   verificationGasLimit: bigint;
   preVerificationGas: bigint;
+  /**
+   * The paymaster's own two limits, when one is paying.
+   *
+   * Present so `totalGas` can count what the EntryPoint's prefund actually
+   * counts. NEVER multiplied by any headroom: they are the sponsor's numbers,
+   * bounded by paymaster.ts and asserted unchanged by `assertBoundsHeld`, and
+   * inflating somebody else's limits is not ours to do.
+   */
+  paymasterVerificationGasLimit?: bigint;
+  paymasterPostOpGasLimit?: bigint;
 }
 
 export interface GasBounds {
   /**
-   * Multiplier applied to the bundler's estimate, in basis points.
+   * Multiplier applied to the bundler's estimate for EACH FIELD, in basis points.
+   *
+   * The per-field values and the measurement behind them are on GAS_BOUNDS
+   * below. What follows is the original reasoning, which is sound for
+   * callGasLimit and is where the (mistaken) blanket 2x came from.
    *
    * 2x, matching Vex. Not tuning: it is the smallest headroom that survives the
    * spread they measured on an unchanged input, and the cost of being generous
-   * is nothing. A UserOp is charged for gas USED, not gas requested — the limit
+   * is LOW — though not nothing: the account must HOLD the prefund even though
+   * it only PAYS for gas used, and the unspent remainder is credited to its
+   * EntryPoint deposit rather than returned to its balance. A UserOp is charged
+   * for gas USED, not gas requested — the limit
    * only has to be large enough, and the EntryPoint refunds the difference.
    * The asymmetry is total: too high costs a slightly larger prefund, too low
    * costs the entire operation.
    */
-  headroomBps: number;
+  callHeadroomBps: number;
+  verificationHeadroomBps: number;
+  preVerificationHeadroomBps: number;
   /**
    * Refuse when the estimate exceeds this multiple of the FIRST estimate, bps.
    *
@@ -74,36 +93,84 @@ export interface GasBounds {
 }
 
 export const GAS_BOUNDS: GasBounds = {
-  headroomBps: 20_000, // 2x
+  // ── ONE HEADROOM PER FIELD, BECAUSE THE ASYMMETRY IS PER FIELD ──────────
+  //
+  // This was a single 2x applied to all three, and the reasoning above — "too
+  // high costs a slightly larger prefund, too low costs the entire operation" —
+  // is derived from callGasLimit and is FALSE for the other two:
+  //
+  //   callGasLimit too low        the EntryPoint runs the call, it OOGs,
+  //                               success=false, and THE ACCOUNT PAYS IN FULL.
+  //                               Silent and expensive. Headroom earns its keep.
+  //   verificationGasLimit low    validation reverts, FailedOp, the op never
+  //                               enters a bundle. THE ACCOUNT PAYS NOTHING.
+  //   preVerificationGas low      the bundler rejects it before inclusion.
+  //                               THE ACCOUNT PAYS NOTHING.
+  //
+  // Two of the three fail free and loud — which is the outcome boundGas already
+  // chooses deliberately everywhere else. Only one fails silently and charges.
+  //
+  // And the cost of getting it wrong was measured. A merrymen first operation
+  // estimates at verif 7,418,031 · preVerif 243,443 · call 50,180 (Pimlico,
+  // chain 4663, 2026-09-03). Under a blanket 2x that signs 15,423,308 and is
+  // refused as gas-absurd — while the RAW total, 7,711,654, clears the ceiling
+  // it was refused by. The doubling was the whole refusal.
+  callHeadroomBps: 20_000, // 2x — genuinely variable: pool state at inclusion
+  // 1.25x. Deterministic given fixed calldata against a fixed account: signature
+  // verification, a CREATE2 of fixed bytecode, and zero-to-nonzero SSTOREs. The
+  // only drift is warm storage, which makes it CHEAPER. The margin covers
+  // estimator revisions, not variance we can name.
+  verificationHeadroomBps: 12_500,
+  // 1.25x. A pure function of the bytes, which are fixed before the estimate is
+  // asked for, plus a bundler overhead constant. gasUsedForL1 is 0 on 4663, so
+  // there is no L1 data surcharge to move under it.
+  preVerificationHeadroomBps: 12_500,
   disagreementBps: 40_000, // 4x
   absoluteMax: 3_000_000n,
 };
 
 /**
- * THE FIRST OPERATION IS A DIFFERENT OPERATION.
+ * THE ONE-TIME CEILING, FOR THE ONE OPERATION THAT EARNS IT.
  *
- * `absoluteMax` above is reasoned about the steady state, and says so: "an
- * approve plus an `exactInputSingle` does not approach it". True — and the
- * first operation an account ever sends is not an approve plus a swap. It also
- * carries the Kernel factory initCode that deploys the account, the permission
- * validator's plugin-enable (whose enable data is ~960 bytes of ONE_OF lists
- * alone, per wall.ts), and the verification of the enable signature.
+ * A merrymen session key installs its permission validator LAZILY: the enable
+ * data rides in the signature of the first operation that key signs, so that one
+ * operation carries the whole wall — every policy, both ONE_OF lists, and the
+ * owner's EIP-712 enable signature — and Kernel installs all of it inside
+ * validation. Measured, that is +7,059,814 verification gas over the same deploy
+ * without the wall.
  *
- * That matters because `boundGas` REFUSES rather than clamps. A ceiling chosen
- * for the steady state, applied to the deploy, presents as a flat pre-sign
- * refusal on the one operation in an account's life that has to succeed — and
- * the refusal would read "the operation is not the one it is meant to be", which
- * would be exactly wrong.
+ * THE ARITHMETIC, from measurement rather than from a round number:
  *
- * 8M rather than 3M. Deliberately not unbounded: the check still has to catch an
- * operation that is not the one we think it is, and a deploy plus an enable plus
- * an approve plus a swap has a real upper bound. It applies ONLY while the
- * account has no code, and the executor stops using it the moment one op lands.
+ *   measured, Pimlico on 4663, 2026-09-03, the full 18-permission wall:
+ *     verificationGasLimit   7,418,031  × 1.25 =  9,272,538
+ *     preVerificationGas       243,443  × 1.25 =    304,303
+ *     callGasLimit              50,180  × 2.00 =    100,360
+ *                                       bounded =  9,677,201
+ *
+ *   SAFETY MARGIN, documented separately rather than folded in:
+ *     A tenant's own custom tokens widen both ONE_OF lists, and each one costs a
+ *     measured ~370,299 raw / ~462,874 bounded. The margin buys FIVE of them:
+ *       9,677,201 + (5 × 462,874) = 11,991,571
+ *     Rounded up to a flat number a person can hold in their head.
+ *
+ *   => 12,000,000
+ *
+ * That is 1.24x the base operation. It is deliberately NOT generous: at ~16
+ * custom tokens the estimate exceeds it and the op is refused, and beyond ~40
+ * the grant provably cannot validate at all (AA23, measured) — so refusing
+ * early is the kinder failure. Capping the token count at signing time is a
+ * separate change; this ceiling only declines to sign what it cannot justify.
+ *
+ * NOT REACHABLE BY BEING UNDEPLOYED. See isFirstEnable in executor.ts: the
+ * operation has to PROVE it carries a permission-validator enable, out of its
+ * own nonce, before this applies. An undeployed account running any other shape
+ * gets GAS_BOUNDS.
  */
-export const DEPLOY_GAS_BOUNDS: GasBounds = {
+export const FIRST_ENABLE_GAS_BOUNDS: GasBounds = {
   ...GAS_BOUNDS,
-  absoluteMax: 8_000_000n,
+  absoluteMax: 12_000_000n,
 };
+
 
 export type GasVerdict =
   | { ok: true; gas: UserOpGas; total: bigint }
@@ -111,13 +178,33 @@ export type GasVerdict =
    * Mirrors ImpactVerdict (impact.ts) rather than inventing a shape: a literal
    * `rule` a caller can branch on, and a `detail` written for the owner.
    */
-  | { ok: false; rule: "gas-absurd" | "gas-unstable" | "gas-unreadable"; detail: string };
+  | {
+      ok: false;
+      rule: "gas-absurd" | "gas-unstable" | "gas-unreadable" | "gas-paymaster-unexpected";
+      detail: string;
+    };
 
 const bps = (v: bigint, n: number) => (v * BigInt(n)) / 10_000n;
 
-/** callGasLimit + verificationGasLimit + preVerificationGas. */
+/**
+ * Everything the EntryPoint's prefund is computed from.
+ *
+ * THE PAYMASTER FIELDS ARE IN HERE NOW, and their absence was a hole. The
+ * EntryPoint requires the payer to hold
+ * `(callGasLimit + verificationGasLimit + preVerificationGas +
+ *   paymasterVerificationGasLimit + paymasterPostOpGasLimit) × maxFeePerGas`,
+ * and paymaster.ts allows up to 500,000 in EACH of the last two — so up to a
+ * million gas of prefund sat outside every bound this file applies. A ceiling
+ * that cannot see a fifth of what it is bounding is not a ceiling.
+ */
 export function totalGas(g: UserOpGas): bigint {
-  return g.callGasLimit + g.verificationGasLimit + g.preVerificationGas;
+  return (
+    g.callGasLimit +
+    g.verificationGasLimit +
+    g.preVerificationGas +
+    (g.paymasterVerificationGasLimit ?? 0n) +
+    (g.paymasterPostOpGasLimit ?? 0n)
+  );
 }
 
 /**
@@ -132,6 +219,11 @@ export function boundGas(
   first: UserOpGas | null,
   second: UserOpGas | null,
   bounds: GasBounds = GAS_BOUNDS,
+  /**
+   * Is a paymaster paying? Defaults to NO, so a caller that forgets to say gets
+   * the strict reading and a surprise paymaster is refused rather than admitted.
+   */
+  sponsored = false,
 ): GasVerdict {
   if (!first) {
     return {
@@ -197,19 +289,44 @@ export function boundGas(
     first = a >= b ? first : second;
   }
 
+  // A PAYMASTER WE DID NOT ASK FOR IS NOT A ROUNDING ERROR. Unsponsored, both
+  // of these must be absent or zero; anything else means the operation being
+  // estimated is not the operation we think we are sending, and it would add up
+  // to a million gas of prefund that no bound here can see.
+  const pmVer = first.paymasterVerificationGasLimit ?? 0n;
+  const pmPost = first.paymasterPostOpGasLimit ?? 0n;
+  if (!sponsored && (pmVer > 0n || pmPost > 0n)) {
+    return {
+      ok: false,
+      rule: "gas-paymaster-unexpected",
+      detail:
+        `this operation is self-paying, but the estimate came back with paymaster gas ` +
+        `(verification ${pmVer}, postOp ${pmPost}). Nobody asked a sponsor to pay, so the ` +
+        "operation being priced is not the one about to be signed. Refused before signing.",
+    };
+  }
+
   const gas: UserOpGas = {
-    callGasLimit: bps(first.callGasLimit, bounds.headroomBps),
-    verificationGasLimit: bps(first.verificationGasLimit, bounds.headroomBps),
-    preVerificationGas: bps(first.preVerificationGas, bounds.headroomBps),
+    // ONE HEADROOM PER FIELD. See GAS_BOUNDS for why a single multiplier was
+    // wrong: two of these three fail free and loud when they are too low.
+    callGasLimit: bps(first.callGasLimit, bounds.callHeadroomBps),
+    verificationGasLimit: bps(first.verificationGasLimit, bounds.verificationHeadroomBps),
+    preVerificationGas: bps(first.preVerificationGas, bounds.preVerificationHeadroomBps),
+    // Carried, never multiplied — the sponsor's numbers, not ours.
+    ...(pmVer > 0n ? { paymasterVerificationGasLimit: pmVer } : {}),
+    ...(pmPost > 0n ? { paymasterPostOpGasLimit: pmPost } : {}),
   };
+  // Counts the paymaster fields too, because the prefund does.
   const total = totalGas(gas);
   if (total > bounds.absoluteMax) {
     return {
       ok: false,
       rule: "gas-absurd",
       detail:
-        `this operation wants ${total} gas, past the ${bounds.absoluteMax} ceiling. An approve plus a swap does not ` +
-        "approach that, so the operation is not the one it is meant to be. Refused before signing — nothing was spent.",
+        `this operation wants ${total} gas, past the ${bounds.absoluteMax} ceiling. Refused before ` +
+        "signing — nothing was spent. A ceiling is crossed either because the operation is not the " +
+        "one it is meant to be, or because it genuinely needs more than we are willing to sign for; " +
+        "both are reasons to stop rather than to sign.",
     };
   }
   return { ok: true, gas, total };

--- a/worker/src/gas-limits.ts
+++ b/worker/src/gas-limits.ts
@@ -351,3 +351,105 @@ export function boundGas(
   }
   return { ok: true, gas, total };
 }
+
+/**
+ * CAN THIS ACCOUNT ACTUALLY PAY FOR THE OPERATION IT IS ABOUT TO SIGN?
+ *
+ * Separate from every ceiling above. A ceiling asks "is this operation the one
+ * we think it is"; this asks "will the EntryPoint let it in". They fail for
+ * opposite reasons and must not share a message.
+ *
+ * WHAT THE ENTRYPOINT ACTUALLY REQUIRES, v0.7, unsponsored:
+ *
+ *   requiredPrefund = (verificationGasLimit + callGasLimit + preVerificationGas
+ *                      + paymasterVerificationGasLimit + paymasterPostOpGasLimit)
+ *                     × maxFeePerGas
+ *
+ * which is exactly totalGas() × the fee — and the account must COVER it from its
+ * EntryPoint deposit plus, for the shortfall, its own balance. The deposit half
+ * matters: an account that has pre-deposited is not short, and a check that
+ * ignored its deposit would refuse an operation the chain would have accepted.
+ *
+ * The account is CHARGED only for gas used, and the remainder is credited back
+ * to its deposit — so this is a liquidity requirement, not a price. Saying that
+ * in the refusal is the difference between an owner topping up ~0.009 ETH and an
+ * owner concluding that a trade costs it.
+ *
+ * TWO FEES, AND THEY ARE NOT THE SAME NUMBER. Sizing the estimation-time balance
+ * override wants a generous fee, because being generous there costs nothing — it
+ * is a parameter of a simulation that never reaches a signature. Deciding whether
+ * a real account is short wants the fee THE OPERATION WILL ACTUALLY CARRY,
+ * because being generous there refuses people who could have paid. They were
+ * briefly one variable, and the fallback that made the override safe — 5 gwei,
+ * about eleven times the live rate on 4663 — would have demanded roughly ten
+ * times the ETH an operation really needs.
+ *
+ * So this takes its fee from the PREPARED operation and from nowhere else, and
+ * when it cannot have one it says so rather than guessing in either direction.
+ * A "prefund-unverified" is not a "prefund-short": the first is a fact about us,
+ * the second is a fact about an account.
+ */
+export type PrefundVerdict =
+  | { ok: true; required: bigint; covered: bigint }
+  | { ok: false; rule: "prefund-short"; required: bigint; covered: bigint; detail: string }
+  | { ok: false; rule: "prefund-unverified"; detail: string };
+
+export function checkPrefund(args: {
+  /** The gas fields of the operation as PREPARED — what the EntryPoint will price. */
+  gas: UserOpGas | null;
+  /** maxFeePerGas off the prepared operation. Never a fee estimated separately. */
+  maxFeePerGas: bigint | null;
+  /** eth_getBalance(sender). null means the read FAILED, not that it is zero. */
+  balance: bigint | null;
+  /** EntryPoint.balanceOf(sender) — the deposit already staked. null means unread. */
+  deposit: bigint | null;
+}): PrefundVerdict {
+  // Every input is nullable because every input is a read that can fail, and the
+  // whole point of this function is that a failed read is not a small number.
+  if (args.gas === null) {
+    return {
+      ok: false,
+      rule: "prefund-unverified",
+      detail: "the operation carries no gas limits, so there is nothing to price.",
+    };
+  }
+  if (args.maxFeePerGas === null || args.maxFeePerGas <= 0n) {
+    return {
+      ok: false,
+      rule: "prefund-unverified",
+      detail:
+        "the prepared operation carries no usable maxFeePerGas, so what the EntryPoint would " +
+        "require cannot be computed. Refusing rather than pricing it from a fallback: a fee we " +
+        "invented could demand many times the ETH the operation actually needs, and would report " +
+        "a funded account as short. Nothing was signed.",
+    };
+  }
+  if (args.balance === null || args.deposit === null) {
+    const which =
+      args.balance === null ? (args.deposit === null ? "balance and deposit" : "balance") : "deposit";
+    return {
+      ok: false,
+      rule: "prefund-unverified",
+      detail:
+        `the account's ${which} could not be read, so whether it can cover this operation is ` +
+        "unknown. Refusing while it is unknown — the next tick will ask again, and nothing was signed.",
+    };
+  }
+
+  const required = totalGas(args.gas) * args.maxFeePerGas;
+  const covered = args.deposit + args.balance;
+  if (covered >= required) return { ok: true, required, covered };
+  return {
+    ok: false,
+    rule: "prefund-short",
+    required,
+    covered,
+    detail:
+      `the EntryPoint requires ${required} wei to be covered before it will run this operation ` +
+      `(${totalGas(args.gas)} gas at ${args.maxFeePerGas} wei/gas). The account holds ` +
+      `${args.balance} wei and has ${args.deposit} wei on deposit — ${covered} together, short by ` +
+      `${required - covered}. This is a liquidity requirement rather than a price: the account is ` +
+      "charged only for the gas it USES and the remainder returns to its deposit, but the whole " +
+      "amount has to be there first. Nothing was signed.",
+  };
+}


### PR DESCRIPTION
Supersedes #56, which had Stage B RPC and reconciliation work stacked on top of it. This is the gas-correctness work **only** — the three commits that unblock a first trade — so it can be merged without carrying anything unrelated. The RPC/reconciler commits are preserved on `stage-b/rpc-and-reconciler` for a separate PR.

Identical content to #56's first three commits; see that PR and its review comment for the full measurement record. In brief:

**1. The estimate could not run.** viem sends `eth_estimateUserOperationGas` with no gas limits, so the bundler substitutes its own and the EntryPoint's prefund check runs against the real balance against limits nobody chose. On 4663 the block gas limit is 1.125e15. Twenty-four consecutive live attempts died on `AA21 didn't pay prefund` with no gas figure at all. Fixed with an estimation-only `stateOverride` — a parameter of one RPC call, which cannot reach a signature, a broadcast, the calldata, or any policy check.

**2. The doubling was the refusal.** A measured first op is `verification 7,418,031 · preVerification 243,443 · call 50,180`. A blanket ×2 signs 15,423,308 — while the **raw** total, 7,711,654, clears the 8,000,000 ceiling it was refused by. Per-field headroom now: call ×2 (too low ⇒ OOG and the account pays in full), verification and preVerification ×1.25 (too low ⇒ validation reverts, never bundled, costs nothing).

**3. The paymaster hole.** `totalGas` counted three of the five fields the EntryPoint's prefund counts, while `paymaster.ts` allows 500,000 in each of the other two — up to a million gas outside every bound. Counted now, never multiplied; a paymaster on a self-paying op is refused outright.

**4. The enable is one-time per SESSION KEY, not per account.** Found in review. Measured on two real deployed accounts and a synthetic third: a renewal costs 96–98% of the undeployed first op, so `!accountLive` would have refused every one-click renewal. The gate now requires the operation to prove out of its own nonce that it carries a permission-validator enable, at sequence 0, with the chain confirming the permission id is absent — and **fails closed** if it cannot ask.

**5. One fee doing two jobs.** `feeCeiling` sized the simulation override *and* priced the `prefund-short` refusal. Its 5 gwei fallback is ~11× the live rate and would have demanded roughly ten times the ETH an operation needs, reporting funded accounts as short. Split: the simulation keeps its generous fallback; the refusal is priced from the **prepared** operation's own `maxFeePerGas`, which is literally the fee that gets signed. Also corrected: the check ignored the EntryPoint deposit entirely.

`FIRST_ENABLE_GAS_BOUNDS.absoluteMax = 12,000,000`, derived and tested; `GAS_BOUNDS.absoluteMax` unchanged at 3,000,000.

1961 tests, 0 failures. Typecheck clean across worker, web and browser. `wall.test.ts` and `paymaster.test.ts` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)