### PR TITLE
A zero paymaster field is an answer, not a missing estimate

### DIFF
--- a/worker/src/gas-limits.test.ts
+++ b/worker/src/gas-limits.test.ts
@@ -677,3 +677,40 @@ test("the requirement counts the PAYMASTER fields too, because the EntryPoint do
   assert.equal(v.required, (totalGas(WALL_GAS) + 1_000_000n) * REAL_FEE);
 });
 
+
+test("A ZERO PAYMASTER FIELD IS AN ANSWER, NOT A MISSING ESTIMATE", () => {
+  // Measured live on 4663, 2026-09-03. The canary's first enable estimated
+  // cleanly — call 203,258 + verif 7,447,694 + preVerif 247,647 — and was
+  // refused `gas-unreadable` because the bundler returned 0 for
+  // paymasterVerificationGasLimit. An unsponsored operation HAS no paymaster,
+  // so zero there is the truth. The zero-guard iterated every field of
+  // UserOpGas, which was correct when UserOpGas had exactly three.
+  const measured: UserOpGas = {
+    callGasLimit: 203_258n,
+    verificationGasLimit: 7_447_694n,
+    preVerificationGas: 247_647n,
+    paymasterVerificationGasLimit: 0n,
+    paymasterPostOpGasLimit: 0n,
+  };
+  const v = boundGas(measured, measured, FIRST_ENABLE_GAS_BOUNDS);
+  assert.ok(v.ok, `the real first enable must be signable, got ${v.ok === false ? v.rule : ""}`);
+  assert.equal(v.total, 10_025_691n, "406,516 + 9,309,617 + 309,558");
+  assert.ok(v.total < FIRST_ENABLE_GAS_BOUNDS.absoluteMax, "and it clears the derived ceiling");
+
+  // THE GUARD KEEPS ITS FULL STRENGTH where it earns it: a zero in any of the
+  // three real limits is still unreadable, because a zero callGasLimit
+  // guarantees the OOG this file exists to prevent.
+  for (const field of ["callGasLimit", "verificationGasLimit", "preVerificationGas"] as const) {
+    const bad = { ...measured, [field]: 0n };
+    const r = boundGas(bad, bad, FIRST_ENABLE_GAS_BOUNDS);
+    assert.equal(r.ok, false, `a zero ${field} must still be refused`);
+    assert.equal(r.ok === false ? r.rule : null, "gas-unreadable");
+  }
+
+  // And the direction that can actually hide prefund is still refused: a
+  // NONZERO paymaster on a self-paying operation.
+  const sneaky = { ...measured, paymasterVerificationGasLimit: 1n };
+  const s = boundGas(sneaky, sneaky, FIRST_ENABLE_GAS_BOUNDS);
+  assert.equal(s.ok, false);
+  assert.equal(s.ok === false ? s.rule : null, "gas-paymaster-unexpected");
+});

--- a/worker/src/gas-limits.ts
+++ b/worker/src/gas-limits.ts
@@ -270,9 +270,33 @@ export function boundGas(
   // Checked BEFORE the disagreement test on purpose — a zero field also skews
   // the total that test compares, so validating first makes that math
   // trustworthy as well.
+  /**
+   * THE THREE LIMITS THAT MUST BE POSITIVE — and only those three.
+   *
+   * This iterated every field of UserOpGas, which was right when UserOpGas had
+   * exactly three. Stage E added the two paymaster fields so the ceiling could
+   * see what the EntryPoint's prefund sees, and this guard then rejected them:
+   * an UNSPONSORED operation has no paymaster, so the bundler returns
+   * `paymasterVerificationGasLimit: 0`, and zero there is THE TRUE ANSWER rather
+   * than a missing estimate.
+   *
+   * Measured live on 4663, 2026-09-03: the canary's first enable estimated
+   * cleanly at call 203,258 + verif 7,447,694 + preVerif 247,647 and was refused
+   * `gas-unreadable` — "the bundler returned 0 for paymasterVerificationGasLimit"
+   * — on an operation whose numbers were perfectly readable.
+   *
+   * The guard keeps its full strength where it earns it. A zero callGasLimit
+   * still guarantees the OOG this file exists to prevent, and a zero in either
+   * of the other two is still an estimator that did not answer. The paymaster
+   * fields have their own rule already: `gas-paymaster-unexpected` refuses a
+   * NONZERO paymaster on a self-paying operation, which is the direction that
+   * can actually hide a million gas of prefund.
+   */
+  const REQUIRED_LIMITS = ["callGasLimit", "verificationGasLimit", "preVerificationGas"] as const;
   const badField = (g: UserOpGas): [string, bigint] | null => {
-    for (const [name, v] of Object.entries(g) as [keyof UserOpGas, bigint][]) {
-      if (v <= 0n) return [name, v];
+    for (const name of REQUIRED_LIMITS) {
+      const v = g[name];
+      if (typeof v !== "bigint" || v <= 0n) return [name, typeof v === "bigint" ? v : 0n];
     }
     return null;
   };


### PR DESCRIPTION
Found by the live canary. It reached the live rail and its first enable estimated **cleanly** — `call 203,258 + verif 7,447,694 + preVerif 247,647 = 7,898,599` raw, identical on both probes — and was then refused:

```
gas refused (gas-unreadable): the bundler returned 0 for
paymasterVerificationGasLimit, which is not an estimate.
```

`boundGas` iterates every field of `UserOpGas` rejecting anything `<= 0`. That was correct when `UserOpGas` had exactly three fields. Stage E (#60) added the two paymaster fields so the ceiling could see what the EntryPoint's prefund sees — and this guard, which predates them and was written for the other three, then rejected them.

**An unsponsored operation has no paymaster.** The bundler returning `0` is the true answer. My own change turned a correct reading into an unreadable one.

The guard keeps full strength where it earns it: a zero `callGasLimit` still guarantees the out-of-gas this file exists to prevent, and a zero in either of the other two is still an estimator that did not answer. All three are still refused, and that is tested. The direction that can actually hide prefund is untouched — `gas-paymaster-unexpected` still refuses a **nonzero** paymaster on a self-paying operation.

The measured operation now bounds to **10,025,691** (406,516 + 9,309,617 + 309,558), under the derived 12,000,000 first-enable ceiling with 16% to spare. The regression test is pinned on the live figures, not invented ones.

Everything else in the trace was already working: `mode: live`, `account NOT deployed`, `ENABLE 0x794eba66` detected from the nonce and confirmed absent on chain, first-enable ceiling selected, and **real gas numbers where twenty-four previous attempts got `AA21` and no figure at all**.

1973 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)