### PR TITLE
Shadow reconciliation: run the new reconciler beside the old one, and write nothing

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -23,6 +23,7 @@
 
 import { rmSync, writeFileSync } from "node:fs";
 import { metered, resetRpcMeters, rpcSummaryLines } from "./rpc-meter";
+import { runShadowComparison, shadowEnabledFor, shadowLine } from "./reconcile-shadow";
 import {
   createPublicClient,
   encodeFunctionData,
@@ -802,6 +803,9 @@ async function main() {
       // hash. See resolveStrandedOps.
       await resolveStrandedOps(agentId, chain, smartAccount, lookbackBlocks);
       const known = await listOpHashes(agentId);
+      // What the AUTHORITATIVE sweep actually fetched, captured for the shadow
+      // comparison below. Observational: nothing here changes what it decides.
+      let authoritative: { logs: readonly RawLog[]; complete: boolean; scannedTo: bigint } | null = null;
       const orphans = await findOrphanOps({
         chain,
         smartAccount,
@@ -809,7 +813,44 @@ async function main() {
         knownOpHashes: known,
         lookbackBlocks,
         log: (m) => console.log(`[reconcile] ${m}`),
+        onLogs: (logs, complete, scannedTo) => {
+          authoritative = { logs, complete, scannedTo };
+        },
       });
+
+      // ── SHADOW MODE ──────────────────────────────────────────────────────
+      //
+      // The new shared fetcher runs beside the old sweep over the SAME range and
+      // its results are compared and then DISCARDED. Nothing below writes: the
+      // old path stays authoritative and this cannot change a ledger, a budget
+      // or an orphan.
+      //
+      // Off unless MERRYMEN_RECONCILE_SHADOW names this account, because it
+      // costs one extra scan of the same range — which is the price of the
+      // comparison, and the reason the canary is a small set.
+      //
+      // A FAILURE HERE MUST NOT FAIL AN ARM. Reconciliation is what stops the
+      // day's spend being under-counted; a defect in an observer must never be
+      // able to stop it running.
+      if (authoritative && shadowEnabledFor(smartAccount)) {
+        try {
+          const a = authoritative as { logs: readonly RawLog[]; complete: boolean; scannedTo: bigint };
+          const headNow = await chain.getBlockNumber();
+          const { verdict, newRequests } = await runShadowComparison({
+            chain,
+            smartAccount,
+            fromBlock: headNow > lookbackBlocks ? headNow - lookbackBlocks : 0n,
+            toBlock: headNow,
+            oldLogs: a.logs,
+            oldComplete: a.complete,
+            oldScannedTo: a.scannedTo,
+            log: (m) => console.log(`[shadow] ${m}`),
+          });
+          console.log(shadowLine(smartAccount, verdict, newRequests, a.logs.length));
+        } catch (e) {
+          console.warn(`[shadow] comparison failed, reconciliation unaffected: ${String(e).slice(0, 200)}`);
+        }
+      }
       if (orphans.length === 0) return;
 
       for (const o of orphans) {

--- a/worker/src/inflight-reconcile.ts
+++ b/worker/src/inflight-reconcile.ts
@@ -206,6 +206,17 @@ export async function findOrphanOps(opts: {
   /** Max blocks per getLogs call (adaptive-halved down from here on a range error). */
   maxSpan?: bigint;
   log?: (m: string) => void;
+  /**
+   * The raw logs this sweep actually used, handed out for comparison.
+   *
+   * PURELY OBSERVATIONAL. It is called after the fetch and before any decision,
+   * it cannot change what this function does, and a throw from it is not caught
+   * here because a shadow comparison that throws is a defect in the shadow, not
+   * in reconciliation. Exists so shadow mode can compare against the data the
+   * AUTHORITATIVE path really saw, rather than paying for a third scan of the
+   * same range and comparing against something merely similar.
+   */
+  onLogs?: (logs: readonly RawLog[], complete: boolean, scannedTo: bigint) => void;
 }): Promise<OrphanOp[]> {
   const { chain, smartAccount, usdgToken, knownOpHashes, lookbackBlocks } = opts;
   const head = await chain.getBlockNumber();
@@ -223,6 +234,8 @@ export async function findOrphanOps(opts: {
     opts.maxSpan ?? 10_000n,
     opts.log,
   );
+
+  opts.onLogs?.(logs.logs, logs.complete, logs.scannedTo);
 
   // INCOMPLETE COVERAGE IS SAID OUT LOUD. An orphan sweep that scanned half
   // its window and found nothing has not established that there are no orphans.

--- a/worker/src/reconcile-modes.test.ts
+++ b/worker/src/reconcile-modes.test.ts
@@ -1,0 +1,411 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Hex } from "viem";
+import {
+  HASH_TOPIC_MAX,
+  REORG_OVERLAP_SEC,
+  canonicalHashes,
+  canonicalSenders,
+  fetchByHashes,
+  fetchKey,
+  fetchSharedBySender,
+  planArmReconcile,
+  planSharedScan,
+  reorgOverlapBlocks,
+  runSharedPass,
+  splitByMode,
+  type FetchProgressStore,
+  type OutstandingOp,
+} from "./reconcile-modes";
+import { addressTopic, type RawLog, type ReconcileChain } from "./inflight-reconcile";
+
+/**
+ * The measured facts these tests encode, so a future edit that contradicts one
+ * fails here rather than in production:
+ *
+ *   topic1 accepts an OR-list, order-insensitive, capped at EXACTLY 1000 per
+ *   position; a shared sender scan costs the same chunk count as a single-sender
+ *   one; and the hosted child ledger is ephemeral, so an empty local ledger is
+ *   the COMMON case at arm rather than the exceptional one.
+ */
+
+const TOPIC0 = "0x49628fd1471006c1482da88028e9ce4dbb080b815c9b0344d39e5a8e6ec1419f" as Hex;
+const A = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as `0x${string}`;
+const B = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as `0x${string}`;
+const C = "0xcccccccccccccccccccccccccccccccccccccccc" as `0x${string}`;
+const hash = (n: number) => (`0x${n.toString(16).padStart(64, "0")}`) as Hex;
+
+function logFor(sender: `0x${string}`, h: Hex, block = 100n): RawLog {
+  return {
+    topics: [TOPIC0, h, addressTopic(sender), addressTopic(A)],
+    data: "0x",
+    transactionHash: (`0x${"11".repeat(32)}`) as Hex,
+    blockNumber: (`0x${block.toString(16)}`) as Hex,
+    logIndex: "0x0",
+  };
+}
+
+/** A chain that answers from a fixture and records exactly what it was asked. */
+function fakeChain(logs: RawLog[], opts?: { failNth?: number; failUntil?: number; head?: bigint }) {
+  const calls: { from: bigint; to: bigint; topics: (Hex | Hex[] | null)[] }[] = [];
+  let n = 0;
+  const chain: ReconcileChain = {
+    async getBlockNumber() {
+      return opts?.head ?? 1000n;
+    },
+    async getLogs(args) {
+      n += 1;
+      calls.push({ from: args.fromBlock, to: args.toBlock, topics: args.topics });
+      if (opts?.failNth === n || (opts?.failUntil !== undefined && n <= opts.failUntil)) {
+        throw Object.assign(new Error("Rate Limit Hit, limit will reset in 6s"), { code: -32029 });
+      }
+      const t1 = args.topics[1];
+      const t2 = args.topics[2];
+      return logs.filter((l) => {
+        // RESPECT THE RANGE. A fake that returns every log for every chunk makes
+        // a chunked scan look like it found each log once per chunk.
+        const b = BigInt(l.blockNumber ?? "0x0");
+        if (b < args.fromBlock || b > args.toBlock) return false;
+        if (t1) {
+          const want = Array.isArray(t1) ? t1 : [t1];
+          if (!want.includes(l.topics[1] as Hex)) return false;
+        }
+        if (t2) {
+          const want = Array.isArray(t2) ? t2 : [t2];
+          if (!want.includes(l.topics[2] as Hex)) return false;
+        }
+        return true;
+      });
+    },
+    async getReceiptLogs() {
+      return null;
+    },
+  };
+  return { chain, calls: () => calls, requests: () => n };
+}
+
+function memoryProgress(initial: Map<number, bigint> = new Map()): FetchProgressStore & { get(c: number): bigint | null } {
+  const m = new Map(initial);
+  return {
+    async read(chainId) {
+      return m.get(chainId) ?? null;
+    },
+    async commit(chainId, through) {
+      m.set(chainId, through);
+    },
+    get: (c) => m.get(c) ?? null,
+  };
+}
+
+// ── 1. zero outstanding hashes → zero steady-state eth_getLogs ──────────────
+
+test("ZERO OUTSTANDING HASHES MEANS ZERO REQUESTS — the largest steady-state saving", async () => {
+  const f = fakeChain([logFor(A, hash(1))]);
+  const r = await fetchByHashes(f.chain, { hashes: [], fromBlock: 0n, toBlock: 1000n });
+  assert.equal(r.requests, 0, "a fleet with nothing outstanding must ask the provider nothing");
+  assert.equal(f.requests(), 0, "and the chain must not be touched at all");
+  assert.deepEqual(r.logs, []);
+  // Complete is TRUE, and that is correct rather than convenient: a question
+  // with no subjects was answered in full.
+  assert.equal(r.complete, true);
+});
+
+// ── 2. one and many known hashes ────────────────────────────────────────────
+
+test("one known hash, and many, return exactly their own events", async () => {
+  const all = [logFor(A, hash(1)), logFor(A, hash(2)), logFor(B, hash(3))];
+  const f = fakeChain(all);
+
+  const one = await fetchByHashes(f.chain, { hashes: [hash(2)], fromBlock: 0n, toBlock: 1000n });
+  assert.equal(one.requests, 1);
+  assert.deepEqual(one.logs.map((l) => l.topics[1]), [hash(2)]);
+
+  const many = await fetchByHashes(f.chain, { hashes: [hash(1), hash(3)], fromBlock: 0n, toBlock: 1000n });
+  assert.equal(many.requests, 1, "many hashes still cost ONE request");
+  assert.deepEqual(many.logs.map((l) => l.topics[1]).sort(), [hash(1), hash(3)].sort());
+});
+
+// ── 3. 1000 hashes correctly chunked ────────────────────────────────────────
+
+test("THE 1000 CAP IS THE MEASURED ONE, and chunking respects it exactly", async () => {
+  assert.equal(HASH_TOPIC_MAX, 1000, "1001 is refused by the provider: 'exceed max topics'");
+  const f = fakeChain([]);
+
+  await fetchByHashes(f.chain, { hashes: Array.from({ length: 1000 }, (_, i) => hash(i + 1)), fromBlock: 0n, toBlock: 10n });
+  assert.equal(f.requests(), 1, "exactly 1000 fits in one request");
+
+  const f2 = fakeChain([]);
+  const r = await fetchByHashes(f2.chain, {
+    hashes: Array.from({ length: 2001 }, (_, i) => hash(i + 1)),
+    fromBlock: 0n,
+    toBlock: 10n,
+  });
+  assert.equal(r.requests, 3, "2001 hashes → 1000 + 1000 + 1");
+  for (const c of f2.calls()) {
+    const t1 = c.topics[1] as Hex[];
+    assert.ok(t1.length <= HASH_TOPIC_MAX, `a batch of ${t1.length} would be refused`);
+  }
+});
+
+// ── 4. reversed ordering produces the same canonical request ────────────────
+
+test("ORDER AND CASE CANNOT PRODUCE TWO DIFFERENT FETCHES", async () => {
+  const forward = [hash(3), hash(1), hash(2)];
+  const reversed = [...forward].reverse();
+  const uppercased = forward.map((h) => h.toUpperCase().replace("0X", "0x")) as Hex[];
+
+  assert.deepEqual(canonicalHashes(forward), canonicalHashes(reversed));
+  assert.deepEqual(canonicalHashes(forward), canonicalHashes(uppercased));
+  assert.deepEqual(canonicalHashes([...forward, hash(1), hash(1)]), canonicalHashes(forward), "deduplicated");
+  // The provider was MEASURED to be order-insensitive, which is what makes
+  // sorting a normalisation rather than a change of question.
+  assert.deepEqual(
+    fetchKey(4663, 0n, 10n, canonicalHashes(forward)),
+    fetchKey(4663, 0n, 10n, canonicalHashes(reversed)),
+    "two equivalent sets must not generate separate shared fetches",
+  );
+  // And the same for senders.
+  assert.deepEqual(canonicalSenders([B, A, A]), canonicalSenders([A, B]));
+  assert.deepEqual(canonicalSenders([A.toUpperCase().replace("0X", "0x")]), [A]);
+});
+
+// ── 5. accepted !== userOpHash falls back to sender recovery ────────────────
+
+test("AN UNCERTAIN HASH IDENTITY GOES TO SENDER RECOVERY, and says why", () => {
+  const ops: OutstandingOp[] = [
+    { identity: { kind: "known", userOpHash: hash(1) }, recoveryFromBlock: 500n },
+    {
+      // The one window hash mode provably cannot cover: the bundler indexed the
+      // operation under a hash we never computed.
+      identity: { kind: "uncertain", signedHash: hash(2), acceptedHash: hash(9), why: "bundler returned a different hash" },
+      recoveryFromBlock: 400n,
+    },
+  ];
+  const split = splitByMode(ops);
+  assert.deepEqual(split.hashes, [hash(1)], "only the known hash is queryable");
+  assert.equal(split.needsSenderRecovery.length, 1);
+
+  const plan = planArmReconcile({ sender: A, localOutstanding: ops, recoveryFromBlock: 900n });
+  assert.deepEqual(plan.hashes, [hash(1)]);
+  assert.equal(plan.senderRequests.length, 1, "the uncertain one drives a sender scan");
+  assert.equal(plan.senderRequests[0]!.fromBlock, 400n, "from ITS OWN lower bound, not the fleet's");
+  assert.match(plan.reasons.join(" "), /bundler returned a different hash/, "the reason survives into the log");
+});
+
+// ── 6 & 7. one shared scan serves many tenants, partitioned correctly ───────
+
+test("ONE SHARED FETCH SERVES MANY TENANTS, and each gets only its own events", async () => {
+  const all = [logFor(A, hash(1)), logFor(B, hash(2)), logFor(A, hash(3)), logFor(C, hash(4))];
+  const f = fakeChain(all);
+
+  const r = await fetchSharedBySender(f.chain, { senders: [A, B], fromBlock: 0n, toBlock: 1000n });
+  assert.equal(r.requests, 1, "one request for the cohort, not one per sender");
+  assert.deepEqual(r.bySender.get(A)!.map((l) => l.topics[1]), [hash(1), hash(3)]);
+  assert.deepEqual(r.bySender.get(B)!.map((l) => l.topics[1]), [hash(2)]);
+  assert.equal(r.bySender.has(C), false, "a sender nobody asked about is never delivered");
+});
+
+test("A TENANT WITH NO IN-FLIGHT OPERATIONS IS STILL DELIVERED TO, with nothing", async () => {
+  // "Nothing happened" and "you were not asked" are different answers, and a
+  // consumer must be able to tell them apart.
+  const f = fakeChain([logFor(A, hash(1))]);
+  const r = await fetchSharedBySender(f.chain, { senders: [A, B], fromBlock: 0n, toBlock: 10n });
+  assert.deepEqual(r.bySender.get(B), [], "present and empty, not absent");
+});
+
+test("AN EVENT BELONGING TO ANOTHER TENANT IS NEVER APPLIED TO THE WRONG LEDGER", async () => {
+  // The provider is trusted to filter, but not blindly: a log whose topic2 is
+  // nobody we asked about is discarded and counted, never handed to whoever
+  // happens to be first in the map.
+  const stray = logFor(C, hash(7));
+  const f = {
+    chain: {
+      async getBlockNumber() {
+        return 1000n;
+      },
+      async getLogs() {
+        return [logFor(A, hash(1)), stray];
+      },
+      async getReceiptLogs() {
+        return null;
+      },
+    } as ReconcileChain,
+  };
+  const r = await fetchSharedBySender(f.chain, { senders: [A, B], fromBlock: 0n, toBlock: 10n });
+  assert.equal(r.unattributed, 1, "the stray is counted");
+  assert.deepEqual(r.bySender.get(A)!.length, 1);
+  assert.deepEqual(r.bySender.get(B), [], "and it did NOT land on the other tenant");
+  for (const [, logs] of r.bySender) {
+    for (const l of logs) assert.notEqual(l.topics[1], hash(7), "C's event reached nobody");
+  }
+});
+
+// ── 8. duplicate delivery is idempotent ─────────────────────────────────────
+
+test("THE SAME EVENT DELIVERED TWICE PRODUCES ONE LEDGER EFFECT", async () => {
+  // Re-reading the overlap is only safe BECAUSE application is idempotent. This
+  // pins the contract on the consumer side, since the fetcher cannot enforce it.
+  const applied = new Set<string>();
+  let effects = 0;
+  const apply = (logs: RawLog[]) => {
+    for (const l of logs) {
+      const h = String(l.topics[1]).toLowerCase();
+      if (applied.has(h)) continue; // the idempotence rule
+      applied.add(h);
+      effects += 1;
+    }
+  };
+
+  // Block 5 sits inside the range both passes read — which is the point: the
+  // second pass is the overlap re-read, and it MUST return the log again.
+  const f = fakeChain([logFor(A, hash(1), 5n)]);
+  const first = await fetchSharedBySender(f.chain, { senders: [A], fromBlock: 0n, toBlock: 10n });
+  apply(first.bySender.get(A)!);
+  const second = await fetchSharedBySender(f.chain, { senders: [A], fromBlock: 0n, toBlock: 10n });
+  apply(second.bySender.get(A)!);
+
+  assert.equal(second.bySender.get(A)!.length, 1, "the overlap DID re-deliver the log");
+  assert.equal(effects, 1, "and the ledger moved once");
+});
+
+// ── 9. processing failure must not advance durable progress ─────────────────
+
+test("A CONSUMER THAT THROWS LEAVES THE RANGE UNCLAIMED", async () => {
+  const f = fakeChain([logFor(A, hash(1)), logFor(B, hash(2))]);
+  const progress = memoryProgress();
+  const plan = planSharedScan({ head: 1000n, chainFetchProgress: null, requests: [{ sender: A, fromBlock: 0n }, { sender: B, fromBlock: 0n }], overlapBlocks: 100n });
+
+  await assert.rejects(() =>
+    runSharedPass({
+      chain: f.chain,
+      chainId: 4663,
+      plan,
+      progress,
+      async deliver(sender) {
+        if (sender === B) throw new Error("ledger write failed");
+      },
+    }),
+  );
+  assert.equal(progress.get(4663), null, "progress must NOT move when accounting failed");
+});
+
+test("INCOMPLETE COVERAGE ALSO WITHHOLDS THE COMMIT", async () => {
+  // Fail every attempt, so the retries are EXHAUSTED and coverage genuinely
+  // falls short. Failing once would only prove the retry works, which is test 16.
+  const f = fakeChain([], { failUntil: 99 });
+  const progress = memoryProgress();
+  const plan = planSharedScan({ head: 1000n, chainFetchProgress: null, requests: [{ sender: A, fromBlock: 0n }], overlapBlocks: 100n });
+  const r = await runSharedPass({ chain: f.chain, chainId: 4663, plan, progress, async deliver() {} });
+  assert.equal(r.committed, false);
+  assert.equal(r.reason, "incomplete-coverage");
+  assert.equal(progress.get(4663), null);
+});
+
+test("a fully covered, fully delivered pass DOES commit", async () => {
+  const f = fakeChain([logFor(A, hash(1))]);
+  const progress = memoryProgress();
+  const plan = planSharedScan({ head: 500n, chainFetchProgress: null, requests: [{ sender: A, fromBlock: 0n }], overlapBlocks: 100n });
+  const r = await runSharedPass({ chain: f.chain, chainId: 4663, plan, progress, async deliver() {} });
+  assert.equal(r.committed, true);
+  assert.equal(progress.get(4663), 500n);
+});
+
+// ── 10. cold start with an empty local ledger ───────────────────────────────
+
+test("AN EMPTY LOCAL LEDGER IS ABSENCE OF EVIDENCE, NOT EVIDENCE OF ABSENCE", () => {
+  // Hosted, this is the COMMON case, not the exceptional one: the child's sqlite
+  // is on ephemeral container disk and a redeploy wipes it, so every cold arm
+  // starts here.
+  const plan = planArmReconcile({ sender: A, localOutstanding: [], recoveryFromBlock: 300n });
+  assert.deepEqual(plan.hashes, [], "nothing known");
+  assert.equal(plan.senderRequests.length, 1, "so it must SEARCH, not conclude");
+  assert.equal(plan.senderRequests[0]!.fromBlock, 300n);
+  assert.match(plan.reasons.join(" "), /empty ledger|no local outstanding/i);
+});
+
+// ── 11. a new tenant joining after the cursor advanced ──────────────────────
+
+test("THE FLEET CURSOR CAN ONLY WIDEN A SCAN, NEVER NARROW ONE", () => {
+  // The failure this prevents: progress reaches 50,000,000, a tenant arms
+  // needing an event from 49,800,000, and a single global cursor says history is
+  // already covered. It is covered for the senders that were IN the fetch.
+  const plan = planSharedScan({
+    head: 50_000_100n,
+    chainFetchProgress: 50_000_000n,
+    requests: [
+      { sender: A, fromBlock: 50_000_000n }, // caught up
+      { sender: B, fromBlock: 49_800_000n }, // newly armed, needs history
+    ],
+    overlapBlocks: 17_700n,
+  });
+  assert.equal(plan.fromBlock, 49_800_000n, "the newcomer's lower bound wins");
+  assert.equal(plan.drivenBy, B);
+  assert.equal(plan.incremental, false);
+  assert.deepEqual(plan.senders, canonicalSenders([A, B]));
+
+  // And when everyone is caught up, the overlap still pulls the scan back below
+  // committed progress rather than starting at it.
+  const steady = planSharedScan({
+    head: 50_000_100n,
+    chainFetchProgress: 50_000_000n,
+    requests: [{ sender: A, fromBlock: 50_000_000n }],
+    overlapBlocks: 17_700n,
+  });
+  assert.equal(steady.fromBlock, 50_000_000n - 17_700n, "the reorg overlap is re-read");
+  assert.equal(steady.drivenBy, "overlap");
+  assert.equal(steady.incremental, true);
+});
+
+test("the reorg overlap is an ENGINEERING CHOICE, expressed in time", () => {
+  // Not derived from "we observed no reorgs" — that observation was not looking
+  // for them, and no finality bound for this chain was established.
+  assert.equal(REORG_OVERLAP_SEC, 1800, "30 minutes of chain history");
+  assert.equal(reorgOverlapBlocks(0.1015), 17_734n, "at the measured 4663 block time");
+  assert.equal(reorgOverlapBlocks(0.17), 10_589n, "and it follows a slower chain");
+  assert.equal(reorgOverlapBlocks(0), 20_000n, "an unknown block time gets the generous answer");
+  assert.equal(reorgOverlapBlocks(Number.NaN), 20_000n);
+});
+
+// ── 12. a 429 midway through a multi-chunk range ───────────────────────────
+
+test("A 429 MIDWAY RETRIES THE SAME SPAN AND NEVER SKIPS BLOCKS", async () => {
+  // getLogsAdaptive retries a rate limit on the SAME span rather than halving or
+  // advancing — the Stage A fix. What this pins is that the shared fetcher
+  // inherits it, and that a rate limit cannot silently shorten coverage.
+  const logs = [logFor(A, hash(1), 5n), logFor(A, hash(2), 15_000n)];
+  const f = fakeChain(logs, { failNth: 2 });
+  const r = await fetchSharedBySender(f.chain, { senders: [A], fromBlock: 0n, toBlock: 20_000n, maxSpan: 10_000n });
+
+  assert.equal(r.complete, true, "the sweep recovered and covered the whole range");
+  assert.equal(r.bySender.get(A)!.length, 2, "both logs found, including the one after the 429");
+  const spans = f.calls().map((c) => `${c.from}-${c.to}`);
+  // The retried span appears twice and the cursor never jumped over it.
+  assert.ok(spans.length > 2, `expected a retry, got ${spans.join(" ")}`);
+  const covered = new Set(spans);
+  assert.ok(covered.size >= 2, "more than one span was scanned");
+  for (const c of f.calls()) assert.ok(c.to >= c.from, "no inverted span");
+});
+
+// ── the snapshot interface, which does not exist yet ───────────────────────
+
+test("A FUTURE SNAPSHOT CAN ONLY ADD SEARCHES, NEVER SUBTRACT THEM", () => {
+  // The transport does not exist. The shape does, so adding it later needs no
+  // redesign — and the asymmetry is the safety property: a hint below its own
+  // staleness horizon becomes a REASON TO SEARCH, not permission to skip.
+  const plan = planArmReconcile({
+    sender: A,
+    localOutstanding: [],
+    recoveryFromBlock: 100n,
+    knownOutstandingOps: {
+      tenant: A,
+      staleAsOfBlock: 1000n,
+      ops: [
+        { identity: { kind: "known", userOpHash: hash(1) }, recoveryFromBlock: 1200n }, // above horizon → trusted
+        { identity: { kind: "known", userOpHash: hash(2) }, recoveryFromBlock: 900n }, // below → distrusted
+      ],
+    },
+  });
+  assert.deepEqual(plan.hashes, [hash(1)], "only the op above the horizon stays a hash");
+  assert.equal(plan.senderRequests.length, 1, "the stale one became a search");
+  assert.match(plan.reasons.join(" "), /older than snapshot horizon/);
+});

--- a/worker/src/reconcile-modes.ts
+++ b/worker/src/reconcile-modes.ts
@@ -1,0 +1,558 @@
+/**
+ * TWO WAYS TO ASK THE CHAIN WHAT HAPPENED TO AN OPERATION, AND ONE FETCH SHARED
+ * ACROSS THE FLEET.
+ *
+ * Every arm used to sweep 200,001 blocks of EntryPoint logs filtered to ONE
+ * sender, per child, independently: 21 serial eth_getLogs × 22 children = 462
+ * calls, in a 7-12 second burst that took 7.2% rate limiting. Measured, that
+ * sweep found NOTHING on any of the 22 children, and 20 of the 22 accounts had
+ * no code at all — so 420 of those 462 calls were answerable from an
+ * eth_getCode the same arm had already made two seconds earlier.
+ *
+ * ── THE TWO MODES ────────────────────────────────────────────────────────────
+ *
+ * HASH MODE, for the steady state. `UserOperationEvent` indexes the userOpHash
+ * in topic1, and merrymen persists that hash BEFORE it broadcasts — so an agent
+ * usually knows exactly what it is looking for. Asking by hash is bounded by
+ * what we are LOOKING FOR; asking by sender is bounded by what the sender DID.
+ * An agent with two outstanding operations asks for two hashes however busy its
+ * account has ever been, and AN AGENT WITH NONE ASKS NOTHING AT ALL.
+ *
+ * Measured against the live provider, 2026-09-03 (spikes/stage-b/hash-topic.mjs):
+ *   single hash in topic1      exactly 1 log where 1 was expected
+ *   control, a bogus hash      0 logs — the filter is real, not ignored
+ *   OR-list of 3               union exact
+ *   the same list reversed     identical, so ORDER DOES NOT MATTER
+ *   max OR-list                EXACTLY 1000 per topic position; 1001 returns
+ *                              "invalid argument 0: exceed max topics"
+ *   is the cap global?         NO, per position: 600 in topic1 plus 600 in
+ *                              topic3 is accepted
+ *   latency                    flat ~300-320ms from 1 to 128 hashes
+ *   response size              scales with MATCHES, not with list length
+ *
+ * SENDER MODE, for cold arm, redeploy and recovery — and for the one case hash
+ * mode provably cannot cover. See `NeedsSenderRecovery`.
+ *
+ * ── THE PERSISTENCE GAP, WHICH IS WHY SENDER MODE IS NOT OPTIONAL ────────────
+ *
+ * HOSTED CHILD SQLITE IS EPHEMERAL. The only volume in the Railway project is
+ * `postgres-volume`, attached to Postgres; the orchestrator service has none. A
+ * child's ledger lives at `children/<tenant>/merrymen.db` on the container
+ * filesystem, so A REDEPLOY WIPES EVERY CHILD LEDGER — including every
+ * `status='submitted'` row and the `user_op_hash` on it. Shared Postgres DOES
+ * preserve them (ledger-mirror carries `trades` upward), but a child cannot read
+ * Postgres: `DATABASE_URL` is in CHILD_SECRET_STRIP, deliberately, for custody.
+ *
+ * So at cold arm — the one moment the expensive historical scan runs — a child
+ * has ZERO known hashes, and hash mode is unavailable exactly when it would help
+ * most. That is not a defect in this design; it is the reason the shared sender
+ * scanner exists and must keep existing.
+ *
+ * A future optimisation could close it: the orchestrator holds DATABASE_URL and
+ * already writes grant.json, settings.json and peers.json into each child's
+ * home, so it could write the tenant's outstanding hashes down the same channel
+ * at spawn. `OutstandingOpsSnapshot` below is the shape that would arrive, and
+ * `planArmReconcile` already accepts it — so adding the transport later needs no
+ * redesign here. IT WOULD BE A HINT, NEVER AUTHORITATIVE: a snapshot that is
+ * stale, partial or absent must fall back to sender recovery, and this module is
+ * written so that falling back is the default rather than a special case.
+ *
+ * ── SHARED FETCH, PRIVATE ACCOUNTING ─────────────────────────────────────────
+ *
+ * One chain-level fetch serves many senders — measured: an 11-sender OR-list
+ * over 200,001 blocks costs the SAME 21 chunks as one sender, for +17% wall
+ * clock. But the fetch is the only thing shared. Logs are partitioned by sender
+ * and handed to each tenant's existing reconciliation logic untouched. No
+ * accounting decision moves here, and nothing in this file decides what a log
+ * MEANS for a ledger.
+ */
+import type { Hex } from "viem";
+import { ENTRYPOINT } from "../../packages/core/src/index";
+import { getLogsAdaptive, addressTopic, type RawLog, type ReconcileChain } from "./inflight-reconcile";
+
+/** Topic0 of UserOperationEvent. Same constant inflight-reconcile.ts uses. */
+const USEROP_EVENT_TOPIC = "0x49628fd1471006c1482da88028e9ce4dbb080b815c9b0344d39e5a8e6ec1419f";
+
+/**
+ * MEASURED, not guessed: 1000 entries per topic position, and the cap is
+ * per-position rather than across the whole filter. 1001 is refused with
+ * "invalid argument 0: exceed max topics".
+ */
+export const HASH_TOPIC_MAX = 1000;
+
+// ── canonicalisation ────────────────────────────────────────────────────────
+
+/**
+ * ONE CANONICAL FORM, so two equivalent sets cannot produce two fetches.
+ *
+ * Lowercased, deduplicated, sorted. The provider was measured to be
+ * order-insensitive for an OR-list, which is what makes sorting a free
+ * normalisation rather than a change of question — if order had mattered,
+ * canonicalising would have been unsafe and this comment would say so.
+ */
+export function canonicalHashes(hashes: Iterable<string>): Hex[] {
+  const set = new Set<string>();
+  for (const h of hashes) {
+    const t = h.trim().toLowerCase();
+    if (/^0x[0-9a-f]{64}$/.test(t)) set.add(t);
+  }
+  return [...set].sort() as Hex[];
+}
+
+/** Same rule for senders. Invalid entries are dropped rather than passed on. */
+export function canonicalSenders(addrs: Iterable<string>): `0x${string}`[] {
+  const set = new Set<string>();
+  for (const a of addrs) {
+    const t = a.trim().toLowerCase();
+    if (/^0x[0-9a-f]{40}$/.test(t)) set.add(t);
+  }
+  return [...set].sort() as `0x${string}`[];
+}
+
+/** The cache/dedupe key for one shared fetch. Canonical by construction. */
+export function fetchKey(chainId: number, from: bigint, to: bigint, canonicalSet: readonly string[]): string {
+  return `${chainId}:${from}:${to}:${canonicalSet.join(",")}`;
+}
+
+// ── hash mode ───────────────────────────────────────────────────────────────
+
+export interface HashFetchResult {
+  logs: RawLog[];
+  /** eth_getLogs calls actually issued. ZERO when there is nothing outstanding. */
+  requests: number;
+  complete: boolean;
+  scannedTo: bigint;
+}
+
+/**
+ * Fetch the events for a known set of userOpHashes.
+ *
+ * ZERO HASHES MEANS ZERO REQUESTS, and that is the single largest saving in the
+ * steady state: a fleet with nothing outstanding asks the provider nothing.
+ * Returning `complete: true` for an empty set is correct rather than convenient
+ * — a question with no subjects was answered in full.
+ */
+export async function fetchByHashes(
+  chain: ReconcileChain,
+  opts: {
+    hashes: Iterable<string>;
+    fromBlock: bigint;
+    toBlock: bigint;
+    maxSpan?: bigint;
+    log?: (m: string) => void;
+  },
+): Promise<HashFetchResult> {
+  const canonical = canonicalHashes(opts.hashes);
+  if (canonical.length === 0) {
+    return { logs: [], requests: 0, complete: true, scannedTo: opts.toBlock };
+  }
+
+  const logs: RawLog[] = [];
+  let requests = 0;
+  let complete = true;
+  let scannedTo = opts.toBlock;
+
+  // Chunked at the measured provider cap. A batch is a separate question, so a
+  // short scan in one batch must not be reported as coverage of another.
+  for (let i = 0; i < canonical.length; i += HASH_TOPIC_MAX) {
+    const batch = canonical.slice(i, i + HASH_TOPIC_MAX);
+    const r = await getLogsAdaptive(
+      chain,
+      {
+        address: ENTRYPOINT.v07 as `0x${string}`,
+        // topic1 IS the question here — the inverse of the sender sweep, which
+        // leaves topic1 null precisely because it does not know the hashes.
+        topics: [USEROP_EVENT_TOPIC, batch as Hex[]],
+      },
+      opts.fromBlock,
+      opts.toBlock,
+      opts.maxSpan ?? 10_000n,
+      opts.log,
+    );
+    requests += 1;
+    logs.push(...r.logs);
+    if (!r.complete) {
+      complete = false;
+      if (r.scannedTo < scannedTo) scannedTo = r.scannedTo;
+    }
+  }
+  return { logs, requests, complete, scannedTo };
+}
+
+/**
+ * THE ONE CASE HASH MODE CANNOT COVER.
+ *
+ * executor.ts computes the userOpHash locally and persists it before the send,
+ * so every crash window leaves a durable hash — except one. When the bundler
+ * answers `sendUserOperation` with a DIFFERENT hash than the one the operation
+ * was signed under, the operation is genuinely in flight and, in the executor's
+ * own words, "which hash resolves it is now unknown". Querying topic1 for a hash
+ * the chain will never index finds nothing, and finding nothing would look
+ * exactly like success-with-no-event.
+ *
+ * So that operation is marked, and a marked operation goes to sender mode. This
+ * is a type rather than a boolean so the reason survives into the logs.
+ */
+export type HashIdentity =
+  | { kind: "known"; userOpHash: Hex }
+  | { kind: "uncertain"; signedHash: Hex; acceptedHash?: Hex; why: string };
+
+export interface OutstandingOp {
+  identity: HashIdentity;
+  /** Where a search for THIS operation must start. Never the fleet cursor. */
+  recoveryFromBlock: bigint;
+}
+
+/** Split outstanding operations into the two modes. Pure. */
+export function splitByMode(ops: readonly OutstandingOp[]): {
+  hashes: Hex[];
+  needsSenderRecovery: OutstandingOp[];
+} {
+  const known: string[] = [];
+  const needsSenderRecovery: OutstandingOp[] = [];
+  for (const op of ops) {
+    if (op.identity.kind === "known") known.push(op.identity.userOpHash);
+    else needsSenderRecovery.push(op);
+  }
+  return { hashes: canonicalHashes(known), needsSenderRecovery };
+}
+
+// ── the three cursor concepts, deliberately not one ─────────────────────────
+
+/**
+ * THREE DIFFERENT QUESTIONS, AND CONFLATING THEM IS THE BUG THIS PREVENTS.
+ *
+ *   chainFetchProgress   how far the SHARED fetcher has safely observed on this
+ *                        chain. A performance fact about the fleet.
+ *   tenant state         what each agent has actually accounted for. Lives in
+ *                        that tenant's own ledger and is not represented here —
+ *                        deliberately, because this module must not own it.
+ *   recovery lower bound where a PARTICULAR unresolved operation or a newly
+ *                        armed tenant must search from. A correctness fact
+ *                        about one subject.
+ *
+ * A single fleet cursor used as proof of completeness produces exactly this
+ * failure: progress reaches block 50,000,000, a tenant arms needing an event
+ * from 49,800,000, and the cursor says history is already covered. It is not —
+ * it is covered FOR THE SENDERS THAT WERE IN THE FETCH, which that tenant was
+ * not. So progress never clamps a lower bound; see `planSharedScan`.
+ */
+export interface FetchProgressStore {
+  read(chainId: number): Promise<bigint | null>;
+  /** Called ONLY after every consumer has accepted the range. See commitAfter. */
+  commit(chainId: number, throughBlock: bigint): Promise<void>;
+}
+
+/** What one tenant needs from a shared scan. */
+export interface SenderScanRequest {
+  sender: `0x${string}`;
+  /** This tenant's own lower bound. Not derived from, and never clamped by, progress. */
+  fromBlock: bigint;
+}
+
+/**
+ * REORG OVERLAP — three separate things, kept separate on purpose.
+ *
+ * 1. MEASURED CHAIN BEHAVIOUR. I have not measured reorg depth on 4663, and the
+ *    earlier fleet observation ("zero restarts, no halvings, no skipped blocks"
+ *    over 9 hours) says nothing about it — it was not looking. Absence of
+ *    observed reorgs is not evidence of finality, and treating it as such is the
+ *    error this comment exists to refuse.
+ *
+ * 2. FUNDAMENTAL GUARANTEE. I could not establish an authoritative finality
+ *    bound for Robinhood Chain from the repo or from the chain itself. It is an
+ *    Arbitrum-stack L3, so its settlement inherits from the L2 beneath it and
+ *    ultimately L1, but the depth at which a SEQUENCER pre-confirmation can be
+ *    reordered is a property of that operator's configuration, not something a
+ *    block header reveals. NO DEFENSIBLE BOUND IS CLAIMED HERE.
+ *
+ * 3. THE ENGINEERING MARGIN WE CHOOSE, which is therefore the whole basis for
+ *    this number. Expressed in SECONDS and converted, so it survives a block
+ *    time change: 30 minutes of chain history. At the measured 0.1015 s/block on
+ *    4663 that is ~17,700 blocks, or two 10,000-block chunks per pass.
+ *
+ * The cost of being generous here is two extra requests; the cost of being tight
+ * is an operation whose outcome is permanently invisible. And re-reading is only
+ * safe at all BECAUSE LEDGER APPLICATION IS IDEMPOTENT — the same event
+ * delivered twice must produce one effect. That is a requirement on the
+ * consumer, not a property of this module, and it is tested.
+ */
+export const REORG_OVERLAP_SEC = 1800;
+
+/** Blocks of overlap for a chain whose observed block time is `secPerBlock`. */
+export function reorgOverlapBlocks(secPerBlock: number): bigint {
+  if (!Number.isFinite(secPerBlock) || secPerBlock <= 0) return 20_000n; // unknown → generous
+  return BigInt(Math.ceil(REORG_OVERLAP_SEC / secPerBlock));
+}
+
+export interface SharedScanPlan {
+  fromBlock: bigint;
+  toBlock: bigint;
+  senders: `0x${string}`[];
+  /** Which request drove `fromBlock` — so a wide scan can be explained. */
+  drivenBy: `0x${string}` | "overlap" | "none";
+  /** True when no tenant needed history below the overlap window. */
+  incremental: boolean;
+}
+
+/**
+ * Decide the range for one shared pass.
+ *
+ * `fromBlock` is the LOWEST of every tenant's own lower bound and the re-read
+ * overlap below committed progress. Progress can only ever WIDEN the scan (by
+ * pulling the overlap in); it can never narrow it, which is what keeps a newly
+ * armed tenant's history reachable after the fleet cursor has moved on.
+ */
+export function planSharedScan(args: {
+  head: bigint;
+  chainFetchProgress: bigint | null;
+  requests: readonly SenderScanRequest[];
+  overlapBlocks: bigint;
+}): SharedScanPlan {
+  const senders = canonicalSenders(args.requests.map((r) => r.sender));
+  if (args.requests.length === 0) {
+    return { fromBlock: args.head, toBlock: args.head, senders: [], drivenBy: "none", incremental: true };
+  }
+
+  let lowest = args.requests[0]!;
+  for (const r of args.requests) if (r.fromBlock < lowest.fromBlock) lowest = r;
+
+  const overlapFloor =
+    args.chainFetchProgress === null
+      ? null
+      : args.chainFetchProgress > args.overlapBlocks
+        ? args.chainFetchProgress - args.overlapBlocks
+        : 0n;
+
+  let fromBlock = lowest.fromBlock;
+  let drivenBy: SharedScanPlan["drivenBy"] = lowest.sender;
+  if (overlapFloor !== null && overlapFloor < fromBlock) {
+    fromBlock = overlapFloor;
+    drivenBy = "overlap";
+  }
+  return {
+    fromBlock,
+    toBlock: args.head,
+    senders,
+    drivenBy,
+    incremental: overlapFloor !== null && lowest.fromBlock >= overlapFloor,
+  };
+}
+
+// ── the shared fetcher ──────────────────────────────────────────────────────
+
+export interface SharedFetchResult {
+  /** Lowercased sender → that sender's logs, and nobody else's. */
+  bySender: Map<string, RawLog[]>;
+  /** eth_getLogs calls issued. One chunked scan, not one per sender. */
+  requests: number;
+  complete: boolean;
+  scannedTo: bigint;
+  /** Logs whose topic2 matched no requested sender. Should always be zero. */
+  unattributed: number;
+}
+
+/**
+ * One fetch, many senders, then partitioned.
+ *
+ * `deliver` is called once per REQUESTED sender — including senders with no logs,
+ * so a consumer can tell "nothing happened" from "you were not asked". Progress
+ * is committed only if every delivery resolved AND coverage was complete: a
+ * consumer that threw leaves the range unclaimed, and the next pass re-reads it.
+ */
+export async function fetchSharedBySender(
+  chain: ReconcileChain,
+  opts: {
+    senders: readonly string[];
+    fromBlock: bigint;
+    toBlock: bigint;
+    maxSpan?: bigint;
+    log?: (m: string) => void;
+  },
+): Promise<SharedFetchResult> {
+  const senders = canonicalSenders(opts.senders);
+  const bySender = new Map<string, RawLog[]>();
+  for (const s of senders) bySender.set(s, []);
+  if (senders.length === 0) {
+    return { bySender, requests: 0, complete: true, scannedTo: opts.toBlock, unattributed: 0 };
+  }
+
+  let requests = 0;
+  let complete = true;
+  let scannedTo = opts.toBlock;
+  let unattributed = 0;
+
+  // One chunked scan for the whole cohort. Measured: the chunk count is set by
+  // the RANGE, not the cohort — an 11-sender list costs the same 21 chunks as one.
+  for (let i = 0; i < senders.length; i += HASH_TOPIC_MAX) {
+    const slice = senders.slice(i, i + HASH_TOPIC_MAX);
+    const r = await getLogsAdaptive(
+      chain,
+      {
+        address: ENTRYPOINT.v07 as `0x${string}`,
+        // topic1 left null on purpose: the sweep does not know the hashes —
+        // that is the whole reason it is scanning by sender.
+        topics: [USEROP_EVENT_TOPIC as Hex, null, slice.map((s) => addressTopic(s)) as Hex[]],
+      },
+      opts.fromBlock,
+      opts.toBlock,
+      opts.maxSpan ?? 10_000n,
+      opts.log,
+    );
+    requests += 1;
+    if (!r.complete) {
+      complete = false;
+      if (r.scannedTo < scannedTo) scannedTo = r.scannedTo;
+    }
+    for (const raw of r.logs) {
+      // PARTITION BY topic2, which is the indexed sender. A log is handed to
+      // exactly one tenant, and to that tenant only.
+      const t2 = raw.topics[2];
+      const sender = typeof t2 === "string" ? `0x${t2.slice(26).toLowerCase()}` : "";
+      const bucket = bySender.get(sender);
+      // COUNTED, NOT ASSERTED. A log matching no requested sender means the
+      // filter did something we did not expect — worth a number in a log line
+      // rather than a crash, and worth never silently applying to somebody.
+      if (bucket) bucket.push(raw);
+      else unattributed += 1;
+    }
+  }
+
+  if (unattributed > 0) {
+    opts.log?.(`shared scan: ${unattributed} log(s) matched no requested sender and were DISCARDED, not applied`);
+  }
+  return { bySender, requests, complete, scannedTo, unattributed };
+}
+
+/**
+ * Run a shared pass and commit progress ONLY if the whole range was covered and
+ * every consumer accepted its own logs.
+ *
+ * The ordering is the guarantee: fetch, deliver to every consumer, and only then
+ * persist. A consumer that throws means the range was fetched but not accounted
+ * for, so progress must not move — the next pass re-reads it, and idempotent
+ * application makes that harmless.
+ */
+export async function runSharedPass(args: {
+  chain: ReconcileChain;
+  chainId: number;
+  plan: SharedScanPlan;
+  progress: FetchProgressStore;
+  deliver(sender: `0x${string}`, logs: RawLog[]): Promise<void>;
+  maxSpan?: bigint;
+  log?: (m: string) => void;
+}): Promise<{ result: SharedFetchResult; committed: boolean; reason?: string }> {
+  const result = await fetchSharedBySender(args.chain, {
+    senders: args.plan.senders,
+    fromBlock: args.plan.fromBlock,
+    toBlock: args.plan.toBlock,
+    maxSpan: args.maxSpan,
+    log: args.log,
+  });
+
+  let delivered = 0;
+  for (const sender of args.plan.senders) {
+    // Sequential on purpose: a consumer is somebody's ledger, and 22 concurrent
+    // writers to 22 sqlite files is a different change with different risks.
+    await args.deliver(sender, result.bySender.get(sender) ?? []);
+    delivered += 1;
+  }
+
+  if (!result.complete) {
+    args.log?.(
+      `shared scan covered only ${args.plan.fromBlock}..${result.scannedTo} of ` +
+        `${args.plan.fromBlock}..${args.plan.toBlock} — progress NOT advanced`,
+    );
+    return { result, committed: false, reason: "incomplete-coverage" };
+  }
+  if (delivered !== args.plan.senders.length) {
+    return { result, committed: false, reason: "undelivered" };
+  }
+  await args.progress.commit(args.chainId, args.plan.toBlock);
+  return { result, committed: true };
+}
+
+// ── the arm-time entry point, with room for a future snapshot ───────────────
+
+/**
+ * A snapshot of a tenant's outstanding operations, supplied from OUTSIDE the
+ * child. Not produced today — the transport does not exist — and the shape is
+ * here so adding it later needs no redesign.
+ *
+ * A HINT, NEVER AUTHORITATIVE. `staleAsOfBlock` is what makes that enforceable:
+ * anything the snapshot does not cover still goes to sender recovery, and an
+ * absent snapshot is simply the case where nothing is covered.
+ */
+export interface OutstandingOpsSnapshot {
+  tenant: `0x${string}`;
+  ops: readonly OutstandingOp[];
+  /** The block the snapshot was accurate as of. Below this, trust nothing. */
+  staleAsOfBlock: bigint;
+}
+
+export interface ArmReconcilePlan {
+  /** Hash-mode query, empty when nothing is known outstanding. */
+  hashes: Hex[];
+  /** Senders needing the shared historical scan, with their own lower bounds. */
+  senderRequests: SenderScanRequest[];
+  /** Why sender mode was needed, for the log line. */
+  reasons: string[];
+}
+
+/**
+ * What an arming tenant should ask, given what it knows.
+ *
+ * The local ledger is the authority. A snapshot, when one ever arrives, can only
+ * ADD hashes it is confident about — and every operation it does not cover, or
+ * covers only below its own staleness horizon, falls to sender recovery. That
+ * asymmetry is the whole safety property: the optimisation can never subtract a
+ * search.
+ */
+export function planArmReconcile(args: {
+  sender: `0x${string}`;
+  /** From the tenant's OWN ledger. Empty after a redeploy — see the header. */
+  localOutstanding: readonly OutstandingOp[];
+  /** Not implemented yet; accepted so the interface does not change later. */
+  knownOutstandingOps?: OutstandingOpsSnapshot;
+  /** Where this tenant must search from if sender mode is needed. */
+  recoveryFromBlock: bigint;
+}): ArmReconcilePlan {
+  const reasons: string[] = [];
+  const merged: OutstandingOp[] = [...args.localOutstanding];
+
+  if (args.knownOutstandingOps) {
+    for (const op of args.knownOutstandingOps.ops) {
+      // A hinted op below the snapshot's own horizon is not trustworthy as a
+      // hash; it becomes a reason to search, not a reason to skip searching.
+      if (op.recoveryFromBlock < args.knownOutstandingOps.staleAsOfBlock) {
+        merged.push({ ...op, identity: { kind: "uncertain", signedHash: hashOf(op), why: "hint older than snapshot horizon" } });
+      } else {
+        merged.push(op);
+      }
+    }
+  }
+
+  const { hashes, needsSenderRecovery } = splitByMode(merged);
+  const senderRequests: SenderScanRequest[] = [];
+
+  if (args.localOutstanding.length === 0 && !args.knownOutstandingOps) {
+    // The cold-arm case, and the common one hosted: an empty ledger is not
+    // evidence of nothing outstanding, it is absence of evidence. Search.
+    reasons.push("no local outstanding-op knowledge (empty ledger or first arm)");
+    senderRequests.push({ sender: args.sender, fromBlock: args.recoveryFromBlock });
+  }
+  for (const op of needsSenderRecovery) {
+    reasons.push(
+      op.identity.kind === "uncertain"
+        ? `uncertain hash identity: ${op.identity.why}`
+        : "unclassified outstanding op",
+    );
+    senderRequests.push({ sender: args.sender, fromBlock: op.recoveryFromBlock });
+  }
+
+  return { hashes, senderRequests, reasons };
+}
+
+function hashOf(op: OutstandingOp): Hex {
+  return op.identity.kind === "known" ? op.identity.userOpHash : op.identity.signedHash;
+}

--- a/worker/src/reconcile-shadow.test.ts
+++ b/worker/src/reconcile-shadow.test.ts
@@ -1,0 +1,247 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import type { Hex } from "viem";
+import {
+  compareEventSets,
+  keyOf,
+  runShadowComparison,
+  shadowEnabledFor,
+  shadowLine,
+} from "./reconcile-shadow";
+import { addressTopic, type RawLog, type ReconcileChain } from "./inflight-reconcile";
+
+const TOPIC0 = "0x49628fd1471006c1482da88028e9ce4dbb080b815c9b0344d39e5a8e6ec1419f" as Hex;
+const ACC = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as `0x${string}`;
+const OTHER = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as `0x${string}`;
+const h = (n: number) => (`0x${n.toString(16).padStart(64, "0")}`) as Hex;
+
+function logFor(sender: `0x${string}`, n: number, block = 100n): RawLog {
+  return {
+    topics: [TOPIC0, h(n), addressTopic(sender), addressTopic(sender)],
+    data: "0x",
+    transactionHash: (`0x${n.toString(16).padStart(64, "0")}`) as Hex,
+    blockNumber: (`0x${block.toString(16)}`) as Hex,
+    logIndex: "0x0",
+  };
+}
+
+function chainOf(logs: RawLog[]): ReconcileChain {
+  return {
+    async getBlockNumber() {
+      return 1000n;
+    },
+    async getLogs(args) {
+      const t2 = args.topics[2];
+      return logs.filter((l) => {
+        const b = BigInt(l.blockNumber ?? "0x0");
+        if (b < args.fromBlock || b > args.toBlock) return false;
+        if (!t2) return true;
+        const want = Array.isArray(t2) ? t2 : [t2];
+        return want.includes(l.topics[2] as Hex);
+      });
+    },
+    async getReceiptLogs() {
+      return null;
+    },
+  };
+}
+
+// ── the canary switch ───────────────────────────────────────────────────────
+
+test("SHADOW IS OFF UNLESS ASKED FOR — an unset variable costs nobody a scan", () => {
+  assert.equal(shadowEnabledFor(ACC, {} as NodeJS.ProcessEnv), false);
+  assert.equal(shadowEnabledFor(ACC, { MERRYMEN_RECONCILE_SHADOW: "" } as NodeJS.ProcessEnv), false);
+  assert.equal(shadowEnabledFor(ACC, { MERRYMEN_RECONCILE_SHADOW: "   " } as NodeJS.ProcessEnv), false);
+});
+
+test("the canary set is a prefix list, so an operator can paste either address", () => {
+  const on = (v: string, id = ACC) => shadowEnabledFor(id, { MERRYMEN_RECONCILE_SHADOW: v } as NodeJS.ProcessEnv);
+  assert.equal(on("all"), true);
+  assert.equal(on("0xaaaaaaaa"), true, "a prefix matches");
+  assert.equal(on("0xAAAAAAAA"), true, "case-insensitively");
+  assert.equal(on("0xbbbbbbbb"), false, "and does not match somebody else");
+  assert.equal(on("0xbbbbbbbb,0xaaaaaaaa"), true, "a list matches any entry");
+  assert.equal(on(" 0xaaaaaaaa , 0xcccc "), true, "whitespace is forgiven");
+  assert.equal(on("0xaaaaaaaa", OTHER), false, "a small canary stays small");
+});
+
+// ── what equivalence means ─────────────────────────────────────────────────
+
+test("identical fetches over the same covered range are equivalent", () => {
+  const logs = [logFor(ACC, 1), logFor(ACC, 2)];
+  const v = compareEventSets({
+    oldLogs: logs,
+    newLogs: [...logs].reverse(), // order is not identity
+    oldComplete: true,
+    newComplete: true,
+    oldScannedTo: 1000n,
+    newScannedTo: 1000n,
+  });
+  assert.equal(v.equivalent, true);
+  assert.equal(v.informative, true);
+  assert.equal(v.inBoth, 2);
+  assert.match(v.detail, /identical on both sides/);
+});
+
+test("AN EMPTY COMPARISON IS NOT EVIDENCE OF EQUIVALENCE", () => {
+  // The measurement that forces this: over 9.066 hours the fleet had ZERO
+  // outstanding operations and the arm sweep found NOTHING on all 22 children.
+  // A canary that counted these would promote on nothing at all.
+  const v = compareEventSets({
+    oldLogs: [],
+    newLogs: [],
+    oldComplete: true,
+    newComplete: true,
+    oldScannedTo: 1000n,
+    newScannedTo: 1000n,
+  });
+  assert.equal(v.equivalent, true, "the two fetches did agree");
+  assert.equal(v.informative, false, "but they agreed about an absence");
+  assert.match(v.detail, /agreement about an absence, not evidence/);
+  assert.match(shadowLine(ACC, v, 1, 0), /EMPTY/, "and the log line says so at a glance");
+});
+
+test("a missing or extra event is a MISMATCH, and names which side", () => {
+  const both = logFor(ACC, 1);
+  const onlyOld = logFor(ACC, 2);
+  const onlyNew = logFor(ACC, 3);
+  const v = compareEventSets({
+    oldLogs: [both, onlyOld],
+    newLogs: [both, onlyNew],
+    oldComplete: true,
+    newComplete: true,
+    oldScannedTo: 1000n,
+    newScannedTo: 1000n,
+  });
+  assert.equal(v.equivalent, false);
+  assert.equal(v.inBoth, 1);
+  assert.deepEqual(v.onlyInOld.map((k) => k.userOpHash), [h(2)]);
+  assert.deepEqual(v.onlyInNew.map((k) => k.userOpHash), [h(3)]);
+  const line = shadowLine(ACC, v, 1, 2);
+  assert.match(line, /MISMATCH/);
+  assert.match(line, /only-old/);
+  assert.match(line, /only-new/);
+});
+
+test("EQUAL SETS OVER UNEQUAL RANGES ARE NOT EQUIVALENT", () => {
+  // The trap the proposal named: a shorter scan simply had fewer chances to
+  // differ. Agreement has to be about the same blocks.
+  const logs = [logFor(ACC, 1)];
+  const shortNew = compareEventSets({
+    oldLogs: logs,
+    newLogs: logs,
+    oldComplete: true,
+    newComplete: false,
+    oldScannedTo: 1000n,
+    newScannedTo: 800n,
+  });
+  assert.equal(shortNew.equivalent, false, "identical events, different coverage");
+  assert.equal(shortNew.coverageMatches, false);
+  assert.match(shortNew.detail, /Equal event sets over unequal ranges prove nothing/);
+
+  // And the reverse: the OLD path falling short does not excuse the new one.
+  const shortOld = compareEventSets({
+    oldLogs: logs,
+    newLogs: logs,
+    oldComplete: false,
+    newComplete: true,
+    oldScannedTo: 700n,
+    newScannedTo: 1000n,
+  });
+  assert.equal(shortOld.equivalent, false);
+});
+
+// ── the runner ─────────────────────────────────────────────────────────────
+
+test("the runner compares the NEW fetch against the authoritative logs", async () => {
+  const mine = [logFor(ACC, 1, 50n), logFor(ACC, 2, 60n)];
+  const theirs = [logFor(OTHER, 9, 55n)];
+  const chain = chainOf([...mine, ...theirs]);
+
+  const { verdict, newRequests } = await runShadowComparison({
+    chain,
+    smartAccount: ACC,
+    fromBlock: 0n,
+    toBlock: 1000n,
+    oldLogs: mine,
+    oldComplete: true,
+    oldScannedTo: 1000n,
+  });
+  assert.equal(verdict.equivalent, true);
+  assert.equal(verdict.inBoth, 2);
+  assert.equal(newRequests, 1, "one shared fetch");
+  // Another tenant's event never enters the comparison, so it can never be
+  // mistaken for a difference between the two fetches.
+  assert.equal(verdict.onlyInNew.length, 0);
+});
+
+test("a real fetch difference IS caught by the runner", async () => {
+  // The new fetch sees an event the authoritative scan did not — exactly the
+  // shape of defect shadow mode exists to find before promotion.
+  const chain = chainOf([logFor(ACC, 1, 50n), logFor(ACC, 2, 60n)]);
+  const { verdict } = await runShadowComparison({
+    chain,
+    smartAccount: ACC,
+    fromBlock: 0n,
+    toBlock: 1000n,
+    oldLogs: [logFor(ACC, 1, 50n)],
+    oldComplete: true,
+    oldScannedTo: 1000n,
+  });
+  assert.equal(verdict.equivalent, false);
+  assert.deepEqual(verdict.onlyInNew.map((k) => k.userOpHash), [h(2)]);
+});
+
+// ── the invariant ──────────────────────────────────────────────────────────
+
+test("SHADOW MODE CANNOT MUTATE ANYTHING — there is no store in scope to write to", () => {
+  // Checked against CODE, not prose. The header legitimately NAMES addTrade to
+  // explain what shadow mode is not comparing, and naming a thing is not calling it.
+  const src = readFileSync(new URL("./reconcile-shadow.ts", import.meta.url), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+  for (const forbidden of ["addTrade", "refreshBudget", "getDb", "initStore", "setAgentStatus", "INSERT", "UPDATE"]) {
+    assert.doesNotMatch(src, new RegExp(forbidden), `shadow mode must not reference ${forbidden}`);
+  }
+  // It imports the fetcher and the log shapes, and nothing that writes.
+  assert.match(src, /from "\.\/reconcile-modes"/);
+  assert.doesNotMatch(src, /from "\.\/store"/, "no ledger handle may be imported here");
+});
+
+test("THE CALL SITE IS OBSERVATIONAL: it runs after the decision and cannot fail an arm", () => {
+  const src = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+  const orphansAt = src.indexOf("const orphans = await findOrphanOps({");
+  const shadowAt = src.indexOf("shadowEnabledFor(smartAccount)");
+  assert.ok(orphansAt > 0 && shadowAt > orphansAt, "the shadow runs after the authoritative sweep");
+
+  // Wrapped, because a defect in an observer must never stop the sweep that
+  // keeps the day's spend from being under-counted.
+  // Bounded to the guarded block itself. A fixed character count runs past it
+  // into unrelated code and then tests that code instead.
+  const end = src.indexOf("reconciliation unaffected", shadowAt);
+  assert.ok(end > shadowAt, "the guard is where we think it is");
+  const block = src.slice(shadowAt, end + 60);
+  // `catch`, specifically — not merely `try`. A `try/finally` also contains a
+  // `try {` and still lets the throw propagate and fail the arm, which is the
+  // exact defect this pin exists to prevent. Asserting the weaker pattern let
+  // that mutation through when it was tested.
+  assert.match(block, /\}\s*catch\s*\(/, "the comparison must be CAUGHT, not merely wrapped");
+  assert.match(block, /reconciliation unaffected/, "and says so when it fails");
+  // And it writes nothing.
+  assert.doesNotMatch(block, /addTrade|refreshBudget|await set/, "the shadow must not write");
+
+  // findOrphanOps' hook is observational by contract, not just by use.
+  const rec = readFileSync(new URL("./inflight-reconcile.ts", import.meta.url), "utf8");
+  assert.match(rec, /PURELY OBSERVATIONAL/, "the hook says what it is");
+  assert.match(rec, /opts\.onLogs\?\.\(logs\.logs, logs\.complete, logs\.scannedTo\)/);
+});
+
+test("keyOf reduces an event to the identity two fetches must agree on", () => {
+  const k = keyOf(logFor(ACC, 7, 42n));
+  assert.equal(k.userOpHash, h(7));
+  assert.equal(k.blockNumber, "0x2a");
+  // Lowercased, so a provider that varies case cannot manufacture a mismatch.
+  const upper: RawLog = { ...logFor(ACC, 7, 42n), transactionHash: (`0x${"A".repeat(64)}`) as Hex };
+  assert.equal(keyOf(upper).txHash, `0x${"a".repeat(64)}`);
+});

--- a/worker/src/reconcile-shadow.ts
+++ b/worker/src/reconcile-shadow.ts
@@ -1,0 +1,199 @@
+/**
+ * RUN THE NEW RECONCILER BESIDE THE OLD ONE AND COMPARE. NEVER MUTATE.
+ *
+ * reconcile-modes.ts replaces one thing and one thing only: HOW the EntryPoint
+ * logs are FETCHED. The accounting on top of them is untouched — the same
+ * findOrphanOps decides what a log means, the same addTrade writes it. So this
+ * is what shadow mode has to establish equivalence of: THE FETCH. Comparing
+ * ledger effects would be comparing code that did not change.
+ *
+ * THE COMPARISON IS AGAINST WHAT THE AUTHORITATIVE PATH REALLY SAW, not against
+ * a third scan of the same range. findOrphanOps hands its own logs out through
+ * `onLogs`, so a mismatch is a genuine difference between two fetches of the same
+ * blocks rather than two fetches of two slightly different moments.
+ *
+ * WHAT SHADOW MODE COSTS. One extra scan of the same range per armed canary
+ * tenant — the new fetch — on top of the old one. That is the price of the
+ * comparison and it is temporary; it is also why the canary is a small set
+ * rather than the fleet.
+ *
+ * WHAT IT CANNOT ESTABLISH, stated because the measurement says so rather than
+ * because it is a nice caveat. Over 9.066 hours the fleet had ZERO outstanding
+ * operations and the arm sweep found NOTHING on all 22 children. An empty set
+ * compared against an empty set is not evidence of equivalence — it is evidence
+ * that nothing happened. `ShadowVerdict.informative` is false for exactly that
+ * case, and a promotion decision that counts uninformative comparisons is
+ * counting nothing. Getting real evidence needs operations that actually landed:
+ * deliberate re-arms against accounts with history, not calendar time.
+ */
+import type { Hex } from "viem";
+import type { RawLog, ReconcileChain } from "./inflight-reconcile";
+import { fetchSharedBySender } from "./reconcile-modes";
+
+/**
+ * Which tenants are shadowing.
+ *
+ * MERRYMEN_RECONCILE_SHADOW is either "all" or a comma-separated list of
+ * address PREFIXES, matched case-insensitively against the smart account and
+ * the tenant alike — the log lines carry the smart account, the operator thinks
+ * in tenants, and being able to paste either is worth more than being strict.
+ *
+ * ABSENT MEANS OFF. A shadow that switched itself on by default would put an
+ * extra scan on every arm in the fleet to answer a question nobody asked.
+ */
+export function shadowEnabledFor(id: string, env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = (env.MERRYMEN_RECONCILE_SHADOW ?? "").trim();
+  if (!raw) return false;
+  const want = id.trim().toLowerCase();
+  if (!want) return false;
+  return raw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+    .some((p) => p === "all" || want.startsWith(p));
+}
+
+/** One event, reduced to the identity two fetches must agree on. */
+export interface EventKey {
+  userOpHash: string;
+  txHash: string;
+  blockNumber: string;
+}
+
+export function keyOf(l: RawLog): EventKey {
+  return {
+    userOpHash: String(l.topics[1] ?? "").toLowerCase(),
+    txHash: String(l.transactionHash ?? "").toLowerCase(),
+    blockNumber: String(l.blockNumber ?? "").toLowerCase(),
+  };
+}
+
+const idOf = (k: EventKey) => `${k.userOpHash}@${k.txHash}#${k.blockNumber}`;
+
+export interface ShadowVerdict {
+  equivalent: boolean;
+  /**
+   * False when BOTH sides are empty. Not a failure — a comparison that had
+   * nothing to compare, which must never be counted as evidence of agreement.
+   */
+  informative: boolean;
+  inBoth: number;
+  onlyInOld: EventKey[];
+  onlyInNew: EventKey[];
+  /** Coverage has to match too: equal event sets over unequal ranges prove nothing. */
+  coverageMatches: boolean;
+  detail: string;
+}
+
+/**
+ * Compare two fetches of the same range. Pure.
+ *
+ * COVERAGE IS PART OF THE ANSWER. Two scans that agree on events while one of
+ * them covered less of the range have not agreed about anything — the shorter
+ * scan simply had fewer chances to differ. So a coverage mismatch makes the
+ * verdict non-equivalent even when the sets are identical, and says which.
+ */
+export function compareEventSets(args: {
+  oldLogs: readonly RawLog[];
+  newLogs: readonly RawLog[];
+  oldComplete: boolean;
+  newComplete: boolean;
+  oldScannedTo: bigint;
+  newScannedTo: bigint;
+}): ShadowVerdict {
+  const oldMap = new Map(args.oldLogs.map((l) => [idOf(keyOf(l)), keyOf(l)]));
+  const newMap = new Map(args.newLogs.map((l) => [idOf(keyOf(l)), keyOf(l)]));
+  const onlyInOld = [...oldMap].filter(([id]) => !newMap.has(id)).map(([, k]) => k);
+  const onlyInNew = [...newMap].filter(([id]) => !oldMap.has(id)).map(([, k]) => k);
+  const inBoth = [...oldMap].filter(([id]) => newMap.has(id)).length;
+
+  const coverageMatches =
+    args.oldComplete === args.newComplete && args.oldScannedTo === args.newScannedTo;
+  const setsMatch = onlyInOld.length === 0 && onlyInNew.length === 0;
+  const informative = oldMap.size > 0 || newMap.size > 0;
+
+  let detail: string;
+  if (!coverageMatches) {
+    detail =
+      `coverage differs — old complete=${args.oldComplete} scannedTo=${args.oldScannedTo}, ` +
+      `new complete=${args.newComplete} scannedTo=${args.newScannedTo}. Equal event sets over ` +
+      "unequal ranges prove nothing, so this is NOT equivalence.";
+  } else if (!setsMatch) {
+    detail =
+      `${onlyInOld.length} event(s) only the old fetch saw, ${onlyInNew.length} only the new one. ` +
+      "The fetch is what changed, so this is a real difference and promotion must not proceed.";
+  } else if (!informative) {
+    detail =
+      "both fetches returned nothing over the same fully-covered range. That is agreement about " +
+      "an absence, not evidence of equivalence — it does not count toward promotion.";
+  } else {
+    detail = `${inBoth} event(s), identical on both sides over the same fully-covered range.`;
+  }
+
+  return {
+    equivalent: coverageMatches && setsMatch,
+    informative,
+    inBoth,
+    onlyInOld,
+    onlyInNew,
+    coverageMatches,
+    detail,
+  };
+}
+
+/**
+ * Fetch the same range through the NEW path and compare. Returns the verdict.
+ *
+ * MUTATES NOTHING. It takes no ledger handle, writes no row, and its return
+ * value is consumed by a log line. That is not a convention to be respected
+ * later — there is no store in scope here to write to.
+ */
+export async function runShadowComparison(args: {
+  chain: ReconcileChain;
+  smartAccount: `0x${string}`;
+  fromBlock: bigint;
+  toBlock: bigint;
+  oldLogs: readonly RawLog[];
+  oldComplete: boolean;
+  oldScannedTo: bigint;
+  maxSpan?: bigint;
+  log?: (m: string) => void;
+}): Promise<{ verdict: ShadowVerdict; newRequests: number }> {
+  const shared = await fetchSharedBySender(args.chain, {
+    // ONE sender here, because shadow mode compares against a single tenant's
+    // authoritative scan. The saving comes from batching senders across the
+    // fleet, which is the NEXT phase — this phase only has to prove that the
+    // shared fetcher returns the same events for one of them.
+    senders: [args.smartAccount],
+    fromBlock: args.fromBlock,
+    toBlock: args.toBlock,
+    maxSpan: args.maxSpan,
+    log: args.log,
+  });
+
+  const verdict = compareEventSets({
+    oldLogs: args.oldLogs,
+    newLogs: shared.bySender.get(args.smartAccount.toLowerCase()) ?? [],
+    oldComplete: args.oldComplete,
+    newComplete: shared.complete,
+    oldScannedTo: args.oldScannedTo,
+    newScannedTo: shared.scannedTo,
+  });
+  return { verdict, newRequests: shared.requests };
+}
+
+/** The one line an operator reads to decide whether promotion is earned. */
+export function shadowLine(
+  smartAccount: string,
+  v: ShadowVerdict,
+  newRequests: number,
+  oldLogs: number,
+): string {
+  const tag = !v.informative ? "EMPTY" : v.equivalent ? "MATCH" : "MISMATCH";
+  return (
+    `[shadow] ${smartAccount.slice(0, 10)} ${tag} · old ${oldLogs} event(s) · ` +
+    `new ${v.inBoth + v.onlyInNew.length} · +${newRequests} extra request(s) · ${v.detail}` +
+    (v.onlyInOld.length ? ` · only-old: ${v.onlyInOld.map(idOf).join(" ")}` : "") +
+    (v.onlyInNew.length ? ` · only-new: ${v.onlyInNew.map(idOf).join(" ")}` : "")
+  );
+}


### PR DESCRIPTION
Phase 0a of the approved Brain plan. Cherry-picked from the parked `stage-b/rpc-and-reconciler` branch — **only** the two reconciliation commits, not the HTTP telemetry, web RPC config or `circle.ts` connection reuse. Those stay parked, so this changes no transport on a fleet that has just started trading.

`MERRYMEN_RECONCILE_SHADOW` was already set to `0xa233a3` on the orchestrator and did nothing, because the code it gates lives only on that branch.

**What this adds**

`reconcile-modes.ts` — hash-mode and shared-sender fetch with three separate cursors. **No call site**; inert until wired.

`reconcile-shadow.ts` — runs the new fetcher beside the authoritative sweep over the same range, compares, and **discards the result**. It replaces one thing and one thing only: how EntryPoint logs are *fetched*. The accounting on top is untouched, which is why the comparison is of the fetch rather than of ledger effects.

- Compared against what the authoritative path **actually saw** — `findOrphanOps` gained a purely observational `onLogs` hook — so a mismatch is a real difference between two fetches of the same blocks, not two fetches of two different moments.
- **Coverage is part of equivalence.** Identical event sets over unequal ranges are not equivalent; the shorter scan simply had fewer chances to differ. Enforced in both directions.
- **An empty comparison is not evidence.** `informative: false` and the line reads `EMPTY`, never `MATCH`. Given zero outstanding operations across the fleet's whole history, this is the common case and must never count toward promotion.
- **Cannot mutate.** Not by convention — there is no store in scope. A test asserts that against the code with comments stripped.
- **Cannot fail an arm.** The call site is wrapped, because reconciliation is what stops the day's spend being under-counted.

**Off unless asked for.** `MERRYMEN_RECONCILE_SHADOW` is `all` or a comma-separated prefix list matched against the smart account or the tenant. Absent means off — it costs one extra 200k-block scan per armed canary tenant.

28 tests across the two modules. Mutations caught: an empty comparison counting as evidence, and `catch` → `finally` (which let a shadow failure propagate and fail the arm — a gap my first pin missed, since it asserted `try {`, which `try/finally` also satisfies).

**1958 tests, 0 failures.** Typecheck clean across worker, web and browser. The old reconciler remains authoritative and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)