### PR TITLE
A redeploy is not a deposit

### DIFF
--- a/packages/core/src/flow-evidence.ts
+++ b/packages/core/src/flow-evidence.ts
@@ -1,0 +1,49 @@
+/**
+ * HOW A CAPITAL FLOW CAME TO BE KNOWN — one rule, shared by both tiers.
+ *
+ * This lives in `core` rather than in the worker because the worker and the web
+ * were each carrying their own answer, and the two disagreed in both directions.
+ * The worker's accounting anchor counted `('chain-log','epoch-carry')`; the
+ * public agent page counted `('chain-log','transfer-intent')`. So an agent that
+ * had crossed an accounting-epoch boundary was publicly told its bridged capital
+ * was guesswork while the anchor, reading the same row from the same database at
+ * the same moment, counted it as evidence.
+ *
+ * A rule that decides whether a number may be published has to have exactly one
+ * definition, or the tiers will keep drifting apart in ways nobody notices until
+ * they contradict each other in front of an owner.
+ */
+
+/**
+ * The four ways a flow gets on the books, ranked by what each can support.
+ *
+ *   chain-log        read off a USDG Transfer log naming this account. A receipt:
+ *                    anyone with an RPC can refetch it. The only evidence that
+ *                    survives distrust of the operator.
+ *   epoch-carry      the closing equity of the epoch just closed, written as the
+ *                    new one's opening balance. NOT a receipt — it has no
+ *                    transaction and never can — but not guesswork either: it is
+ *                    a deterministic function of a figure already in the journal,
+ *                    and it is CHECKABLE against that epoch's final equity mark.
+ *   transfer-intent  a transfer this agent itself initiated. Known by
+ *                    construction, but the settlement is never re-read, so it is
+ *                    an intention rather than an observation.
+ *   inferred         deduced from a balance change nobody can point at. An
+ *                    opinion — and the specific shape that a redeploy's phantom
+ *                    opening balance and the mirror's cursor rewind both produce.
+ */
+export type FlowEvidence = "chain-log" | "epoch-carry" | "transfer-intent" | "inferred";
+
+/**
+ * The sources that can support a published contribution total.
+ *
+ * `transfer-intent` is deliberately absent. It is exact about what was ASKED for
+ * and silent about what settled, and a contribution total is a claim about money
+ * that actually arrived.
+ */
+export const EVIDENCED_FLOW_SOURCES: readonly FlowEvidence[] = ["chain-log", "epoch-carry"];
+
+/** Takes a bare string, because it is fed straight from a database column. */
+export function isEvidencedFlow(source: string): boolean {
+  return (EVIDENCED_FLOW_SOURCES as readonly string[]).includes(source);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,3 +11,4 @@ export * from "./wall";
 export * from "./mcp";
 export * from "./safe-url";
 export * from "./robinhood-oauth";
+export * from "./flow-evidence";

--- a/worker/src/accounting-scope.test.ts
+++ b/worker/src/accounting-scope.test.ts
@@ -1,0 +1,278 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { ACCOUNTING_SCOPES, EPOCH_SCOPED, isEvidencedFlow, reconcileEpochCarry } from "./accounting-scope";
+import { deriveBootstrapAccounting } from "./bootstrap-source";
+import { accountingLicence, classifyAnchor, BOOTSTRAP_SCHEMA_VERSION } from "./bootstrap-state";
+import type { Db } from "./db";
+
+/**
+ * TWO EPOCHS, AND THE SAME CAPITAL COUNTED ONCE.
+ *
+ * `openNextEpoch` bridges a boundary by writing the closing equity of the epoch
+ * just closed as the new one's opening balance. That is only correct if
+ * contributions are read PER EPOCH — and one of the two readers was not.
+ * `getNetContributionsUsdg` summed every row for the agent while the web's
+ * identical query carried an epoch predicate.
+ *
+ * It never fired, and the reason it never fired is the interesting part: the
+ * only agents ever bumped were those with rows predating the accounting fix, and
+ * those rows predate the flows table too — so epoch 1 held no flows and a
+ * lifetime sum happened to equal the current epoch's. Accidentally correct is not
+ * correct, and the accident stops holding the moment an agent funded on today's
+ * code is bumped for any future reason.
+ */
+
+const SMART = "0x3E34E58e39DC6614e047dFD3BAD5B7DEA45DCd62";
+const NOW = 1_760_000_000;
+
+/**
+ * A fake ledger that actually stores flows with epochs, so an epoch predicate is
+ * OBSERVABLE rather than asserted. `deriveBootstrapAccounting` builds its own
+ * SQL; this reads the epoch out of the parameters it was called with and filters
+ * accordingly, which is the only way a test can tell a scoped query from an
+ * unscoped one.
+ */
+function ledger(flows: { epoch: number; amount: number; source: string; tx: string | null }[], opts: {
+  epoch: number;
+  hwm: number;
+  equityByEpoch?: Record<number, number>;
+  cash?: number;
+}) {
+  const asks: { sql: string; params: unknown[] }[] = [];
+  const sum = (rows: typeof flows) => rows.reduce((s, f) => s + f.amount, 0);
+  const db = {
+    prepare(sql: string) {
+      return {
+        async get(...params: unknown[]) {
+          asks.push({ sql, params });
+          if (sql.includes("FROM agents")) return { hwm_usdg: opts.hwm, epoch: opts.epoch };
+          if (sql.includes("FROM fee_accruals")) return { n: 0 };
+          if (sql.includes("SELECT equity_usdg FROM equity")) {
+            const e = opts.equityByEpoch?.[Number(params[1])];
+            return e === undefined ? undefined : { equity_usdg: e };
+          }
+          if (sql.includes("FROM equity")) return { cash_usdg: opts.cash ?? 0, at: NOW - 10 };
+          if (sql.includes("FROM flows")) {
+            // THE EPOCH PREDICATE IS THE THING UNDER TEST. A query that does not
+            // pass an epoch gets every row, which is exactly the bug.
+            const scoped = sql.includes("epoch = ?");
+            const wanted = Number(params[1]);
+            let rows = scoped ? flows.filter((f) => f.epoch === wanted) : flows;
+            if (sql.includes("AND source = 'epoch-carry'")) {
+              rows = rows.filter((f) => f.source === "epoch-carry" && f.amount > 0);
+              return { net: sum(rows), n: rows.length, last_at: NOW };
+            }
+            if (sql.includes("tx_hash IS NOT NULL")) {
+              rows = rows.filter((f) => (f.tx !== null && f.tx !== "") || f.source === "epoch-carry");
+            }
+            return { net: sum(rows), n: rows.length, last_at: NOW };
+          }
+          return undefined;
+        },
+        async all() {
+          return [];
+        },
+        async run() {
+          return { changes: 0 };
+        },
+      };
+    },
+    async exec() {},
+    async tx<T>(fn: (db: Db) => Promise<T>) {
+      return fn(db as Db);
+    },
+  } as unknown as Db;
+  return { db, asks };
+}
+
+const anchorOf = (a: unknown) =>
+  classifyAnchor(
+    JSON.stringify({ schemaVersion: BOOTSTRAP_SCHEMA_VERSION, tenantId: SMART, generatedAt: NOW, accounting: a }),
+    { tenantId: SMART, nowSec: NOW },
+  );
+
+describe("S1 — AN EPOCH-1 DEPOSIT IS NOT AN EPOCH-2 CONTRIBUTION", () => {
+  /**
+   * The exact scenario the user asked to be proven impossible: an agent funded
+   * with a real, tx-hashed deposit in epoch 1, bumped to epoch 2, and then
+   * restarted. Under a lifetime sum its 10 USDG is counted twice — once as the
+   * deposit, once as the carry derived from it — so contributions read 20
+   * against equity of 10 and P&L reads −10 on an account that has done nothing.
+   */
+  const EPOCH1_DEPOSIT = { epoch: 1, amount: 10, source: "chain-log", tx: "0xf0fbf03e" };
+  const CARRY = { epoch: 2, amount: 10, source: "epoch-carry", tx: null };
+
+  it("counts the capital ONCE across the boundary", async () => {
+    const { db } = ledger([EPOCH1_DEPOSIT, CARRY], {
+      epoch: 2,
+      hwm: 10,
+      equityByEpoch: { 1: 10 },
+      cash: 10,
+    });
+    const a = await deriveBootstrapAccounting(db, SMART, NOW);
+    assert.equal(a.kind, "established");
+    if (a.kind !== "established") return;
+    assert.equal(a.netContributionsUsdg, "10000000", "10 USDG contributed, not 20");
+    assert.notEqual(a.netContributionsUsdg, "20000000", "the lifetime sum would say 20");
+    assert.equal(a.accountingEpoch, 2);
+  });
+
+  it("asks the flows table with an epoch predicate at all", async () => {
+    const { db, asks } = ledger([EPOCH1_DEPOSIT, CARRY], { epoch: 2, hwm: 10, equityByEpoch: { 1: 10 } });
+    await deriveBootstrapAccounting(db, SMART, NOW);
+    const flowAsks = asks.filter((a) => a.sql.includes("FROM flows"));
+    assert.ok(flowAsks.length >= 2, "the all-rows and evidenced totals are both flow reads");
+    for (const a of flowAsks) {
+      assert.match(a.sql, /epoch = \?/, `unscoped flow query: ${a.sql.slice(0, 90)}`);
+      assert.equal(a.params[1], 2, "and it must ask for the CURRENT epoch");
+    }
+  });
+
+  it("and a restart does not change the answer", async () => {
+    // The child's SQLite is empty every deploy; the anchor is derived fresh each
+    // time from the same durable rows, so the figure is a pure function of them.
+    const seen = new Set<string>();
+    for (let deploy = 0; deploy < 4; deploy++) {
+      const { db } = ledger([EPOCH1_DEPOSIT, CARRY], { epoch: 2, hwm: 10, equityByEpoch: { 1: 10 }, cash: 10 });
+      const a = await deriveBootstrapAccounting(db, SMART, NOW);
+      if (a.kind === "established") seen.add(a.netContributionsUsdg);
+    }
+    assert.deepEqual([...seen], ["10000000"], "four deploys, one answer");
+  });
+});
+
+describe("S2 — the carry is EVIDENCE, and it is checked", () => {
+  it("a carry that matches the previous epoch's closing equity is evidenced", async () => {
+    const { db } = ledger([{ epoch: 2, amount: 10, source: "epoch-carry", tx: null }], {
+      epoch: 2,
+      hwm: 10,
+      equityByEpoch: { 1: 10 },
+      cash: 10,
+    });
+    const a = await deriveBootstrapAccounting(db, SMART, NOW);
+    assert.equal(a.kind === "established" && a.unanchoredFlowCount, 0, "a reconciling carry is not unanchored");
+    const l = accountingLicence(anchorOf(a), { hosted: true });
+    assert.equal(l.contributionsKnown, true, "AN AGENT PAST A BOUNDARY CAN STILL EVIDENCE ITS CAPITAL");
+  });
+
+  it("a carry that does NOT match is demoted, not silently believed", async () => {
+    // The bridge claims to carry 10 but the epoch closed at 4. It is not a
+    // bridge, and the total resting on it is not evidence.
+    const { db } = ledger([{ epoch: 2, amount: 10, source: "epoch-carry", tx: null }], {
+      epoch: 2,
+      hwm: 10,
+      equityByEpoch: { 1: 4 },
+      cash: 10,
+    });
+    const a = await deriveBootstrapAccounting(db, SMART, NOW);
+    assert.equal(a.kind, "established");
+    if (a.kind !== "established") return;
+    assert.equal(a.unanchoredFlowCount, 1);
+    assert.match(a.carryNote ?? "", /does not match/);
+    assert.equal(accountingLicence(anchorOf(a), { hosted: true }).contributionsKnown, false);
+  });
+
+  it("a carry with no prior closing mark to check against is unverified, not accepted", async () => {
+    const { db } = ledger([{ epoch: 2, amount: 10, source: "epoch-carry", tx: null }], {
+      epoch: 2,
+      hwm: 10,
+      equityByEpoch: {},
+      cash: 10,
+    });
+    const a = await deriveBootstrapAccounting(db, SMART, NOW);
+    assert.equal(a.kind === "established" && a.unanchoredFlowCount, 1);
+    assert.match((a.kind === "established" && a.carryNote) || "", /nothing to check/);
+  });
+
+  it("THE RECOVERY THIS RESTORES: an inferred opening balance would have been permanent", () => {
+    // Before `epoch-carry` existed the bridge was written `source: 'inferred'`
+    // with no transaction, so a receipts-only rule condemned every agent that had
+    // ever crossed a boundary — and no deposit scan could ever fix it, because
+    // there is no transfer to find.
+    assert.equal(isEvidencedFlow("epoch-carry"), true);
+    assert.equal(isEvidencedFlow("chain-log"), true);
+    assert.equal(isEvidencedFlow("inferred"), false);
+    assert.equal(isEvidencedFlow("transfer-intent"), false, "known by construction, but the settlement is not re-read");
+
+    const src = readFileSync(new URL("./store.ts", import.meta.url), "utf8");
+    assert.match(src, /source: "epoch-carry"/, "openNextEpoch must write the distinct source");
+    const open = src.slice(src.indexOf("export async function openNextEpoch"));
+    assert.doesNotMatch(open.slice(0, 1200), /source: "inferred"/, "and must not fall back to inferred");
+  });
+});
+
+describe("S3 — reconcileEpochCarry, directly", () => {
+  it("accepts an exact match and tolerates only storage noise", () => {
+    assert.equal(reconcileEpochCarry({ openingBalanceUsdg: 10, priorEpochClosingEquityUsdg: 10 }).reconciles, true);
+    assert.equal(
+      reconcileEpochCarry({ openingBalanceUsdg: 10, priorEpochClosingEquityUsdg: 10.00005 }).reconciles,
+      true,
+      "REAL storage can shift the last place",
+    );
+    assert.equal(
+      reconcileEpochCarry({ openingBalanceUsdg: 10, priorEpochClosingEquityUsdg: 10.01 }).reconciles,
+      false,
+      "a cent is not noise on a 10 USDG book",
+    );
+  });
+
+  it("a missing prior mark is unverified rather than false-by-default in a misleading way", () => {
+    const r = reconcileEpochCarry({ openingBalanceUsdg: 10, priorEpochClosingEquityUsdg: null });
+    assert.equal(r.reconciles, false);
+    assert.match(r.why, /unverified rather than wrong/);
+  });
+});
+
+describe("S4 — the scope register is not decoration", () => {
+  it("classifies every money figure the user asked about", () => {
+    for (const k of [
+      "netContributionsUsdg",
+      "realizedPnlUsdg",
+      "gasUsdg",
+      "hwmUsdg",
+      "accruedFeeUsdg",
+      "equityUsdg",
+      "costBasisUsdg",
+    ] as const) {
+      assert.ok(ACCOUNTING_SCOPES[k], `${k} must have a declared scope`);
+    }
+    assert.equal(ACCOUNTING_SCOPES.netContributionsUsdg, "epoch");
+    assert.equal(ACCOUNTING_SCOPES.hwmUsdg, "monotonic");
+    assert.equal(ACCOUNTING_SCOPES.equityUsdg, "lifetime");
+    assert.equal(ACCOUNTING_SCOPES.costBasisUsdg, "carried");
+  });
+
+  it("EVERY epoch-scoped figure's query actually carries an epoch predicate", () => {
+    // The register is documentation a test can read. A figure declared
+    // epoch-scoped whose query forgot the predicate is the bug this file is about.
+    assert.ok(EPOCH_SCOPED.includes("netContributionsUsdg"));
+
+    const store = readFileSync(new URL("./store.ts", import.meta.url), "utf8");
+    const fn = store.slice(store.indexOf("export async function getNetContributionsUsdg"));
+    const body = fn.slice(0, fn.indexOf("\n}"));
+    assert.match(body, /FROM flows WHERE agent_id = \? AND epoch = \?/, "the worker's reader must be scoped");
+
+    // The anchor's SQL is assembled by concatenation across lines, so the quotes
+    // and joins are stripped before looking — otherwise the match stops at the
+    // first `"` and every query reads as unscoped.
+    const source = readFileSync(new URL("./bootstrap-source.ts", import.meta.url), "utf8")
+      .replace(/"\s*\+\s*\n?\s*"/g, "")
+      .replace(/\s+/g, " ");
+    const at: number[] = [];
+    for (let i = source.indexOf("FROM flows"); i >= 0; i = source.indexOf("FROM flows", i + 1)) at.push(i);
+    assert.ok(at.length >= 3, `expected the all-rows, evidenced and carry reads, found ${at.length}`);
+    for (const i of at) {
+      const clause = source.slice(i, i + 220);
+      assert.match(clause, /epoch = \?/, `unscoped flow query in the anchor derivation: ${clause.slice(0, 120)}`);
+    }
+  });
+
+  it("the HWM is NOT epoch-scoped, deliberately", () => {
+    // Resetting a monotonic peak at a boundary would re-charge the owner for
+    // profit already paid on. setAgentHwm is MAX() in SQL for the same reason.
+    assert.equal(EPOCH_SCOPED.includes("hwmUsdg" as never), false);
+    const store = readFileSync(new URL("./store.ts", import.meta.url), "utf8");
+    assert.match(store, /UPDATE agents SET hwm_usdg = MAX\(hwm_usdg, \?\)/);
+  });
+});

--- a/worker/src/accounting-scope.ts
+++ b/worker/src/accounting-scope.ts
@@ -1,0 +1,149 @@
+/**
+ * WHICH FRAME EACH MONEY FIGURE LIVES IN.
+ *
+ * merrymen has accounting EPOCHS. An epoch is opened when the rows before it
+ * cannot be audited — pre-flow-tracking balances, fills booked off a slippage
+ * floor — and everything before the boundary is kept for forensics but excluded
+ * from performance. `openNextEpoch` bridges the two by writing the closing
+ * equity of the old epoch as an OPENING BALANCE flow in the new one.
+ *
+ * THAT BRIDGE IS ONLY CORRECT IF CONTRIBUTIONS ARE READ PER EPOCH, and one of
+ * the two readers was not. `getNetContributionsUsdg` summed `FROM flows WHERE
+ * agent_id = ?` with no epoch predicate while the web's identical query carried
+ * one. The mismatch was invisible because the only agents ever bumped were those
+ * with pre-fix rows, and pre-fix rows predate the flows table — so epoch 1 held
+ * no flows and lifetime happened to equal current-epoch.
+ *
+ * Accidentally correct is not correct. Fund an agent today (a real chain-log
+ * flow in epoch 1), bump it for any future reason, and the lifetime sum counts
+ * that deposit AND the opening balance derived from it: contributions double,
+ * P&L goes as negative as the deposit was large, and nothing anywhere notices.
+ *
+ * So the frames are written down, and the queries are made to match them.
+ */
+
+/**
+ * The frame a figure is measured in.
+ *
+ *   lifetime      every row the account ever wrote, across all epochs
+ *   epoch         only the current accounting epoch
+ *   monotonic     a ratchet that never decreases and never resets at a boundary
+ *   carried       reset at a boundary, with the closing value bridged forward
+ *                 as an explicit opening record in the new epoch
+ */
+export type AccountingScope = "lifetime" | "epoch" | "monotonic" | "carried";
+
+/**
+ * THE REGISTER. Every money figure in the system, and the frame it belongs to.
+ *
+ * This is documentation that a test can read. `accounting-scope.test.ts` asserts
+ * that the queries behind the epoch-scoped entries actually carry an epoch
+ * predicate — so a future reader who adds a figure here without scoping its
+ * query gets a failure rather than a comment that has quietly become false.
+ */
+export const ACCOUNTING_SCOPES = {
+  /**
+   * Σ flows in − Σ flows out. EPOCH-scoped, because the epoch boundary writes an
+   * opening balance equal to what was carried: summing across the boundary
+   * counts the same capital twice, once as the original deposit and once as the
+   * bridge derived from it.
+   */
+  netContributionsUsdg: "epoch",
+  /**
+   * Realized P&L on closing fills. EPOCH-scoped: it is performance, and
+   * performance before an unauditable boundary is exactly what the boundary
+   * exists to exclude.
+   */
+  realizedPnlUsdg: "epoch",
+  /**
+   * Gas burned. EPOCH-scoped for the same reason as realized P&L — it is a cost
+   * of trading and belongs to the period whose performance it reduces.
+   */
+  gasUsdg: "epoch",
+  /**
+   * The high-water mark. MONOTONIC and deliberately NOT reset at a boundary.
+   *
+   * `setAgentHwm` is `MAX(hwm_usdg, ?)` in SQL — a one-way door with a real
+   * performance fee written in the same breath, and no procedure walks either
+   * back. Resetting it at a boundary would re-charge the owner for profit
+   * already paid on. The bridge keeps the frames consistent: the new epoch opens
+   * with the old one's equity as contributed capital, so the peak that equity
+   * reached is still the right thing to measure against.
+   */
+  hwmUsdg: "monotonic",
+  /** What the house has earned, ever. MONOTONIC — a boundary does not un-earn a fee. */
+  accruedFeeUsdg: "monotonic",
+  /**
+   * Equity. LIFETIME by nature: it is a balance reading, not an accumulation.
+   * An epoch cannot reset what the account is worth right now.
+   */
+  equityUsdg: "lifetime",
+  /** Cash, positions and vault — components of that same balance reading. */
+  cashUsdg: "lifetime",
+  positionsUsdg: "lifetime",
+  vaultUsdg: "lifetime",
+  /**
+   * Cost basis of open positions. CARRIED: the holdings survive a boundary, so
+   * their basis must too, or the first sale after a bump books the entire
+   * proceeds as realized profit.
+   */
+  costBasisUsdg: "carried",
+} as const satisfies Record<string, AccountingScope>;
+
+export type ScopedFigure = keyof typeof ACCOUNTING_SCOPES;
+
+/** Figures that MUST be read with an epoch predicate. */
+export const EPOCH_SCOPED: readonly ScopedFigure[] = (
+  Object.keys(ACCOUNTING_SCOPES) as ScopedFigure[]
+).filter((k) => ACCOUNTING_SCOPES[k] === "epoch");
+
+/**
+ * The flow-evidence rule is DEFINED IN core, not here.
+ *
+ * The worker and the web were each carrying their own answer and the two
+ * disagreed in both directions, so an agent past an epoch boundary was publicly
+ * told its bridged capital was guesswork while the anchor counted the same row
+ * as evidence. Re-exported rather than redefined so there is exactly one rule.
+ */
+export { EVIDENCED_FLOW_SOURCES, isEvidencedFlow, type FlowEvidence } from "../../packages/core/src/flow-evidence";
+
+
+/**
+ * Does an epoch-opening balance agree with what the previous epoch closed at?
+ *
+ * This is what makes `epoch-carry` evidence rather than assertion. The carry is
+ * `lastKnownEquityUsdg` of the closing epoch, so it must equal the final
+ * `equityUsdg` mark before the boundary. If it does not, the bridge is not a
+ * bridge and the total resting on it is unknown.
+ *
+ * Pure, so an auditor with only an export can run it.
+ */
+export function reconcileEpochCarry(args: {
+  openingBalanceUsdg: number;
+  priorEpochClosingEquityUsdg: number | null;
+  toleranceUsdg?: number;
+}): { reconciles: boolean; why: string } {
+  const tol = args.toleranceUsdg ?? 0.0001;
+  if (args.priorEpochClosingEquityUsdg === null) {
+    return {
+      reconciles: false,
+      why:
+        "the previous epoch recorded no closing equity, so there is nothing to check the opening " +
+        "balance against — the carried capital is unverified rather than wrong",
+    };
+  }
+  const diff = args.openingBalanceUsdg - args.priorEpochClosingEquityUsdg;
+  if (Math.abs(diff) <= tol) {
+    return {
+      reconciles: true,
+      why: `opening balance ${args.openingBalanceUsdg.toFixed(6)} matches the previous epoch's closing equity`,
+    };
+  }
+  return {
+    reconciles: false,
+    why:
+      `opening balance ${args.openingBalanceUsdg.toFixed(6)} does not match the previous epoch's closing ` +
+      `equity ${args.priorEpochClosingEquityUsdg.toFixed(6)} (off by ${diff.toFixed(6)}) — the bridge does ` +
+      `not carry what the old epoch actually held`,
+  };
+}

--- a/worker/src/accounting-truth.test.ts
+++ b/worker/src/accounting-truth.test.ts
@@ -1,0 +1,572 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import {
+  accountingLicence,
+  BOOTSTRAP_MAX_AGE_SEC,
+  BOOTSTRAP_SCHEMA_VERSION,
+  classifyAnchor,
+  doubt,
+  foldLicence,
+  INITIAL_CONTRIBUTION_TRUTH,
+  planFirstObservation,
+  type AnchorVerdict,
+  type BootstrapAccounting,
+} from "./bootstrap-state";
+import { usdgRealToMicro } from "./bootstrap-source";
+
+/**
+ * THE REDEPLOY THAT KEPT BEING BOOKED AS A DEPOSIT, PINNED.
+ *
+ * The canary held 10 USDG and never received another cent. Three deploys later
+ * its ledger said 30 USDG had been contributed, because a hosted child's SQLite
+ * lives in an ephemeral container directory and the accounting code read an
+ * empty database as "this money just arrived".
+ *
+ * Everything below drives the REAL decision functions — `accountingLicence` and
+ * `planFirstObservation` are what `index.ts` calls — rather than asserting on
+ * the shape of the code around them.
+ */
+
+const TENANT = "0xa233a3000000000000000000000000000000beef";
+const U = (n: number) => BigInt(Math.round(n * 1e6));
+const MATERIAL = 10_000n;
+const NOW = 1_760_000_000;
+
+const anchorFile = (accounting: BootstrapAccounting, over: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    schemaVersion: BOOTSTRAP_SCHEMA_VERSION,
+    tenantId: TENANT,
+    generatedAt: NOW,
+    accounting,
+    ...over,
+  });
+
+/**
+ * A PROVEN anchor by default: the receipts-only total equals the all-rows
+ * total and no flow lacks a transaction. Tests that care about the
+ * contaminated case say so explicitly, so the default cannot quietly become
+ * the weaker claim.
+ */
+const established = (over: Partial<Extract<BootstrapAccounting, { kind: "established" }>> = {}) =>
+  ({
+    kind: "established",
+    highWaterMarkUsdg: "10000000",
+    netContributionsUsdg: "10000000",
+    anchoredContributionsUsdg: "10000000",
+    unanchoredFlowCount: 0,
+    lastObservedCashUsdg: "10000000",
+    accountingEpoch: 2,
+    observedAt: NOW - 60,
+    ...over,
+  }) as BootstrapAccounting;
+
+/**
+ * Source with comments removed.
+ *
+ * Every pin below that counts occurrences uses it, because the code being
+ * pinned QUOTES the old buggy expression in the block explaining why it went —
+ * and a pin that counts its own documentation breaks when someone improves the
+ * wording.
+ */
+const strip = (s: string) =>
+  s
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .filter((l) => !l.trim().startsWith("//") && !l.trim().startsWith("*"))
+    .join("\n");
+
+const read = (raw: string | null, nowSec = NOW): AnchorVerdict =>
+  classifyAnchor(raw, { tenantId: TENANT, nowSec });
+
+/** Run one hosted arm and return what it would have booked. */
+function armHosted(raw: string | null, world: { equityUsdg: bigint; cashUsdg: bigint }, nowSec = NOW) {
+  const licence = accountingLicence(read(raw, nowSec), { hosted: true });
+  const plan = planFirstObservation({
+    licence: licence.licence,
+    equityUsdg: world.equityUsdg,
+    cashUsdg: world.cashUsdg,
+    anchorCashUsdg: licence.lastObservedCashUsdg,
+    materialDriftUsdg: MATERIAL,
+    why: licence.why,
+  });
+  const booked = plan.action === "book-opening-balance" ? plan.amountUsdg : 0n;
+  const contributionsKnown =
+    plan.action === "resume-with-drift" || plan.action === "stand-down" ? false : licence.contributionsKnown;
+  return { licence, plan, booked, contributionsKnown };
+}
+
+describe("P1 — THE EXACT FAILURE: 10 USDG, three restarts, still 10 USDG", () => {
+  it("books the opening balance once and never again", () => {
+    // The orchestrator derives the anchor from durable Postgres, so the ledger
+    // it reports is the one that survived the container. Modelled here as a
+    // single number the restarts share.
+    let durableContributionsUsdg = 0n;
+    let durableHwmUsdg = 0n;
+    const equity = U(10);
+
+    // Deploy 0: a genuinely new account. Postgres answered and found nothing.
+    const first = armHosted(anchorFile({ kind: "no-prior-accounting", observedAt: NOW }), {
+      equityUsdg: equity,
+      cashUsdg: equity,
+    });
+    assert.equal(first.plan.action, "book-opening-balance");
+    durableContributionsUsdg += first.booked;
+    durableHwmUsdg += first.booked; // record() raises the HWM with the flow
+    assert.equal(durableContributionsUsdg, U(10));
+
+    // Deploys 1, 2, 3: same account, same money, empty child database each time.
+    for (const deploy of [1, 2, 3]) {
+      const r = armHosted(
+        anchorFile(
+          established({
+            highWaterMarkUsdg: durableHwmUsdg.toString(),
+            netContributionsUsdg: durableContributionsUsdg.toString(),
+            anchoredContributionsUsdg: durableContributionsUsdg.toString(),
+            unanchoredFlowCount: 0,
+            lastObservedCashUsdg: equity.toString(),
+          }),
+        ),
+        { equityUsdg: equity, cashUsdg: equity },
+      );
+      assert.equal(r.plan.action, "resume-clean", `deploy ${deploy} must resume, not re-open`);
+      assert.equal(r.booked, 0n, `deploy ${deploy} booked ${r.booked} micro-USDG out of nowhere`);
+      assert.equal(r.contributionsKnown, true, "a clean resume still knows what was contributed");
+      durableContributionsUsdg += r.booked;
+    }
+
+    // THE NUMBER THE BUG PRODUCED WAS 40. It is 10.
+    assert.equal(durableContributionsUsdg, U(10), "contributions must not grow by redeploying");
+    assert.notEqual(durableContributionsUsdg, U(20));
+    assert.notEqual(durableContributionsUsdg, U(30));
+    assert.notEqual(durableContributionsUsdg, U(40));
+  });
+
+  it("RESTORES THE HIGH-WATER MARK, so deleting the phantom contribution cannot start charging fees", () => {
+    // The two errors used to cancel: the phantom contribution raised the HWM by
+    // the same amount, so no fee was wrongly charged. Removing one without the
+    // other would hand the whole principal to accrueAboveHwm as profit.
+    const l = accountingLicence(read(anchorFile(established({ highWaterMarkUsdg: "10000000" }))), { hosted: true });
+    assert.equal(l.highWaterMarkUsdg, U(10), "the peak must come back with the contributions");
+    assert.equal(l.netContributionsUsdg, U(10));
+  });
+});
+
+describe("P2 — the anchor licenses an opening balance; nothing else does", () => {
+  it("a genuinely new funded agent books its opening balance", () => {
+    const r = armHosted(anchorFile({ kind: "no-prior-accounting", observedAt: NOW }), {
+      equityUsdg: U(250),
+      cashUsdg: U(250),
+    });
+    assert.equal(r.plan.action, "book-opening-balance");
+    assert.equal(r.booked, U(250));
+    assert.equal(r.contributionsKnown, true);
+  });
+
+  it("a MISSING anchor books nothing and marks contributions unknown", () => {
+    const r = armHosted(null, { equityUsdg: U(10), cashUsdg: U(10) });
+    assert.equal(r.plan.action, "stand-down");
+    assert.equal(r.booked, 0n);
+    assert.equal(r.contributionsKnown, false);
+  });
+
+  it("a MALFORMED anchor books nothing", () => {
+    for (const bad of [
+      "{not json",
+      JSON.stringify({ schemaVersion: BOOTSTRAP_SCHEMA_VERSION, tenantId: TENANT, generatedAt: NOW }),
+      anchorFile(established({ netContributionsUsdg: "1.5" as never })),
+      anchorFile(established({ highWaterMarkUsdg: "abc" as never })),
+    ]) {
+      const r = armHosted(bad, { equityUsdg: U(10), cashUsdg: U(10) });
+      assert.equal(r.plan.action, "stand-down", `${bad.slice(0, 40)} must not license anything`);
+      assert.equal(r.booked, 0n);
+      assert.equal(r.contributionsKnown, false);
+    }
+  });
+
+  it("AN ANCHOR FOR ANOTHER TENANT IS MALFORMED, not merely ignored", () => {
+    // Applying a different account's high-water mark is the worst thing this
+    // file could do, so it is checked rather than left to the caller.
+    const other = anchorFile(established(), { tenantId: "0xdeadbeef00000000000000000000000000000000" });
+    const v = read(other);
+    assert.equal(v.kind, "malformed");
+    assert.equal(armHosted(other, { equityUsdg: U(10), cashUsdg: U(10) }).booked, 0n);
+  });
+
+  it("a STALE anchor books nothing", () => {
+    const raw = anchorFile(established());
+    assert.equal(read(raw, NOW).kind, "valid");
+    const late = NOW + BOOTSTRAP_MAX_AGE_SEC + 1;
+    assert.equal(read(raw, late).kind, "stale");
+    const r = armHosted(raw, { equityUsdg: U(10), cashUsdg: U(10) }, late);
+    assert.equal(r.plan.action, "stand-down");
+    assert.equal(r.contributionsKnown, false);
+  });
+
+  it("an UNSUPPORTED SCHEMA VERSION is refused rather than partially read", () => {
+    const future = anchorFile(established(), { schemaVersion: BOOTSTRAP_SCHEMA_VERSION + 1 });
+    const v = read(future);
+    assert.equal(v.kind, "unsupported-version");
+    assert.equal(armHosted(future, { equityUsdg: U(10), cashUsdg: U(10) }).booked, 0n);
+  });
+
+  it("POSTGRES UNAVAILABLE AT SPAWN is its own arm, and it is not 'empty'", () => {
+    // The whole bug in one line: a database that threw must never look like a
+    // database that answered "nothing here".
+    const raw = anchorFile({ kind: "unknown", why: "connection refused", observedAt: NOW });
+    const v = read(raw);
+    assert.equal(v.kind, "valid", "the FILE is well-formed — it is the CONTENT that says unknown");
+    const r = armHosted(raw, { equityUsdg: U(10), cashUsdg: U(10) });
+    assert.equal(r.plan.action, "stand-down");
+    assert.equal(r.booked, 0n, "an unreachable database must not license an opening balance");
+    assert.equal(r.contributionsKnown, false);
+  });
+
+  it("AN ANCHOR WRITE FAILURE looks exactly like a missing anchor, and fails closed", () => {
+    // The orchestrator's write is best-effort; when it fails there is simply no
+    // file, which is the `absent` arm, which stands down.
+    assert.equal(read(null).kind, "absent");
+    assert.equal(armHosted(null, { equityUsdg: U(999), cashUsdg: U(999) }).contributionsKnown, false);
+  });
+});
+
+describe("P3 — a balance that moved while the worker was down is never guessed at", () => {
+  it("cash changed by a legitimate deposit is NOT booked from the delta", () => {
+    // A deposit is real money and it still must not be inferred here: the chain
+    // scan books it with a transaction hash, or the book says it does not know.
+    const r = armHosted(anchorFile(established({ lastObservedCashUsdg: "10000000" })), {
+      equityUsdg: U(15),
+      cashUsdg: U(15),
+    });
+    assert.equal(r.plan.action, "resume-with-drift");
+    assert.equal(r.plan.action === "resume-with-drift" && r.plan.driftUsdg, U(5));
+    assert.equal(r.booked, 0n, "an inferred deposit is not an actual capital-flow event");
+    assert.equal(r.contributionsKnown, false, "and the book must say the total is no longer complete");
+  });
+
+  it("cash changed by a TRADE is not booked as a withdrawal", () => {
+    // The case that makes inference indefensible: an in-flight UserOperation
+    // that landed during downtime lowers cash, inflight-reconcile books the
+    // trade, and inferring the delta here would double-count it with the wrong
+    // sign.
+    const r = armHosted(anchorFile(established({ lastObservedCashUsdg: "10000000" })), {
+      equityUsdg: U(10),
+      cashUsdg: U(8.33),
+    });
+    assert.equal(r.plan.action, "resume-with-drift");
+    assert.equal(r.booked, 0n);
+    assert.equal(r.contributionsKnown, false);
+  });
+
+  it("noise below the materiality bound is not drift", () => {
+    // The durable columns are REAL, so a round trip can shift the last decimal.
+    const r = armHosted(anchorFile(established({ lastObservedCashUsdg: "10000000" })), {
+      equityUsdg: U(10),
+      cashUsdg: U(10) + 1n,
+    });
+    assert.equal(r.plan.action, "resume-clean");
+    assert.equal(r.contributionsKnown, true);
+  });
+
+  it("no cash reading on record is not the same as a zero balance", () => {
+    const r = armHosted(anchorFile(established({ lastObservedCashUsdg: null })), {
+      equityUsdg: U(10),
+      cashUsdg: U(10),
+    });
+    assert.equal(r.plan.action, "resume-clean", "an absent baseline yields no drift claim");
+    assert.equal(r.booked, 0n);
+  });
+});
+
+describe("P3b — a contribution total built on inference is resumed from but not believed", () => {
+  /**
+   * THE SECOND INFLATION MECHANISM, which lives in the mirror rather than in
+   * the worker. When a hosted child's SQLite is rebuilt, the mirror finds its
+   * watermark row gone, rewinds the cursor to zero and re-copies rows 1..N from
+   * the reborn child. The INSERT has no ON CONFLICT and `flows` has no unique
+   * key, so the shared table accumulates the OLD rows plus whatever the new
+   * incarnation wrote — including a fresh phantom opening balance.
+   *
+   * Stopping the worker from writing new phantoms does not un-write the ones
+   * already in Postgres, so an anchor summing every row inherits the
+   * corruption. The rows are distinguishable, though: a flow read off a USDG
+   * Transfer log carries a tx hash, an inferred one does not.
+   */
+  it("RESUMES (so the peak comes back) but marks contributions UNKNOWN", () => {
+    const contaminated = anchorFile(
+      established({
+        netContributionsUsdg: "30000000", // three phantom openings
+        anchoredContributionsUsdg: "0", // none of them names a transaction
+        unanchoredFlowCount: 3,
+      }),
+    );
+    const l = accountingLicence(read(contaminated), { hosted: true });
+    assert.equal(l.licence, "resume", "it must still resume — an unrestored peak charges fees on principal");
+    assert.equal(l.highWaterMarkUsdg, U(10), "the peak comes back regardless");
+    assert.equal(l.contributionsKnown, false, "but a total made of inference is not evidence");
+    assert.match(l.why, /rests on inference/);
+
+    const r = armHosted(contaminated, { equityUsdg: U(10), cashUsdg: U(10) });
+    assert.equal(r.plan.action, "resume-clean");
+    assert.equal(r.booked, 0n, "and nothing new is booked on top of it");
+  });
+
+  it("one unanchored flow among many is enough to make the total unproven", () => {
+    const l = accountingLicence(
+      read(anchorFile(established({ netContributionsUsdg: "10000000", anchoredContributionsUsdg: "9000000", unanchoredFlowCount: 1 }))),
+      { hosted: true },
+    );
+    assert.equal(l.contributionsKnown, false);
+  });
+
+  it("an anchor predating the receipts-only fields is unproven, not assumed sound", () => {
+    // Absent evidence is not evidence of soundness — the field being missing
+    // means nobody computed it, which is the same epistemic position as a
+    // mismatch and gets the same answer.
+    const old = anchorFile(
+      established({ anchoredContributionsUsdg: undefined, unanchoredFlowCount: undefined } as never),
+    );
+    const l = accountingLicence(read(old), { hosted: true });
+    assert.equal(l.licence, "resume");
+    assert.equal(l.contributionsKnown, false);
+    assert.match(l.why, /unproven/);
+  });
+
+  it("agreement between the two totals is what proves it, not either one alone", () => {
+    // A receipts total that happens to equal a WRONG all-rows total must not
+    // pass: the check is agreement AND zero unanchored rows.
+    for (const bad of [
+      { netContributionsUsdg: "10000000", anchoredContributionsUsdg: "10000000", unanchoredFlowCount: 2 },
+      { netContributionsUsdg: "20000000", anchoredContributionsUsdg: "10000000", unanchoredFlowCount: 0 },
+    ]) {
+      assert.equal(
+        accountingLicence(read(anchorFile(established(bad as never))), { hosted: true }).contributionsKnown,
+        false,
+        JSON.stringify(bad),
+      );
+    }
+    assert.equal(
+      accountingLicence(read(anchorFile(established())), { hosted: true }).contributionsKnown,
+      true,
+      "matched totals with zero unanchored rows is the one case that proves it",
+    );
+  });
+
+  it("a malformed receipts field makes the whole anchor malformed", () => {
+    const v = read(anchorFile(established({ anchoredContributionsUsdg: "1.5" } as never)));
+    assert.equal(v.kind, "malformed");
+  });
+});
+
+describe("P3c — a doubt raised by watching the account is never lifted by a file", () => {
+  /**
+   * `applyAccountingAnchor` runs inside `syncGrant`, which the tick re-enters on
+   * any re-arm — and a transient executor failure nulls `active` and causes one.
+   * The two places that CLEAR contributionsKnown sit behind a first-observation
+   * guard and fire at most once per process. One-way false against two-way true
+   * means the doubt always loses, and contributionsKnown is the sole gate on the
+   * performance fee.
+   *
+   * This was written after a mutation that deleted the guard entirely passed all
+   * 44 tests.
+   */
+  const resumeLicence = () => accountingLicence(read(anchorFile(established())), { hosted: true });
+
+  it("a clean anchor establishes the truth", () => {
+    const t = foldLicence(INITIAL_CONTRIBUTION_TRUTH, resumeLicence());
+    assert.equal(t.known, true);
+    assert.equal(t.doubted, false);
+  });
+
+  it("A RE-ARM CANNOT RESURRECT contributionsKnown AFTER A DOUBT", () => {
+    let t = foldLicence(INITIAL_CONTRIBUTION_TRUTH, resumeLicence());
+    assert.equal(t.known, true);
+
+    // Tick 1 observes drift across the downtime window.
+    t = doubt("cash moved across the downtime window and nothing could price it");
+    assert.equal(t.known, false);
+
+    // Hour 2: an executor failure nulls `active`; syncGrant re-runs and folds
+    // the SAME still-valid licence back in. Ten times, for good measure.
+    for (let i = 0; i < 10; i++) t = foldLicence(t, resumeLicence());
+    assert.equal(t.known, false, "the fee gate must not reopen on a book already declared unknowable");
+    assert.equal(t.doubted, true);
+    assert.match(t.why, /downtime window/, "and the original reason must survive, not be overwritten");
+  });
+
+  it("a stand-down doubt is equally permanent", () => {
+    let t = doubt("anchor absent: no bootstrap.json in the child's home");
+    // Even if a VALID anchor appears later — an operator drops the file in —
+    // this process does not change its mind. It restarts and re-derives.
+    for (let i = 0; i < 3; i++) t = foldLicence(t, resumeLicence());
+    assert.equal(t.known, false);
+  });
+
+  it("the initial state is unknown, not known", () => {
+    assert.equal(INITIAL_CONTRIBUTION_TRUTH.known, false);
+    assert.equal(INITIAL_CONTRIBUTION_TRUTH.doubted, false, "unknown but not yet doubted — a licence may still establish it");
+  });
+
+  it("index.ts routes BOTH clearing sites through the sticky helper", () => {
+    // A future edit that assigns the field directly would silently restore the
+    // asymmetry, so the call sites are pinned as well as the reducer.
+    const src = strip(readFileSync(new URL("./index.ts", import.meta.url), "utf8"));
+    assert.match(src, /setTruth\(foldLicence\(truth, l\)\);/);
+    assert.equal((src.match(/doubtContributions\(/g) ?? []).length, 3, "one definition, two call sites");
+    // And nothing writes contributionsKnown outside setTruth.
+    const writes = src.match(/accounting\.contributionsKnown\s*=/g) ?? [];
+    assert.equal(writes.length, 1, `contributionsKnown must have exactly one writer, found ${writes.length}`);
+  });
+});
+
+describe("P4 — self-hosted keeps the behaviour whose premise is true there", () => {
+  it("a self-hosted worker takes the legacy local path, anchor or no anchor", () => {
+    for (const raw of [null, anchorFile(established())]) {
+      const l = accountingLicence(read(raw), { hosted: false });
+      assert.equal(l.licence, "self-hosted-local");
+      assert.equal(l.contributionsKnown, true, "the local ledger is durable on a real disk");
+      const plan = planFirstObservation({
+        licence: l.licence,
+        equityUsdg: U(10),
+        cashUsdg: U(10),
+        anchorCashUsdg: null,
+        materialDriftUsdg: MATERIAL,
+      });
+      assert.equal(plan.action, "legacy-local");
+    }
+  });
+
+  it("a child SQLite emptied by a redeploy is only meaningful when HOSTED", () => {
+    // Same empty database, two opposite correct answers. The flag is the hinge.
+    const empty = anchorFile(established());
+    assert.equal(accountingLicence(read(empty), { hosted: true }).licence, "resume");
+    assert.equal(accountingLicence(read(empty), { hosted: false }).licence, "self-hosted-local");
+  });
+});
+
+describe("P5 — no path converts uncertainty into a P&L figure", () => {
+  it("every arm that cannot establish contributions refuses to publish P&L", () => {
+    const cannot = [
+      null,
+      "{not json",
+      anchorFile(established(), { schemaVersion: 99 }),
+      anchorFile({ kind: "unknown", why: "db down", observedAt: NOW }),
+    ];
+    for (const raw of cannot) {
+      const r = armHosted(raw, { equityUsdg: U(10), cashUsdg: U(10) });
+      assert.equal(r.booked, 0n);
+      assert.equal(r.contributionsKnown, false);
+      // The PUBLICATION half of this — a P&L surface refusing on the same
+      // signal — lands with the portfolio-truth change. Here the property is
+      // narrower and is the one that matters at runtime: nothing was booked,
+      // and the flag that gates the performance fee is false.
+    }
+  });
+
+  it("THE FEE IS SUPPRESSED WHEN CONTRIBUTIONS ARE UNKNOWN, but the peak still ratchets", () => {
+    // Freezing the high-water mark would make the drawdown breaker LESS likely
+    // to halt a falling book, so the suppression is applied to the fee rate and
+    // not to the accrual call.
+    const src = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+    assert.match(src, /const feeBpsThisTick = accounting\.contributionsKnown \? effFeeBps : 0;/);
+    assert.match(src, /accrueAboveHwm\(equityUsdg, highWaterMarkUsdg, feeBpsThisTick\)/);
+  });
+
+  it("the old inference is gone from the hosted path", () => {
+    // Comments stripped first: the block explaining the bug quotes the old
+    // test verbatim, and a pin that counts its own documentation is a pin that
+    // breaks when someone improves the wording.
+    const src = strip(readFileSync(new URL("./index.ts", import.meta.url), "utf8"));
+    // It survives EXACTLY ONCE, inside the self-hosted arm where its premise
+    // holds. Two occurrences would mean the hosted path grew one back.
+    const hits = src.match(/equityUsdg > 0n && highWaterMarkUsdg === 0n/g) ?? [];
+    assert.equal(hits.length, 1, "the HWM==0 inference must exist only in the legacy-local arm");
+    assert.match(src, /if \(plan\.action === "legacy-local"\) \{/);
+  });
+});
+
+
+
+describe("P8 — the bootstrap contract is versioned and its reserved field stays reserved", () => {
+  it("carries money as exact integer strings, never floats", () => {
+    const raw = anchorFile(established({ netContributionsUsdg: "154870000" }));
+    const v = read(raw);
+    assert.equal(v.kind, "valid");
+    assert.equal(
+      accountingLicence(v, { hosted: true }).netContributionsUsdg,
+      154_870_000n,
+      "154.87 USDG must survive the boundary exactly",
+    );
+    assert.doesNotMatch(raw, /"netContributionsUsdg":\s*\d+\.\d/);
+  });
+
+  it("REAL columns convert to micro-USDG without drifting", () => {
+    assert.equal(usdgRealToMicro(154.87), 154_870_000n);
+    assert.equal(usdgRealToMicro(0), 0n);
+    assert.equal(usdgRealToMicro(-3.33), -3_330_000n);
+    assert.equal(usdgRealToMicro(Number.NaN), 0n);
+  });
+
+  it("outstandingOps is DECLARED but nothing reads it", () => {
+    // Reserved so adding the orchestrator-to-child hash push later is not a
+    // schema break. An accounting change is not the place to also alter which
+    // blocks get scanned.
+    const state = readFileSync(new URL("./bootstrap-state.ts", import.meta.url), "utf8");
+    assert.match(state, /outstandingOps\?: readonly string\[\];/);
+    for (const file of ["./index.ts", "./orchestrator.ts", "./inflight-reconcile.ts"]) {
+      const src = readFileSync(new URL(file, import.meta.url), "utf8");
+      const code = src
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .split("\n")
+        .filter((l) => !l.trim().startsWith("//"))
+        .join("\n");
+      assert.doesNotMatch(code, /outstandingOps/, `${file} must not consume the reserved field yet`);
+    }
+  });
+
+  it("a future anchor from a skewed clock is refused, not treated as fresh", () => {
+    const raw = anchorFile(established(), { generatedAt: NOW + BOOTSTRAP_MAX_AGE_SEC * 2 });
+    assert.equal(read(raw).kind, "malformed");
+  });
+
+  it("THE CHILD IS NEVER GIVEN DATABASE_URL, which is why this file exists at all", () => {
+    const src = readFileSync(new URL("./orchestrator.ts", import.meta.url), "utf8");
+    assert.match(src, /const CHILD_SECRET_STRIP = \[[^\]]*"DATABASE_URL"/s);
+    // And the anchor is written before the child is spawned, not after.
+    const writeAt = src.indexOf("await writeBootstrapForChild(tenant, smartAccount);");
+    const spawnAt = src.indexOf("const tickSeconds =", writeAt);
+    assert.ok(writeAt > 0 && spawnAt > writeAt, "the anchor must land before the child arms");
+  });
+
+  it("THE ANCHOR IS KEYED ON THE SMART ACCOUNT, NOT THE TENANT", () => {
+    // The worst defect this change ever had, and it was silent in both
+    // directions. `tenant` is the OWNER address that signed the grant; the smart
+    // account is the ERC-4337 wallet, and every ledger table keys on the latter
+    // (`agents.smart_account`, `flows.agent_id`). The orchestrator holds both
+    // and passes them side by side to the identity store, which is what makes
+    // reaching for the wrong one so easy.
+    //
+    // Querying durable state by the owner address finds no rows FOR A FUNDED
+    // ACCOUNT — and "the query succeeded and found no history" is the single arm
+    // that LICENSES booking the whole balance as an opening contribution. It
+    // would have manufactured a contribution on every deploy with the parent's
+    // explicit blessing: strictly worse than the bug being fixed.
+    //
+    // It was masked only by a second mismatch — the parent stamped the tenant
+    // while the child compared its smart account — which made every anchor read
+    // as `malformed` and the whole mechanism inert. Two bugs cancelling is not a
+    // safety property, so both are pinned here.
+    const orch = strip(readFileSync(new URL("./orchestrator.ts", import.meta.url), "utf8"));
+    assert.match(orch, /deriveBootstrapAccounting\([\s\S]*?smartAccount, now\)/, "the derive must take the smart account");
+    assert.doesNotMatch(orch, /deriveBootstrapAccounting\([\s\S]*?[( ]tenant, now\)/, "never the tenant");
+    assert.match(orch, /tenantId: smartAccount\.toLowerCase\(\)/, "and the file must be stamped with it");
+
+    const src2 = strip(readFileSync(new URL("./bootstrap-source.ts", import.meta.url), "utf8"));
+    assert.match(src2, /const agentId = smartAccount\.toLowerCase\(\);/);
+
+    // The child validates against `agentId`, which IS its smart account.
+    const child = strip(readFileSync(new URL("./index.ts", import.meta.url), "utf8"));
+    assert.match(child, /readAnchor\(merrymenHome\(\), \{ tenantId: agentId \}\)/);
+    assert.match(child, /getAgentFinancials/, "agentId is the smart_account key the store reads on");
+  });
+});

--- a/worker/src/bootstrap-source.test.ts
+++ b/worker/src/bootstrap-source.test.ts
@@ -1,0 +1,377 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Db } from "./db";
+import { deriveBootstrapAccounting, usdgRealToMicro } from "./bootstrap-source";
+import {
+  accountingLicence,
+  BOOTSTRAP_SCHEMA_VERSION,
+  classifyAnchor,
+  planFirstObservation,
+} from "./bootstrap-state";
+
+/**
+ * THE SOLE LICENSOR OF AN OPENING BALANCE, TESTED.
+ *
+ * `deriveBootstrapAccounting` is the only thing in the system that can say
+ * `no-prior-accounting`, and that arm is the only thing that permits booking a
+ * whole balance as a new contribution. It shipped with no test at all, and the
+ * defect that got through was as bad as defects get: it queried the ledger by
+ * the OWNER address while every table keys on the SMART ACCOUNT, so every funded
+ * tenant would have read as brand new and been re-booked on every deploy — with
+ * the parent's explicit blessing, which is strictly worse than the inference it
+ * replaced.
+ *
+ * So the tests below assert on the PARAMETERS, not only the verdict. A fake `Db`
+ * records what it was asked; getting the right answer from the wrong key is the
+ * failure mode, and only the parameter can see it.
+ */
+
+const OWNER = "0xa233a3085a6f9b43274410e45836d43d091b5908";
+const SMART = "0x3E34E58e39DC6614e047dFD3BAD5B7DEA45DCd62";
+const NOW = 1_760_000_000;
+
+interface Ask {
+  sql: string;
+  params: unknown[];
+}
+
+/**
+ * A Db that answers from a table of canned rows, keyed by a substring of the
+ * SQL, and records every question.
+ */
+function fakeDb(rows: { match: string; row: unknown }[], onQuery?: (a: Ask) => void): { db: Db; asks: Ask[] } {
+  const asks: Ask[] = [];
+  const db = {
+    prepare(sql: string) {
+      return {
+        async get(...params: unknown[]) {
+          const ask = { sql, params };
+          asks.push(ask);
+          onQuery?.(ask);
+          return rows.find((r) => sql.includes(r.match))?.row;
+        },
+        async all() {
+          return [];
+        },
+        async run() {
+          return { changes: 0 };
+        },
+      };
+    },
+    async exec() {},
+    async tx<T>(fn: (db: Db) => Promise<T>) {
+      return fn(db as Db);
+    },
+  } as unknown as Db;
+  return { db, asks };
+}
+
+/**
+ * MATCH ORDER IS SIGNIFICANT — the first entry whose substring appears in the
+ * SQL wins, so the narrow queries must come before the broad ones. Four of the
+ * six reads hit the flows table, and they mean different things.
+ */
+const EMPTY = [
+  { match: "FROM agents", row: undefined },
+  { match: "AND source = 'epoch-carry'", row: { net: 0, n: 0, last_at: 0 } },
+  { match: "tx_hash IS NOT NULL", row: { net: 0, n: 0, last_at: 0 } },
+  { match: "FROM flows", row: { net: 0, n: 0, last_at: 0 } },
+  { match: "SELECT equity_usdg FROM equity", row: undefined },
+  { match: "FROM equity", row: undefined },
+  { match: "FROM fee_accruals", row: { n: 0 } },
+];
+
+/** One evidenced deposit in epoch 2, no carry. */
+const FUNDED = [
+  { match: "FROM agents", row: { hwm_usdg: 10, epoch: 2 } },
+  { match: "AND source = 'epoch-carry'", row: { net: 0, n: 0, last_at: 0 } },
+  { match: "tx_hash IS NOT NULL", row: { net: 10, n: 1, last_at: NOW - 100 } },
+  { match: "FROM flows", row: { net: 10, n: 1, last_at: NOW - 100 } },
+  { match: "SELECT equity_usdg FROM equity", row: { equity_usdg: 0 } },
+  { match: "FROM equity", row: { cash_usdg: 3.334, at: NOW - 50 } },
+  { match: "FROM fee_accruals", row: { n: 0 } },
+];
+
+describe("B1 — IT MUST ASK ABOUT THE SMART ACCOUNT", () => {
+  it("passes the smart account, never the owner address, to every query", async () => {
+    const { db, asks } = fakeDb(FUNDED);
+    await deriveBootstrapAccounting(db, SMART, NOW);
+    assert.ok(asks.length >= 4, `expected the four accounting reads, got ${asks.length}`);
+    for (const a of asks) {
+      // The account is always the FIRST parameter; an epoch may follow it.
+      assert.equal(a.params[0], SMART.toLowerCase(), `queried with ${JSON.stringify(a.params)}: ${a.sql.slice(0, 60)}`);
+      assert.notEqual(a.params[0], OWNER.toLowerCase(), "the owner address is not a ledger key");
+    }
+  });
+
+  it("lowercases, because the ledger stores mixed case and the queries compare LOWER()", async () => {
+    const { db, asks } = fakeDb(FUNDED);
+    await deriveBootstrapAccounting(db, SMART.toUpperCase(), NOW);
+    for (const a of asks) assert.equal(a.params[0], SMART.toLowerCase());
+  });
+
+  it("every query is a LOWER() comparison, so a mixed-case stored key still matches", async () => {
+    const { db, asks } = fakeDb(FUNDED);
+    await deriveBootstrapAccounting(db, SMART, NOW);
+    for (const a of asks) assert.match(a.sql, /LOWER\((?:agent_id|smart_account)\)\s*=\s*\?/);
+  });
+});
+
+describe("B2 — 'no prior accounting' is a positive finding, not a default", () => {
+  it("claims it ONLY when every durable trace is absent", async () => {
+    const { db } = fakeDb(EMPTY);
+    const a = await deriveBootstrapAccounting(db, SMART, NOW);
+    assert.equal(a.kind, "no-prior-accounting");
+  });
+
+  it("ANY ONE surviving trace is enough to refuse the claim", async () => {
+    // Each of these alone means the account has history, and booking an opening
+    // balance on top of it would double the owner's recorded capital.
+    const cases: [string, { match: string; row: unknown }[]][] = [
+      ["a high-water mark", [{ match: "FROM agents", row: { hwm_usdg: 10, epoch: 2 } }]],
+      ["a flow row", [{ match: "FROM flows", row: { net: 10, n: 1, last_at: NOW } }]],
+      ["an equity mark", [{ match: "FROM equity", row: { cash_usdg: 0, at: NOW } }]],
+      ["a fee accrual", [{ match: "FROM fee_accruals", row: { n: 1 } }]],
+    ];
+    for (const [what, override] of cases) {
+      const rows = EMPTY.map((e) => override.find((o) => o.match === e.match) ?? e);
+      const a = await deriveBootstrapAccounting(fakeDb(rows).db, SMART, NOW);
+      assert.equal(a.kind, "established", `${what} must refuse the new-account claim`);
+    }
+  });
+
+  it("a funded agent that is UNDERWATER is not new — a zero peak is not emptiness", async () => {
+    // hwm 0 with real flows: an agent can be below every peak it ever had.
+    const rows = EMPTY.map((e) =>
+      e.match === "FROM flows" ? { match: "FROM flows", row: { net: 50, n: 3, last_at: NOW } } : e,
+    );
+    const a = await deriveBootstrapAccounting(fakeDb(rows).db, SMART, NOW);
+    assert.equal(a.kind, "established");
+  });
+});
+
+describe("B3 — a database that throws is not a database that answered", () => {
+  it("returns the `unknown` arm, never `no-prior-accounting`", async () => {
+    const db = {
+      prepare() {
+        return {
+          async get() {
+            throw new Error("connection refused");
+          },
+        };
+      },
+    } as unknown as Db;
+    const a = await deriveBootstrapAccounting(db, SMART, NOW);
+    assert.equal(a.kind, "unknown");
+    assert.match(a.kind === "unknown" ? a.why : "", /connection refused/);
+  });
+
+  it("a failure PART WAY THROUGH still refuses, rather than reporting what it got", async () => {
+    // The agents read succeeds and the flows read throws. Half an answer about
+    // money is not an answer.
+    let n = 0;
+    const db = {
+      prepare(sql: string) {
+        return {
+          async get() {
+            n += 1;
+            if (sql.includes("FROM flows")) throw new Error("statement timeout");
+            return { hwm_usdg: 10, epoch: 2 };
+          },
+        };
+      },
+    } as unknown as Db;
+    const a = await deriveBootstrapAccounting(db, SMART, NOW);
+    assert.equal(a.kind, "unknown");
+    assert.ok(n > 0);
+  });
+
+  it("NEVER THROWS, so no caller has to decide for itself what a dead database means", async () => {
+    const db = {
+      prepare() {
+        throw new Error("pool exhausted");
+      },
+    } as unknown as Db;
+    await assert.doesNotReject(() => deriveBootstrapAccounting(db, SMART, NOW));
+  });
+});
+
+describe("B4 — the receipts-only total is computed separately and reported honestly", () => {
+  it("agrees with the all-rows total when every flow names a transaction", async () => {
+    const a = await deriveBootstrapAccounting(fakeDb(FUNDED).db, SMART, NOW);
+    assert.equal(a.kind, "established");
+    if (a.kind !== "established") return;
+    assert.equal(a.netContributionsUsdg, "10000000");
+    assert.equal(a.anchoredContributionsUsdg, "10000000");
+    assert.equal(a.unanchoredFlowCount, 0);
+    assert.equal(a.highWaterMarkUsdg, "10000000");
+    assert.equal(a.lastObservedCashUsdg, "3334000");
+    assert.equal(a.accountingEpoch, 2);
+  });
+
+  it("reports the SHORTFALL when some flows carry no transaction", async () => {
+    // Three phantom openings, none of them a receipt — the canary's shape.
+    const rows = [
+      { match: "FROM agents", row: { hwm_usdg: 30, epoch: 2 } },
+      { match: "AND source = 'epoch-carry'", row: { net: 0, n: 0, last_at: 0 } },
+      { match: "tx_hash IS NOT NULL", row: { net: 0, n: 0, last_at: 0 } },
+      { match: "FROM flows", row: { net: 30, n: 3, last_at: NOW } },
+      { match: "SELECT equity_usdg FROM equity", row: { equity_usdg: 0 } },
+      { match: "FROM equity", row: { cash_usdg: 3.334, at: NOW } },
+      { match: "FROM fee_accruals", row: { n: 0 } },
+    ];
+    const a = await deriveBootstrapAccounting(fakeDb(rows).db, SMART, NOW);
+    assert.equal(a.kind, "established");
+    if (a.kind !== "established") return;
+    assert.equal(a.netContributionsUsdg, "30000000");
+    assert.equal(a.anchoredContributionsUsdg, "0", "not one of them is a receipt");
+    assert.equal(a.unanchoredFlowCount, 3);
+  });
+
+  it("distinguishes 'no cash reading' from 'held nothing'", async () => {
+    const rows = FUNDED.map((e) => (e.match === "FROM equity" ? { match: "FROM equity", row: undefined } : e));
+    const a = await deriveBootstrapAccounting(fakeDb(rows).db, SMART, NOW);
+    assert.equal(a.kind === "established" && a.lastObservedCashUsdg, null);
+
+    const zero = FUNDED.map((e) =>
+      e.match === "FROM equity" ? { match: "FROM equity", row: { cash_usdg: 0, at: NOW } } : e,
+    );
+    const b = await deriveBootstrapAccounting(fakeDb(zero).db, SMART, NOW);
+    assert.equal(b.kind === "established" && b.lastObservedCashUsdg, "0");
+  });
+
+  it("money crosses as exact integer strings, never as floats", async () => {
+    const rows = FUNDED.map((e) =>
+      e.match === "tx_hash IS NOT NULL"
+        ? { match: "tx_hash IS NOT NULL", row: { net: 154.87, n: 2, last_at: NOW } }
+        : e.match === "FROM flows"
+          ? { match: "FROM flows", row: { net: 154.87, n: 2, last_at: NOW } }
+          : e,
+    );
+    const a = await deriveBootstrapAccounting(fakeDb(rows).db, SMART, NOW);
+    assert.equal(a.kind === "established" && a.netContributionsUsdg, "154870000");
+  });
+
+  it("Postgres numerics arriving as strings are still counted", async () => {
+    // node-postgres hands NUMERIC/int8 back as strings unless told otherwise.
+    const rows = [
+      { match: "FROM agents", row: { hwm_usdg: "10", epoch: "2" } },
+      { match: "tx_hash IS NOT NULL", row: { net: "10", n: "1", last_at: "0" } },
+      { match: "FROM flows", row: { net: "10", n: "1", last_at: String(NOW) } },
+      { match: "FROM equity", row: { cash_usdg: "3.334", at: String(NOW) } },
+      { match: "FROM fee_accruals", row: { n: "0" } },
+    ];
+    const a = await deriveBootstrapAccounting(fakeDb(rows).db, SMART, NOW);
+    assert.equal(a.kind, "established");
+    if (a.kind !== "established") return;
+    assert.equal(a.netContributionsUsdg, "10000000");
+    assert.equal(a.accountingEpoch, 2);
+  });
+});
+
+describe("B6 — THE PRE-DEPLOY GATE: the polluted Postgres, as it actually is", () => {
+  /**
+   * PR A must be safe to deploy against the database as it stands TODAY, which
+   * is not clean. Two mechanisms put contributions there that never happened:
+   * the worker booked the whole balance as a fresh opening balance on every
+   * redeploy, and the mirror — finding its watermark row gone after a rebuild —
+   * rewound to zero and re-copied rows 1..N into a table with no unique key and
+   * an INSERT with no ON CONFLICT.
+   *
+   * So this is the shape that is really in there: one genuine 10 USDG deposit
+   * with a transaction, and three phantom inferred openings of the same amount.
+   * The requirement is not that the derivation cleans it up — it cannot, that is
+   * a data repair — but that it does not treat those rows as EVIDENCE.
+   */
+  const POLLUTED = [
+    { match: "FROM agents", row: { hwm_usdg: 40, epoch: 1 } },
+    { match: "AND source = 'epoch-carry'", row: { net: 0, n: 0, last_at: 0 } },
+    // Only the real deposit is evidenced.
+    { match: "tx_hash IS NOT NULL", row: { net: 10, n: 1, last_at: NOW - 5000 } },
+    // All four rows: the deposit plus three phantoms.
+    { match: "FROM flows", row: { net: 40, n: 4, last_at: NOW - 100 } },
+    { match: "SELECT equity_usdg FROM equity", row: undefined },
+    { match: "FROM equity", row: { cash_usdg: 3.334, at: NOW - 50 } },
+    { match: "FROM fee_accruals", row: { n: 0 } },
+  ];
+
+  it("does not treat the phantom rows as evidence", async () => {
+    const a = await deriveBootstrapAccounting(fakeDb(POLLUTED).db, SMART, NOW);
+    assert.equal(a.kind, "established");
+    if (a.kind !== "established") return;
+    assert.equal(a.netContributionsUsdg, "40000000", "it reports what is there, honestly");
+    assert.equal(a.anchoredContributionsUsdg, "10000000", "and what is EVIDENCED, separately");
+    assert.equal(a.unanchoredFlowCount, 3, "three rows nothing can point at");
+  });
+
+  it("and the licence therefore refuses to call contributions known", async () => {
+    const a = await deriveBootstrapAccounting(fakeDb(POLLUTED).db, SMART, NOW);
+    const l = accountingLicence(
+      classifyAnchor(
+        JSON.stringify({
+          schemaVersion: BOOTSTRAP_SCHEMA_VERSION,
+          tenantId: SMART,
+          generatedAt: NOW,
+          accounting: a,
+        }),
+        { tenantId: SMART, nowSec: NOW },
+      ),
+      { hosted: true },
+    );
+    // RESUME, so the peak still comes back — an unrestored peak is how a fee
+    // lands on principal, and that danger does not care how dirty the flows are.
+    assert.equal(l.licence, "resume");
+    assert.equal(l.highWaterMarkUsdg, 40_000_000n);
+    // But the total is not evidence, so nothing downstream may publish a return.
+    assert.equal(l.contributionsKnown, false);
+    assert.match(l.why, /rests on inference/);
+  });
+
+  it("BOOKS NOTHING NEW on top of it, however many times it restarts", async () => {
+    // The failure that would make PR A unsafe to deploy: arriving at a polluted
+    // ledger and adding a fifth phantom to it.
+    for (let deploy = 0; deploy < 5; deploy++) {
+      const a = await deriveBootstrapAccounting(fakeDb(POLLUTED).db, SMART, NOW);
+      const l = accountingLicence(
+        classifyAnchor(
+          JSON.stringify({
+            schemaVersion: BOOTSTRAP_SCHEMA_VERSION,
+            tenantId: SMART,
+            generatedAt: NOW,
+            accounting: a,
+          }),
+          { tenantId: SMART, nowSec: NOW },
+        ),
+        { hosted: true },
+      );
+      const plan = planFirstObservation({
+        licence: l.licence,
+        equityUsdg: 9_873_005n,
+        cashUsdg: 3_334_000n,
+        anchorCashUsdg: l.lastObservedCashUsdg,
+        materialDriftUsdg: 10_000n,
+      });
+      assert.notEqual(plan.action, "book-opening-balance", `deploy ${deploy} tried to book another one`);
+    }
+  });
+
+  it("a polluted ledger is never mistaken for a NEW account", async () => {
+    // The catastrophic direction. `no-prior-accounting` is the only arm that
+    // licenses booking a balance, and forty USDG of junk flows is still history.
+    const a = await deriveBootstrapAccounting(fakeDb(POLLUTED).db, SMART, NOW);
+    assert.notEqual(a.kind, "no-prior-accounting");
+  });
+});
+
+describe("B5 — the REAL to micro conversion", () => {
+  it("is exact at six places and defensive beyond them", () => {
+    assert.equal(usdgRealToMicro(154.87), 154_870_000n);
+    assert.equal(usdgRealToMicro(3.334), 3_334_000n);
+    assert.equal(usdgRealToMicro(-6.666), -6_666_000n);
+    assert.equal(usdgRealToMicro(0), 0n);
+    // A non-finite figure is a broken read, and 0n is the only value that
+    // cannot make a downstream total larger than the truth.
+    assert.equal(usdgRealToMicro(Number.NaN), 0n);
+    assert.equal(usdgRealToMicro(Number.POSITIVE_INFINITY), 0n);
+  });
+});

--- a/worker/src/bootstrap-source.ts
+++ b/worker/src/bootstrap-source.ts
@@ -1,0 +1,234 @@
+/**
+ * DERIVING A CHILD'S ACCOUNTING ANCHOR FROM THE DURABLE DATABASE.
+ *
+ * The child cannot do this. `CHILD_SECRET_STRIP` removes `DATABASE_URL`
+ * precisely so that one compromised tenant cannot read every other tenant's
+ * ledger, and that isolation is not up for renegotiation to fix an accounting
+ * bug. So the parent — which already holds the URL, already supervises every
+ * child, and already writes three other private files into each child's home —
+ * reads Postgres and hands down a summary.
+ *
+ * WHY POSTGRES RATHER THAN THE CHILD'S OWN SQLITE. Because the child's SQLite
+ * is the thing that keeps disappearing. Reading the anchor out of the directory
+ * a redeploy just emptied would produce a confident anchor full of zeroes,
+ * which is the original bug wearing a new hat. The mirror has been carrying
+ * `flows`, `equity`, `fee_accruals` and the `agents` row (with `hwm_usdg` and
+ * `epoch`) up to Postgres all along; that copy is what survives a container.
+ *
+ * THE THREE ANSWERS ARE NOT INTERCHANGEABLE, and this file's whole job is to
+ * keep them apart:
+ *
+ *   established         durable rows exist — resume from them
+ *   no-prior-accounting the query SUCCEEDED and found nothing at all
+ *   unknown             the query did not succeed
+ *
+ * The middle one is the only thing that licenses an opening-balance
+ * contribution, and it is a positive finding, not a default. A database that
+ * threw must never look like a database that answered "empty" — that
+ * substitution is exactly how a redeploy came to be recorded as a deposit.
+ */
+import type { Db } from "./db";
+import { bigintToMicro, type BootstrapAccounting } from "./bootstrap-state";
+import { reconcileEpochCarry } from "./accounting-scope";
+
+/**
+ * USDG REAL (as the ledger stores it) to micro-USDG bigint.
+ *
+ * The rounding is real and worth naming: the durable columns are SQLite REAL /
+ * Postgres double precision, so six decimal places is already the most that can
+ * be recovered from them. Rounding at the boundary is lossless with respect to
+ * what is actually stored, and it is where the loss stops — everything
+ * downstream of the anchor is integer.
+ */
+export function usdgRealToMicro(v: number): bigint {
+  if (!Number.isFinite(v)) return 0n;
+  return BigInt(Math.round(v * 1e6));
+}
+
+interface AgentRow {
+  hwm_usdg: number | string | null;
+  epoch: number | string | null;
+}
+interface FlowAgg {
+  net: number | string | null;
+  n: number | string | null;
+  last_at: number | string | null;
+}
+interface EquityRow {
+  cash_usdg: number | string | null;
+  at: number | string | null;
+}
+interface CountRow {
+  n: number | string | null;
+}
+
+const num = (v: number | string | null | undefined): number => {
+  if (v === null || v === undefined) return 0;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : 0;
+};
+
+/**
+ * Read a tenant's durable accounting position.
+ *
+ * NEVER THROWS. Every failure becomes `{ kind: "unknown" }` carrying the reason,
+ * because the caller's only alternative to a typed unknown is a `catch` that
+ * decides for itself what an unavailable database means — and the entire point
+ * of this change is that nothing gets to make that decision implicitly.
+ */
+export async function deriveBootstrapAccounting(
+  shared: Db,
+  /**
+   * THE SMART ACCOUNT, not the tenant. They are different addresses and this
+   * distinction is the whole correctness of the query.
+   *
+   * A tenant is the OWNER address that signed the grant; the smart account is
+   * the ERC-4337 wallet it controls, and every ledger table — `agents`
+   * (`smart_account`), `flows`, `equity`, `fee_accruals` (`agent_id`) — is keyed
+   * on the latter. `orchestrator.ts:237` passes both to the identity store side
+   * by side, which is what makes it easy to reach for the wrong one.
+   *
+   * Getting it wrong here does not merely return nothing. It returns nothing FOR
+   * A FUNDED ACCOUNT, and "the query succeeded and found no history" is the one
+   * arm that LICENSES booking the whole balance as an opening contribution — so
+   * a lookup by the wrong key would have manufactured a contribution on every
+   * deploy, with the parent's explicit blessing. Strictly worse than the bug
+   * this file was written to fix.
+   */
+  smartAccount: string,
+  nowSec: number = Math.floor(Date.now() / 1000),
+): Promise<BootstrapAccounting> {
+  const agentId = smartAccount.toLowerCase();
+  try {
+    const agent = (await shared
+      .prepare("SELECT hwm_usdg, epoch FROM agents WHERE LOWER(smart_account) = ?")
+      .get(agentId)) as AgentRow | undefined;
+
+    // Direction carries the sign and `amount_usdg` is always positive, so the
+    // net has to be built in SQL rather than summed off a signed column that
+    // does not exist.
+    // EPOCH-SCOPED. The boundary bridges two epochs by writing the closing equity
+    // of the old one as an opening balance in the new one, so a lifetime sum
+    // counts the same capital twice — once as the original deposit and once as
+    // the bridge derived from it. The child's own reader is epoch-scoped and so
+    // is the web's; an anchor summing across every epoch would hand the child a
+    // figure neither of them agrees with. See accounting-scope.ts.
+    const epoch = Math.max(1, Math.trunc(num(agent?.epoch)) || 1);
+    const flows = (await shared
+      .prepare(
+        "SELECT COALESCE(SUM(CASE WHEN direction = 'in' THEN amount_usdg ELSE -amount_usdg END), 0) AS net, " +
+          "COUNT(*) AS n, COALESCE(MAX(at), 0) AS last_at FROM flows WHERE LOWER(agent_id) = ? AND epoch = ?",
+      )
+      .get(agentId, epoch)) as FlowAgg | undefined;
+
+    // WHY THE DISTINCTION EARNS ITS KEEP. When a hosted child's SQLite is
+    // rebuilt by a redeploy, the mirror finds its watermark row gone, rewinds the
+    // cursor to zero (the orchestrator logs CURSOR REWOUND) and re-copies rows
+    // 1..N from the reborn child. The INSERT has no ON CONFLICT and  has
+    // no unique key, so the shared table accumulates the OLD rows plus whatever
+    // the new incarnation wrote — including a fresh phantom opening balance.
+    // Summing every row over-counts by construction. The anchor therefore reports
+    // both totals and lets the licence decide.
+    // EVIDENCED, not merely tx-hashed.
+    //
+    // `epoch-carry` has no transaction and never can: it is the closing equity
+    // of the epoch just closed, bridged forward. Demanding a hash of it made
+    // every agent that had ever crossed a boundary permanently unable to
+    // evidence its contributions — and no future deposit scan could fix that,
+    // because there is no transfer to find. It is checkable against the prior
+    // epoch's own closing mark instead, which `reconcileEpochCarry` does.
+    const anchored = (await shared
+      .prepare(
+        "SELECT COALESCE(SUM(CASE WHEN direction = 'in' THEN amount_usdg ELSE -amount_usdg END), 0) AS net, " +
+          "COUNT(*) AS n, COALESCE(MAX(at), 0) AS last_at FROM flows " +
+          "WHERE LOWER(agent_id) = ? AND epoch = ? AND " +
+          "((tx_hash IS NOT NULL AND tx_hash <> '') OR source = 'epoch-carry')",
+      )
+      .get(agentId, epoch)) as FlowAgg | undefined;
+
+    // The carry, if this epoch opened with one, and the mark it must match.
+    const carry = (await shared
+      .prepare(
+        "SELECT COALESCE(SUM(amount_usdg), 0) AS net, COUNT(*) AS n, 0 AS last_at FROM flows " +
+          "WHERE LOWER(agent_id) = ? AND epoch = ? AND source = 'epoch-carry' AND direction = 'in'",
+      )
+      .get(agentId, epoch)) as FlowAgg | undefined;
+    const priorClose =
+      epoch > 1
+        ? ((await shared
+            .prepare(
+              "SELECT equity_usdg FROM equity WHERE LOWER(agent_id) = ? AND epoch = ? " +
+                "ORDER BY at DESC, id DESC LIMIT 1",
+            )
+            .get(agentId, epoch - 1)) as { equity_usdg: number | string | null } | undefined)
+        : undefined;
+
+    const equity = (await shared
+      .prepare("SELECT cash_usdg, at FROM equity WHERE LOWER(agent_id) = ? ORDER BY at DESC, id DESC LIMIT 1")
+      .get(agentId)) as EquityRow | undefined;
+
+    const accruals = (await shared
+      .prepare("SELECT COUNT(*) AS n FROM fee_accruals WHERE LOWER(agent_id) = ?")
+      .get(agentId)) as CountRow | undefined;
+
+    const hwm = usdgRealToMicro(num(agent?.hwm_usdg));
+    const flowCount = num(flows?.n);
+    const accrualCount = num(accruals?.n);
+    const hasEquity = equity !== undefined && equity !== null;
+
+    // NO PRIOR ACCOUNTING is asserted only when every durable trace is absent.
+    // A zero HWM on its own is not enough — an agent can be underwater — and
+    // neither is an empty flows table, because an agent funded before the flow
+    // ledger existed has equity marks and no flows.
+    if (hwm === 0n && flowCount === 0 && accrualCount === 0 && !hasEquity) {
+      return { kind: "no-prior-accounting", observedAt: nowSec };
+    }
+
+    // The freshest durable observation this anchor rests on. Reported so a
+    // consumer can see how old the underlying evidence is, separately from how
+    // old the FILE is — a recently written anchor over month-old rows is a
+    // different situation from a month-old file.
+    const observedAt = Math.max(num(flows?.last_at), num(equity?.at)) || nowSec;
+
+    let unanchoredFlows = flowCount - num(anchored?.n);
+
+    // A CARRY THAT DOES NOT RECONCILE IS NOT EVIDENCE, so it is demoted back to
+    // the unanchored count rather than quietly counted as support. The bridge is
+    // only as good as its agreement with the mark it claims to carry.
+    let carryNote: string | null = null;
+    if (num(carry?.n) > 0) {
+      const r = reconcileEpochCarry({
+        openingBalanceUsdg: num(carry?.net),
+        priorEpochClosingEquityUsdg: priorClose === undefined ? null : num(priorClose.equity_usdg),
+      });
+      if (!r.reconciles) {
+        unanchoredFlows += num(carry?.n);
+        carryNote = r.why;
+      }
+    }
+
+    return {
+      kind: "established",
+      highWaterMarkUsdg: bigintToMicro(hwm),
+      netContributionsUsdg: bigintToMicro(usdgRealToMicro(num(flows?.net))),
+      // The receipts-only total, and how many rows are NOT receipts. Together
+      // they are what makes "contributions are known" a checkable claim rather
+      // than an assumption about rows nobody looked at.
+      anchoredContributionsUsdg: bigintToMicro(usdgRealToMicro(num(anchored?.net))),
+      unanchoredFlowCount: unanchoredFlows,
+      // Null rather than zero when there is no mark: "no cash reading on
+      // record" and "the account held nothing" are different claims, and the
+      // child branches on which one it got.
+      lastObservedCashUsdg: hasEquity ? bigintToMicro(usdgRealToMicro(num(equity?.cash_usdg))) : null,
+      accountingEpoch: epoch,
+      observedAt,
+      ...(carryNote === null ? {} : { carryNote }),
+    };
+  } catch (e) {
+    return {
+      kind: "unknown",
+      why: e instanceof Error ? e.message : String(e),
+      observedAt: nowSec,
+    };
+  }
+}

--- a/worker/src/bootstrap-state.ts
+++ b/worker/src/bootstrap-state.ts
@@ -1,0 +1,654 @@
+/**
+ * WHAT THE ORCHESTRATOR TELLS A CHILD ABOUT ITS OWN MONEY, BEFORE IT TRADES.
+ *
+ * THE BUG THIS EXISTS FOR. A hosted child's SQLite lives in an ephemeral
+ * container directory. Every redeploy hands the worker an EMPTY database, and
+ * the accounting code read that emptiness as a fact about the world:
+ *
+ *     if (equityUsdg > 0n && highWaterMarkUsdg === 0n) record(equityUsdg, "opening balance")
+ *
+ * "No high-water mark on record AND there is money here" was taken to mean
+ * "this money just arrived". In self-hosted mode that inference is sound — the
+ * database outlives the process, so an empty one really is a new agent. In
+ * hosted mode it is false on every single redeploy, and the canary booked its
+ * 10 USDG as a brand-new contribution three separate times. Nothing about the
+ * account changed; only the container did.
+ *
+ * WHY IT WAS NOT MERELY A REPORTING ERROR. `record()` also calls
+ * `adjustAgentHwm`, so each phantom contribution raised the high-water mark by
+ * the same amount. The two errors cancelled, which is why no fee was wrongly
+ * charged and why nobody noticed. That cancellation is also the trap: DELETING
+ * the phantom contribution on its own would leave the restored HWM at zero, and
+ * the next equity mark would hand the whole principal to `accrueAboveHwm` as
+ * profit and take a performance fee on the owner's own capital. The two figures
+ * have to be restored together or neither. That is why this file carries the
+ * HWM beside the contributions rather than just the contributions.
+ *
+ * THE SHAPE OF THE FIX. The orchestrator holds `DATABASE_URL` and the child
+ * never will (`CHILD_SECRET_STRIP`), so the durable accounting state is derived
+ * from Postgres by the parent and delivered as a small private file in the
+ * child's own home — the same model as `grant.json`, `settings.json` and
+ * `peers.json`. It is a versioned bootstrap CONTRACT, not a one-off HWM dump:
+ * other things the parent knows and the child cannot will want the same channel.
+ *
+ * AND IT FAILS CLOSED. Missing, malformed, stale, or written from a Postgres
+ * that would not answer, the child does NOT fall back to the old inference. It
+ * marks contribution truth UNKNOWN and books nothing. An agent that cannot say
+ * what was contributed cannot say what it earned, and saying so is the whole
+ * point — a fabricated contribution is worse than an absent one, because a
+ * number nobody flags gets believed.
+ *
+ * ── THE CONTRACT, field by field ────────────────────────────────────────────
+ *
+ * EVERY FIELD HAS A CONSUMER. That is a rule, not an observation. A value that
+ * is derived, transported, validated and then dropped is worse than an absent
+ * one: it creates the impression that the bootstrap state restores more truth
+ * than it does, and the strict validation makes the impression convincing. Four
+ * fields failed that test on the first pass and were removed rather than kept
+ * "for later" — `asOfBlock` (declared reserved, never written), `ownerAddress`
+ * (written by the parent, structurally dropped by `classifyAnchor`),
+ * `anchorNetContributionsUsdg` and `restartDriftUsdg` (both assigned in the
+ * child and read by nothing).
+ *
+ *   field                        source → validation → consumer → effect
+ *   ─────────────────────────────────────────────────────────────────────────
+ *   schemaVersion                orchestrator → exact equality, BEFORE the
+ *                                tenant check → classifyAnchor → an unknown
+ *                                version refuses the whole file rather than
+ *                                reading the fields it happens to recognise
+ *   tenantId (= smart account)   orchestrator → case-insensitive equality →
+ *                                classifyAnchor → a mismatch is MALFORMED, not
+ *                                stale: applying another account's peak is the
+ *                                worst thing this file could do
+ *   generatedAt                  orchestrator → finite, and bounded in BOTH
+ *                                directions → classifyAnchor → stale or
+ *                                future-dated fails closed
+ *   accounting.kind              deriveBootstrapAccounting → discriminant →
+ *                                accountingLicence → decides whether an opening
+ *                                balance may be booked at all
+ *   highWaterMarkUsdg            durable agents row → micro-string shape →
+ *                                restoreAnchoredHighWaterMark → setAgentHwm,
+ *                                MAX() in SQL. The only durable write, and the
+ *                                one that stops a fee landing on principal
+ *   netContributionsUsdg         epoch-scoped flows sum → micro-string shape →
+ *                                accountingLicence → compared against the
+ *                                evidenced total; disagreement means unknown
+ *   anchoredContributionsUsdg    the same sum over evidenced rows only → same →
+ *                                accountingLicence → equality with the above,
+ *                                plus zero unanchored rows, is what proves it
+ *   unanchoredFlowCount          count of the difference → integer → same → any
+ *                                non-zero value makes contributions unknown
+ *   carryNote                    reconcileEpochCarry, when a bridge fails →
+ *                                string → appended to the licence's `why` →
+ *                                reaches the operator log and agents.
+ *                                contributions_why, so a demoted carry is not
+ *                                just an unexplained count
+ *   lastObservedCashUsdg         newest durable equity row → micro-string or
+ *                                null → planFirstObservation → the downtime
+ *                                drift baseline; null means no reading, which
+ *                                yields no drift claim rather than a zero one
+ *   accountingEpoch              durable agents row → integer → setAgentEpoch,
+ *                                MAX() → the child files its rows in the epoch
+ *                                the rest of the system is reading
+ *   observedAt                   newest durable row → finite → the licence's
+ *                                `why` → says how old the EVIDENCE is, which is
+ *                                a different question from how old the file is
+ *   outstandingOps               NOT WRITTEN. Reserved so the orchestrator to
+ *                                child hash push is not a schema break later;
+ *                                pinned dead by accounting-truth.test.ts
+ */
+
+import { readFileSync } from "node:fs";
+import { join as pathJoin } from "node:path";
+
+/**
+ * Bump on any INCOMPATIBLE change. A child that does not recognise the version
+ * refuses the file rather than reading the fields it happens to know: a partial
+ * read of an accounting anchor is exactly the silent-wrong-number failure this
+ * whole file exists to prevent.
+ */
+export const BOOTSTRAP_SCHEMA_VERSION = 1;
+
+/** The file, in the child's own home. Private (0600) like every other one there. */
+export const BOOTSTRAP_FILE = "bootstrap.json";
+
+/**
+ * How old an anchor may be before it stops counting as evidence.
+ *
+ * The parent writes it immediately before `spawn()`, and the child reads it
+ * exactly once, at its first arm — so at the moment of the read the file is
+ * seconds old. Anything materially older means this child did not get a file
+ * written for it and is looking at a leftover from a previous deploy, which is
+ * precisely the state that must not be trusted: the account may have moved.
+ *
+ * THE BOUND IS ONLY MEANINGFUL AGAINST A READ AT STARTUP. It said "refreshed on
+ * every reconcile pass" while nothing refreshed it, and the child re-read it on
+ * every re-arm — so a healthy child that simply stayed up for seven hours would
+ * fail its own correct anchor closed. The read is memoised now (`anchorOnce`),
+ * which is what makes this number mean what it says.
+ */
+export const BOOTSTRAP_MAX_AGE_SEC = 6 * 3600;
+
+/**
+ * Micro-USDG as a decimal integer string.
+ *
+ * NOT a number. The ledger stores USDG as SQLite REAL and the worker computes
+ * in bigint micro-units; a JSON float in between would round the anchor and
+ * every figure derived from it. A string crosses the boundary exactly.
+ */
+export type MicroUsdgString = string;
+
+/**
+ * What the parent can say about a tenant's durable accounting.
+ *
+ * A CLOSED UNION WITH A DISTINCT ARM FOR "I COULD NOT ASK". `unknown` is not a
+ * degenerate `established` with zeroes in it — zeroes are a claim, and a
+ * database that would not answer has made no claim. The three arms get three
+ * different behaviours in the child, and collapsing any two of them
+ * reintroduces the bug in a new shape.
+ */
+export type BootstrapAccounting =
+  /** Durable history exists. Resume from these figures; book no opening balance. */
+  | {
+      kind: "established";
+      /** The persisted peak, restored so the fee path cannot see principal as profit. */
+      highWaterMarkUsdg: MicroUsdgString;
+      /** Σ flows in − Σ flows out, signed, over EVERY row. */
+      netContributionsUsdg: MicroUsdgString;
+      /**
+       * The same total counting only flows that name a transaction.
+       *
+       * A flow with a tx hash was read off a USDG Transfer log; one without was
+       * inferred from a balance change. When the two totals agree, every
+       * contribution is a receipt and the figure can be checked by anyone with
+       * an RPC. When they disagree, some of the total rests on inference — and
+       * inference is exactly what the mirror's cursor rewind duplicates, so the
+       * difference is not a rounding detail but the shape of the corruption.
+       *
+       * Optional so an older anchor still parses; absent means "not computed",
+       * which is treated as unproven rather than as agreement.
+       */
+      anchoredContributionsUsdg?: MicroUsdgString;
+      /** How many flows this epoch are not evidenced. Zero is the only value that proves anything. */
+      unanchoredFlowCount?: number;
+      /**
+       * Why an epoch-opening carry was NOT accepted as evidence, when one was
+       * present and failed to reconcile against the prior epoch's closing mark.
+       * Absent means either no carry, or a carry that checked out.
+       */
+      carryNote?: string;
+      /** Cash at the newest durable observation — the baseline for a downtime delta. */
+      lastObservedCashUsdg: MicroUsdgString | null;
+      accountingEpoch: number;
+      /** Unix seconds of the newest durable row this was derived from. */
+      observedAt: number;
+    }
+  /**
+   * Postgres answered and the tenant has NO accounting history at all: no
+   * flows, no equity marks, no fee accruals, zero HWM.
+   *
+   * This is the ONLY thing that licenses an opening-balance contribution, and
+   * it is an assertion by the one process that can actually see durable state.
+   * The child cannot make this call — an empty child database is a statement
+   * about the container, not about the account.
+   */
+  | { kind: "no-prior-accounting"; observedAt: number }
+  /**
+   * The parent could not establish the truth (Postgres unreachable, query
+   * failed). Written deliberately rather than omitted, so the child can tell
+   * "the parent tried and failed" from "no parent wrote here at all".
+   */
+  | { kind: "unknown"; why: string; observedAt: number };
+
+/**
+ * The orchestrator to child bootstrap contract.
+ *
+ * Deliberately extensible: this is the channel for anything the parent knows
+ * and the child structurally cannot, and there will be more of it.
+ */
+export interface TenantBootstrapState {
+  schemaVersion: number;
+  /**
+   * THE SMART ACCOUNT. Named `tenantId` for the file's shape, but the value is
+   * the ERC-4337 wallet, because that is the key every ledger table is on and
+   * therefore the only identity under which these figures mean anything.
+   *
+   * The owner address that signed the grant is a DIFFERENT string, carried
+   * separately below. Confusing the two is not a naming nit: a lookup under the
+   * owner address finds no rows for a funded account, and "no rows" is the arm
+   * that licenses booking the whole balance as a new contribution.
+   */
+  tenantId: string;
+  /** Unix seconds when this file was written. Staleness is measured from here. */
+  generatedAt: number;
+  accounting: BootstrapAccounting;
+  /**
+   * RESERVED — DECLARED, NOT IMPLEMENTED.
+   *
+   * The orchestrator-to-child outstanding-hash push (reconcile-modes.ts) is a
+   * separate change and is explicitly out of scope here. The field exists so
+   * that adding it later is not a schema break; nothing reads it, and
+   * `accounting-truth.test.ts` pins that nothing does. An accounting-correctness
+   * change is not the place to also alter which blocks get scanned.
+   */
+  outstandingOps?: readonly string[];
+}
+
+/**
+ * Why an anchor is not usable. Each arm is a different operational problem and
+ * a different log line; `absent` on a self-hosted worker is normal, `malformed`
+ * on a hosted one is a bug in the parent.
+ */
+export type AnchorVerdict =
+  | { kind: "valid"; state: TenantBootstrapState; accounting: BootstrapAccounting }
+  | { kind: "absent"; why: string }
+  | { kind: "malformed"; why: string }
+  | { kind: "stale"; why: string; ageSec: number }
+  | { kind: "unsupported-version"; why: string; found: unknown };
+
+const isMicro = (v: unknown): v is MicroUsdgString => typeof v === "string" && /^-?\d{1,30}$/.test(v);
+
+/** Parse a micro-USDG string. Safe only on values `isMicro` has accepted. */
+export function microToBigint(v: MicroUsdgString): bigint {
+  return BigInt(v);
+}
+
+/** Render a bigint micro-USDG figure for the file. */
+export function bigintToMicro(v: bigint): MicroUsdgString {
+  return v.toString();
+}
+
+function validAccounting(a: unknown): BootstrapAccounting | null {
+  if (!a || typeof a !== "object") return null;
+  const o = a as Record<string, unknown>;
+  const observedAt = typeof o.observedAt === "number" && Number.isFinite(o.observedAt) ? o.observedAt : null;
+  if (observedAt === null) return null;
+
+  if (o.kind === "no-prior-accounting") return { kind: "no-prior-accounting", observedAt };
+  if (o.kind === "unknown") {
+    return { kind: "unknown", why: typeof o.why === "string" ? o.why : "unspecified", observedAt };
+  }
+  if (o.kind !== "established") return null;
+
+  // EVERY MONEY FIELD OR NONE. A partially-readable accounting anchor is
+  // treated as malformed, not as the fields that happened to survive — half an
+  // anchor restores half the invariant, which is the same as none of it.
+  if (!isMicro(o.highWaterMarkUsdg)) return null;
+  if (!isMicro(o.netContributionsUsdg)) return null;
+  if (o.lastObservedCashUsdg !== null && !isMicro(o.lastObservedCashUsdg)) return null;
+  if (typeof o.accountingEpoch !== "number" || !Number.isInteger(o.accountingEpoch)) return null;
+
+  // The receipts-only fields are OPTIONAL — an anchor written before they
+  // existed must still parse — but a malformed one is not silently dropped to
+  // "absent", because "absent" and "present but unreadable" get the same
+  // treatment only by accident. A bad value makes the whole anchor malformed.
+  if (o.anchoredContributionsUsdg !== undefined && !isMicro(o.anchoredContributionsUsdg)) return null;
+  if (o.unanchoredFlowCount !== undefined && !Number.isInteger(o.unanchoredFlowCount)) return null;
+  if (o.carryNote !== undefined && typeof o.carryNote !== "string") return null;
+
+  return {
+    kind: "established",
+    highWaterMarkUsdg: o.highWaterMarkUsdg,
+    netContributionsUsdg: o.netContributionsUsdg,
+    ...(o.anchoredContributionsUsdg === undefined
+      ? {}
+      : { anchoredContributionsUsdg: o.anchoredContributionsUsdg as MicroUsdgString }),
+    ...(o.unanchoredFlowCount === undefined ? {} : { unanchoredFlowCount: o.unanchoredFlowCount as number }),
+    ...(o.carryNote === undefined ? {} : { carryNote: o.carryNote as string }),
+    lastObservedCashUsdg: (o.lastObservedCashUsdg as MicroUsdgString | null) ?? null,
+    accountingEpoch: o.accountingEpoch,
+    observedAt,
+  };
+}
+
+/**
+ * Judge an anchor's text. PURE — no filesystem, no clock, no environment.
+ *
+ * `nowSec` is a parameter because staleness is the one property here that a
+ * test has to be able to drive, and a function that reads `Date.now()` cannot
+ * be asked "what would you have said four hours from now".
+ */
+export function classifyAnchor(
+  raw: string | null,
+  args: { tenantId: string; nowSec: number; maxAgeSec?: number },
+): AnchorVerdict {
+  if (raw === null) return { kind: "absent", why: `no ${BOOTSTRAP_FILE} in the child's home` };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    return { kind: "malformed", why: `unparseable JSON — ${e instanceof Error ? e.message : String(e)}` };
+  }
+  if (!parsed || typeof parsed !== "object") return { kind: "malformed", why: "not a JSON object" };
+  const o = parsed as Record<string, unknown>;
+
+  // VERSION BEFORE ANYTHING ELSE, including the tenant check: an unrecognised
+  // version means the field layout itself is not agreed on, so no other field
+  // in the file can be read with confidence.
+  if (o.schemaVersion !== BOOTSTRAP_SCHEMA_VERSION) {
+    return {
+      kind: "unsupported-version",
+      why: `anchor is schemaVersion ${String(o.schemaVersion)}, this worker speaks ${BOOTSTRAP_SCHEMA_VERSION}`,
+      found: o.schemaVersion,
+    };
+  }
+
+  // WRONG TENANT IS MALFORMED, NOT STALE. Applying another account's high-water
+  // mark would be the worst outcome this file can produce, so it is checked
+  // explicitly rather than left to the caller to remember.
+  const tenantId = typeof o.tenantId === "string" ? o.tenantId : "";
+  if (tenantId.toLowerCase() !== args.tenantId.toLowerCase()) {
+    return { kind: "malformed", why: `anchor names tenant ${tenantId || "(none)"}, this child is ${args.tenantId}` };
+  }
+
+  const generatedAt = typeof o.generatedAt === "number" && Number.isFinite(o.generatedAt) ? o.generatedAt : null;
+  if (generatedAt === null) return { kind: "malformed", why: "no usable generatedAt" };
+
+  const accounting = validAccounting(o.accounting);
+  if (!accounting) return { kind: "malformed", why: "accounting block missing or incomplete" };
+
+  // Staleness LAST, so a stale file still gets its structural problems reported
+  // first — "stale" on a file that was also malformed would send an operator
+  // looking at the writer's schedule instead of at the writer.
+  const maxAge = args.maxAgeSec ?? BOOTSTRAP_MAX_AGE_SEC;
+  const ageSec = args.nowSec - generatedAt;
+  if (ageSec > maxAge) {
+    return {
+      kind: "stale",
+      why: `anchor was written ${Math.round(ageSec / 60)} min ago, past the ${Math.round(maxAge / 60)} min bound`,
+      ageSec,
+    };
+  }
+  // A clock skew that puts the file in the future is not evidence either.
+  if (ageSec < -maxAge) {
+    return { kind: "malformed", why: `anchor is dated ${Math.round(-ageSec / 60)} min in the future` };
+  }
+
+  return {
+    kind: "valid",
+    state: {
+      schemaVersion: BOOTSTRAP_SCHEMA_VERSION,
+      tenantId,
+      generatedAt,
+      accounting,
+      ...(Array.isArray(o.outstandingOps) ? { outstandingOps: o.outstandingOps as readonly string[] } : {}),
+    },
+    accounting,
+  };
+}
+
+/**
+ * Read and judge the anchor in a child's home.
+ *
+ * The only impure function here, and it is a two-liner on purpose: everything
+ * that decides anything lives in `classifyAnchor`, which a test can drive
+ * without a filesystem. A missing file is `absent` rather than a throw, because
+ * "no anchor" is a normal state for a self-hosted worker and an expected one
+ * for the first hosted deploy after this ships.
+ */
+export function readAnchor(
+  home: string,
+  args: { tenantId: string; nowSec?: number; maxAgeSec?: number },
+): AnchorVerdict {
+  const nowSec = args.nowSec ?? Math.floor(Date.now() / 1000);
+  let raw: string | null = null;
+  try {
+    raw = readFileSync(pathJoin(home, BOOTSTRAP_FILE), "utf8");
+  } catch {
+    raw = null;
+  }
+  return classifyAnchor(raw, { tenantId: args.tenantId, nowSec, maxAgeSec: args.maxAgeSec });
+}
+
+// ── what the anchor entitles a worker to claim ─────────────────────────────
+
+/**
+ * What this process may say about the owner's capital.
+ *
+ *   new-account        durable state was READ and is empty — book the opening balance
+ *   resume             durable state exists — resume from it, book nothing
+ *   none               durable state could not be established — book nothing, and
+ *                      say contributions are unknown
+ *   self-hosted-local  there is no parent; the local ledger IS the durable record
+ *
+ * The `none` arm is the one that did not exist before, and its absence is the
+ * whole bug: with no way to express "I could not find out", the code had to pick
+ * between the other two, and it picked the one that manufactures money.
+ */
+export type OpeningBalanceLicence = "new-account" | "resume" | "none" | "self-hosted-local";
+
+export interface AccountingLicence {
+  licence: OpeningBalanceLicence;
+  contributionsKnown: boolean;
+  /** The authoritative contribution total, when durable state supplied one. */
+  netContributionsUsdg: bigint | null;
+  /** The peak to restore into the local store, when durable state supplied one. */
+  highWaterMarkUsdg: bigint | null;
+  /** Cash at the newest durable observation — the downtime baseline. */
+  lastObservedCashUsdg: bigint | null;
+  /** The durable accounting epoch, adopted so this child files its rows in the right one. */
+  accountingEpoch: number | null;
+  why: string;
+}
+
+/**
+ * Turn an anchor verdict into a licence. PURE.
+ *
+ * THE HOSTED/SELF-HOSTED SPLIT IS THE HINGE. Self-hosted, the worker's SQLite
+ * lives on a real disk that outlives the process, so it IS the durable record
+ * and an empty one really does mean a new agent — the original inference was
+ * correct there and is kept. Hosted, the same directory is discarded on every
+ * deploy, so emptiness means nothing at all and the only durable record is the
+ * one the parent can see. Getting this boundary wrong in either direction is a
+ * money bug, so it is drawn on one explicit flag rather than inferred.
+ */
+export function accountingLicence(verdict: AnchorVerdict, opts: { hosted: boolean }): AccountingLicence {
+  const base: AccountingLicence = {
+    licence: "none",
+    contributionsKnown: false,
+    netContributionsUsdg: null,
+    highWaterMarkUsdg: null,
+    lastObservedCashUsdg: null,
+    accountingEpoch: null,
+    why: "",
+  };
+
+  if (!opts.hosted) {
+    return {
+      ...base,
+      licence: "self-hosted-local",
+      contributionsKnown: true,
+      why: "self-hosted — the local ledger is the durable record and survives a restart",
+    };
+  }
+  if (verdict.kind !== "valid") {
+    return { ...base, why: `anchor ${verdict.kind}: ${verdict.why}` };
+  }
+
+  const a = verdict.accounting;
+  if (a.kind === "no-prior-accounting") {
+    return {
+      ...base,
+      licence: "new-account",
+      contributionsKnown: true,
+      why: "durable state was read and is empty — this account is genuinely new",
+    };
+  }
+  if (a.kind === "unknown") {
+    return { ...base, why: `the orchestrator could not establish durable state (${a.why})` };
+  }
+  // RESUME ALWAYS, BUT "KNOWN" ONLY ON RECEIPTS.
+  //
+  // These two are deliberately separated, because they answer different
+  // questions and the dangerous move is to tie them together:
+  //
+  //   the LICENCE says "do not book an opening balance" and carries the
+  //   high-water mark back. That must happen whatever the contributions look
+  //   like — an unrestored peak is how a fee gets charged on principal.
+  //
+  //   contributionsKnown says "the total is evidence". It is true only when
+  //   every flow in it names a transaction, because a flow without one was
+  //   inferred from a balance change, and inferred flows are precisely what the
+  //   mirror's cursor rewind re-copies into the shared database on every
+  //   redeploy. A total containing them cannot be checked, so it is not known.
+  //
+  // The consequence is honest and recoverable: an agent whose history is all
+  // inferred resumes safely, books nothing, and reports P&L as unavailable
+  // until the deposit scan gives its flows transaction hashes.
+  // THE CARRY'S REJECTION REASON IS THE MOST USEFUL SENTENCE THIS FILE CARRIES,
+  // and it was validated strictly and then dropped. Without it a demoted bridge
+  // surfaces only as an unexplained non-zero `unanchoredFlowCount`, and an
+  // operator has no way to tell "the epoch opened with a figure that does not
+  // match what the last one closed at" from any other kind of unevidenced flow.
+  const carry = a.carryNote ? ` (epoch carry rejected: ${a.carryNote})` : "";
+  const total = microToBigint(a.netContributionsUsdg);
+  const anchored = a.anchoredContributionsUsdg === undefined ? null : microToBigint(a.anchoredContributionsUsdg);
+  const unanchored = a.unanchoredFlowCount;
+  const provenContributions = anchored !== null && unanchored === 0 && anchored === total;
+  const observed = new Date(a.observedAt * 1000).toISOString();
+  return {
+    licence: "resume",
+    contributionsKnown: provenContributions,
+    netContributionsUsdg: total,
+    highWaterMarkUsdg: microToBigint(a.highWaterMarkUsdg),
+    lastObservedCashUsdg: a.lastObservedCashUsdg === null ? null : microToBigint(a.lastObservedCashUsdg),
+    accountingEpoch: a.accountingEpoch,
+    why: provenContributions
+      ? `resuming from durable state observed ${observed}; every flow is evidenced${carry}`
+      : anchored === null
+        ? `resuming from durable state observed ${observed}, but the anchor predates the receipts-only total, ` +
+          `so the contribution figure is unproven${carry}`
+        : `resuming from durable state observed ${observed}, but ${unanchored ?? "some"} flow(s) carry no ` +
+          `transaction (receipts total ${anchored}, all rows total ${total} micro-USDG) — the contribution ` +
+          `figure rests on inference and cannot be checked${carry}`,
+  };
+}
+
+/**
+ * What the process currently believes about its own contributions.
+ *
+ * Separate from the licence because a licence is what a FILE says and this is
+ * what the process has CONCLUDED, and the two must not be able to overwrite one
+ * another in both directions.
+ */
+export interface ContributionTruth {
+  known: boolean;
+  /** Once set, no licence may raise `known` again for the life of the process. */
+  doubted: boolean;
+  why: string;
+}
+
+export const INITIAL_CONTRIBUTION_TRUTH: ContributionTruth = {
+  known: false,
+  doubted: false,
+  why: "not armed yet",
+};
+
+/**
+ * Fold a licence into what the process believes. PURE.
+ *
+ * DOUBT IS STICKY, AND THAT ASYMMETRY IS THE WHOLE FUNCTION.
+ *
+ * The anchor is not read only at startup: the child re-enters `syncGrant` on any
+ * re-arm, and a transient executor failure is enough to cause one. Meanwhile the
+ * two places that can CLEAR the flag — a material restart drift, and standing
+ * down with no usable anchor — sit behind a first-observation guard and can fire
+ * at most once per process.
+ *
+ * One-way false against two-way true means the doubt always loses. And
+ * `contributionsKnown` is the sole gate on the performance fee, so losing it
+ * means the fee comes back at full rate on a book the code had already declared
+ * unknowable — silently, because the one-shot warning has already been logged.
+ *
+ * Nothing a file says can lift a doubt raised by observing the account. Lifting
+ * it needs evidence — a chain-scanned flow carrying a transaction — and that
+ * recovery does not exist yet, so the honest behaviour is to keep reporting
+ * unknown until the process restarts and re-derives from a fresh anchor.
+ */
+export function foldLicence(prev: ContributionTruth, l: AccountingLicence): ContributionTruth {
+  if (prev.doubted) return { known: false, doubted: true, why: `${l.why} — but ${prev.why}` };
+  return { known: l.contributionsKnown, doubted: false, why: l.why };
+}
+
+/** Raise a doubt that no later licence may lift. PURE. */
+export function doubt(why: string): ContributionTruth {
+  return { known: false, doubted: true, why };
+}
+
+/**
+ * What to do on the FIRST balance observation of a process. PURE.
+ *
+ * This is the money decision, extracted so it can be tested directly rather
+ * than inferred from the shape of the code around it. Every arm is a deliberate
+ * answer to "is this money a contribution?", and only one of them says yes.
+ */
+export type FirstObservationPlan =
+  /** Book the whole balance as the opening contribution. Licensed, not guessed. */
+  | { action: "book-opening-balance"; amountUsdg: bigint }
+  /** The legacy self-hosted path, where the local ledger can answer for itself. */
+  | { action: "legacy-local" }
+  /** A funded account coming back. Book nothing; contributions stay known. */
+  | { action: "resume-clean" }
+  /**
+   * A funded account coming back with cash that moved while it was down, and
+   * nothing that can say why. Book nothing and mark contributions unknown.
+   */
+  | { action: "resume-with-drift"; driftUsdg: bigint }
+  /** No usable durable state. Book nothing, claim nothing. */
+  | { action: "stand-down"; why: string };
+
+/**
+ * WHY A DOWNTIME DELTA IS NEVER BOOKED.
+ *
+ * The tempting move is to treat `cash − anchorCash` as a deposit, and the old
+ * code did a weaker version of exactly that against the local store. It is not
+ * safe. A balance delta across a downtime window cannot distinguish a deposit
+ * from a withdrawal from an in-flight UserOperation that landed while the
+ * worker was down — and that last one is separately booked by
+ * inflight-reconcile, so inferring it here would double-count it with the wrong
+ * sign. An inferred delta is not an actual capital-flow event.
+ *
+ * The mechanism that DOES book a real deposit made during downtime is the chain
+ * scan, which reads USDG Transfer logs and gives every flow a transaction hash.
+ * When it is off or did not cover the window, a material delta means
+ * contributions are no longer fully known — recorded as a gap, not papered over.
+ */
+export function planFirstObservation(args: {
+  licence: OpeningBalanceLicence;
+  equityUsdg: bigint;
+  cashUsdg: bigint;
+  anchorCashUsdg: bigint | null;
+  materialDriftUsdg: bigint;
+  why?: string;
+}): FirstObservationPlan {
+  if (args.licence === "self-hosted-local") return { action: "legacy-local" };
+  if (args.licence === "new-account") {
+    return { action: "book-opening-balance", amountUsdg: args.equityUsdg };
+  }
+  if (args.licence === "resume") {
+    const drift = args.anchorCashUsdg === null ? 0n : args.cashUsdg - args.anchorCashUsdg;
+    if (drift > args.materialDriftUsdg || drift < -args.materialDriftUsdg) {
+      return { action: "resume-with-drift", driftUsdg: drift };
+    }
+    return { action: "resume-clean" };
+  }
+  return { action: "stand-down", why: args.why ?? "no usable accounting anchor" };
+}
+
+/** The one line an operator reads to know which accounting mode a child armed in. */
+export function anchorLine(tenantId: string, v: AnchorVerdict): string {
+  const head = `[anchor] ${tenantId.slice(0, 10)}`;
+  if (v.kind !== "valid") return `${head} ${v.kind.toUpperCase()} — ${v.why}`;
+  const a = v.accounting;
+  if (a.kind === "established") {
+    return (
+      `${head} ESTABLISHED — hwm ${a.highWaterMarkUsdg} contributions ${a.netContributionsUsdg} ` +
+      `cash ${a.lastObservedCashUsdg ?? "unknown"} epoch ${a.accountingEpoch} (micro-USDG)`
+    );
+  }
+  if (a.kind === "no-prior-accounting") {
+    return `${head} NEW — no durable accounting history; an opening balance may be booked`;
+  }
+  return `${head} UNKNOWN — the parent could not establish durable state (${a.why})`;
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -34,6 +34,7 @@ import {
   type PublicClient,
 } from "viem";
 import {
+  isHostedMode,
   CASH,
   CIRCLE_TIERS,
   MORPHO,
@@ -98,6 +99,17 @@ import { archiveCurrentGrant, grantExpired, grantKey, loadGrantFile } from "./gr
 import { TRADEABLE_CHAIN_ID } from "./preflight";
 import { execModeOf, type ExecMode } from "./exec-mode";
 import { limitsFromGrant } from "./limits";
+import {
+  accountingLicence,
+  anchorLine,
+  doubt,
+  foldLicence,
+  INITIAL_CONTRIBUTION_TRUTH,
+  planFirstObservation,
+  readAnchor,
+  type AnchorVerdict,
+  type ContributionTruth,
+} from "./bootstrap-state";
 import { ensureHome, homePaths, merrymenHome } from "./home";
 import { resolveLlm } from "./llm";
 import { applyPaperIntent, type PaperPosition } from "./paper";
@@ -214,6 +226,7 @@ import {
   setPaperBook,
   setAgentName,
   setAgentXHandle,
+  setAgentEpoch,
   setAgentHwm,
   setAgentMode,
   setAgentStatus,
@@ -241,6 +254,17 @@ const VAULT_ABI = parseAbi([
 
 const usdg = (v: number) => BigInt(Math.round(v * 10 ** USDG_DECIMALS));
 const usdgNum = (v: bigint) => Number(formatUnits(v, USDG_DECIMALS));
+
+/**
+ * How much cash may move across a downtime window before it stops being noise.
+ *
+ * 0.01 USDG. The durable columns are REAL, so a figure that made the round trip
+ * through Postgres and back can differ from the on-chain balance in the last
+ * decimal place without anything having happened. Below this the difference is
+ * storage precision; at or above it, something moved and the book must say it
+ * does not know what.
+ */
+const MATERIAL_DRIFT_USDG = 10_000n;
 const fmt = (v: bigint) => formatUnits(v, USDG_DECIMALS);
 
 function swapRouterFor(cfg: ResolvedConfig): `0x${string}` {
@@ -1038,30 +1062,79 @@ async function main() {
     const covered = scan ? await scanChainFlows(scan) : false;
 
     if (!covered && lastCashUsdg === null) {
-      // Nothing observed in THIS process yet. Two very different situations,
-      // and conflating them was a real bug:
+      // FIRST OBSERVATION OF THIS PROCESS. Everything hard about hosted
+      // accounting is in this branch, so it is worth being exact about what
+      // changed and why.
       //
-      //   • a genuinely new agent (no HWM) — the balance is the opening
-      //     deposit, booked as a flow so the ledger is complete from row one;
+      // THE OLD TEST WAS `equityUsdg > 0n && highWaterMarkUsdg === 0n`, read as
+      // "money is here and no peak is on record, so this money just arrived".
+      // In self-hosted mode that is sound: the database outlives the process, so
+      // an empty one really is a new agent. In HOSTED mode the child's SQLite
+      // lives in an ephemeral container directory, so a redeploy hands the
+      // worker an empty database and the test fires on an account that has been
+      // funded for weeks. The canary booked its 10 USDG as a brand-new
+      // contribution three separate times, once per deploy.
       //
-      //   • a RESTART of a funded agent (HWM persisted, so > 0) — here the old
-      //     code did nothing at all, because `lastCashUsdg` is a process-
-      //     lifetime variable that resets to null on every start. A top-up made
-      //     while the worker was stopped was therefore invisible: the next tick
-      //     handed the higher equity to accrueAboveHwm, which called it profit
-      //     and took a 10% performance fee on the owner's own capital, and
-      //     netContributions stayed understated forever.
+      // WHY NOBODY SAW IT. `record()` also raises the HWM by the same amount,
+      // so the phantom contribution and the phantom peak cancelled and no fee
+      // was wrongly charged. That cancellation is also why the fix cannot be
+      // "stop booking it": with the peak left at zero the next mark would hand
+      // the whole principal to accrueAboveHwm as profit. Both figures have to be
+      // restored together, which is what the anchor does (bootstrap-state.ts).
       //
-      // Stop worker → top up → start worker is the most natural thing a first-
-      // day owner does. Seeding from the last persisted cash reading closes it.
-      if (equityUsdg > 0n && highWaterMarkUsdg === 0n) {
-        await record(equityUsdg, "opening balance");
-      } else {
-        const prior = await lastKnownCashUsdg(agentId);
-        if (prior !== null) {
-          await record(cashUsdg - usdg(prior), "changed while the worker was stopped");
+      // WHAT REPLACES IT. The orchestrator holds DATABASE_URL and the child
+      // never will, so the parent derives the tenant's durable position from
+      // Postgres and writes it into the child's home. THE ANCHOR IS THE ONLY
+      // THING THAT LICENSES AN OPENING BALANCE, and it says so positively:
+      // `no-prior-accounting` means a query SUCCEEDED and found nothing, which
+      // is a claim only a process that can see durable state may make.
+      // THE DECISION IS PURE AND LIVES IN bootstrap-state.ts. Only the recording
+      // is here, so the rule that decides whether money is a contribution can be
+      // tested directly rather than inferred from the shape of this block.
+      const plan = planFirstObservation({
+        licence: accounting.openingBalanceLicence,
+        equityUsdg,
+        cashUsdg,
+        anchorCashUsdg,
+        materialDriftUsdg: MATERIAL_DRIFT_USDG,
+        why: accounting.why,
+      });
+      if (plan.action === "legacy-local") {
+        // SELF-HOSTED KEEPS THE ORIGINAL BEHAVIOUR, unchanged, because the
+        // premise it rests on is true here: the ledger is on a real disk that
+        // outlives the process, so an empty one is a new agent and a persisted
+        // cash reading really is where the account was left. The hosted arms
+        // below exist because that premise is false in a container, not because
+        // the reasoning was ever wrong on its own terms.
+        if (equityUsdg > 0n && highWaterMarkUsdg === 0n) {
+          await record(equityUsdg, "opening balance");
+        } else {
+          const prior = await lastKnownCashUsdg(agentId);
+          if (prior !== null) {
+            await record(cashUsdg - usdg(prior), "changed while the worker was stopped");
+          }
         }
+      } else if (plan.action === "book-opening-balance") {
+        // THE ONLY PATH THAT BOOKS A CONTRIBUTION HERE, and it runs only when
+        // the orchestrator READ durable state and found none.
+        if (plan.amountUsdg > 0n) await record(plan.amountUsdg, "opening balance");
+      } else if (plan.action === "resume-with-drift") {
+        doubtContributions(`cash moved across the downtime window and nothing could price it`);
+        await addEvent(
+          agentId,
+          "warn",
+          `cash moved ${plan.driftUsdg > 0n ? "+" : ""}${fmt(plan.driftUsdg)} USDG while the worker was stopped and ` +
+            `no chain scan covered the window — this is NOT booked as a contribution, because a balance change ` +
+            `across downtime cannot distinguish a deposit from a withdrawal from a trade that landed. ` +
+            `Contributions and P&L are marked unknown until a deposit scan can price it.`,
+        );
+      } else if (plan.action === "stand-down") {
+        // NO USABLE ANCHOR. The one thing that must not happen here is the old
+        // inference, so nothing is booked and the book says so.
+        doubtContributions(plan.why);
       }
+      // `resume-clean` is the remaining arm and it does nothing on purpose: a
+      // funded account came back with the cash the anchor said it had.
     } else if (!covered && lastCashUsdg !== null && ledgerWrites === ledgerWritesAtSnapshot) {
       await record(cashUsdg - lastCashUsdg, "no trade explains this");
     }
@@ -1075,6 +1148,177 @@ async function main() {
   // moved and NOTHING was written to the ledger in between, the money came from
   // outside. Deliberately narrow — see reconcileFlows.
   let lastCashUsdg: bigint | null = null;
+  /**
+   * WHAT THIS PROCESS IS ENTITLED TO CLAIM ABOUT THE OWNER'S CAPITAL.
+   *
+   * Set once, at arm, from the accounting anchor the orchestrator wrote (see
+   * bootstrap-state.ts). Kept beside `lastCashUsdg` because the two are read in
+   * the same breath and it is the pair that decides whether a balance is a
+   * contribution or just a balance.
+   *
+   * `openingBalanceLicence` is deliberately a licence rather than a guess:
+   *
+   *   new-account  durable state was READ and is empty — book the opening balance
+   *   resume       durable state exists — resume from it, book nothing
+   *   none         durable state could not be established — book nothing, and
+   *                say that contributions are unknown
+   *
+   * The third arm is the one that did not exist before. Its absence is the
+   * whole bug: with no way to express "I could not find out", the code had to
+   * pick one of the first two, and it picked the one that manufactures money.
+   */
+  const accounting: {
+    openingBalanceLicence: "new-account" | "resume" | "none" | "self-hosted-local";
+    contributionsKnown: boolean;
+    /** Once true, no later anchor read may set contributionsKnown back to true. */
+    contributionsDoubted: boolean;
+    /** Why, in one phrase, for the log line and the quality report. */
+    why: string;
+  } = {
+    openingBalanceLicence: "none",
+    contributionsKnown: false,
+    contributionsDoubted: false,
+    why: "not armed yet",
+  };
+  /** The believed truth about contributions, folded from every licence seen. */
+  let truth: ContributionTruth = INITIAL_CONTRIBUTION_TRUTH;
+  /** Cash at the anchor's newest durable observation. The downtime baseline. */
+  let anchorCashUsdg: bigint | null = null;
+  /** The peak the anchor says was already reached, restored into the local store. */
+  let anchorHwmUsdg: bigint | null = null;
+  /** The durable accounting epoch this child must file its rows under. */
+  let anchorEpoch: number | null = null;
+  /** One warning per process, not one per tick, when the fee is being suppressed. */
+  let feeSuppressionLogged = false;
+
+  /**
+   * Turn the anchor verdict into a licence. Runs once, at arm.
+   *
+   * THE HOSTED/SELF-HOSTED SPLIT IS THE HINGE. Self-hosted, the child's own
+   * SQLite lives on a real disk that outlives the process, so it IS the durable
+   * record and an empty one really does mean a new agent — the original
+   * inference was correct there and stays. Hosted, the same directory is
+   * discarded on every deploy, so emptiness means nothing at all and the only
+   * durable record is the one the parent can see. Getting this boundary wrong
+   * in either direction is a money bug, so it is drawn on `MERRYMEN_HOSTED`,
+   * which `childEnv` sets and nothing else does.
+   */
+  function applyAccountingAnchor(agentId: string, verdict: AnchorVerdict): void {
+    console.log(anchorLine(agentId, verdict));
+    const l = accountingLicence(verdict, { hosted: isHostedMode() });
+    accounting.openingBalanceLicence = l.licence;
+    anchorHwmUsdg = l.highWaterMarkUsdg;
+    anchorCashUsdg = l.lastObservedCashUsdg;
+    anchorEpoch = l.accountingEpoch;
+
+    // DOUBT IS STICKY FOR THE LIFE OF THE PROCESS.
+    //
+    // This function does not only run at startup. It runs inside `syncGrant`,
+    // which the tick re-enters whenever the grant changed or `active` is null —
+    // and a transient executor failure nulls `active`. So a plain assignment
+    // here would RESURRECT `contributionsKnown` on the next tick after something
+    // had already established that it was false.
+    //
+    // The asymmetry is what makes that fatal rather than untidy. The two places
+    // that clear the flag — `resume-with-drift` and `stand-down` — sit behind
+    // `lastCashUsdg === null`, so they can fire at most ONCE per process, while
+    // this runs every re-arm. One-way false against two-way true means the
+    // doubt always loses, and `contributionsKnown` is the sole gate on the
+    // performance fee: the fee would quietly come back at full rate on a book
+    // the code had already declared unknowable, with no second warning because
+    // `feeSuppressionLogged` is still set.
+    //
+    // Nothing an anchor can say lifts a doubt raised by observing the account.
+    // Clearing it needs evidence — a chain-scanned flow with a transaction —
+    // and that recovery does not exist yet, so the honest behaviour is to keep
+    // reporting unknown until the process restarts and re-derives.
+    // The fold is PURE and lives in bootstrap-state.ts so the asymmetry can be
+    // tested directly rather than inferred from the shape of this function — it
+    // had no coverage at all, and a mutation deleting it passed every test.
+    setTruth(foldLicence(truth, l));
+  }
+
+  /** The anchor verdict, read once. See `anchorOnce`. */
+  let anchorVerdict: AnchorVerdict | null = null;
+
+  /**
+   * READ THE ANCHOR EXACTLY ONCE PER PROCESS, at the first arm.
+   *
+   * It is a BOOTSTRAP contract — it describes the durable state the parent
+   * observed just before exec'ing this child — so the moment to read it is the
+   * moment the child starts, and re-reading it later is wrong in two separate
+   * ways that both showed up:
+   *
+   *   STALENESS. The parent writes the file once, in `spawnChild`. A child that
+   *   stays up longer than `BOOTSTRAP_MAX_AGE_SEC` and then re-arms — a grant
+   *   renewal, a transient executor failure that nulls `active` — would read its
+   *   OWN still-correct anchor as expired, fall closed, and permanently lose
+   *   both the peak restore and P&L on a healthy account.
+   *
+   *   FORGETTING. `syncGrant` re-enters on any re-arm, so a re-read handed the
+   *   licence a fresh chance to overwrite conclusions the process had already
+   *   drawn from watching the account.
+   *
+   * Reading once removes both. The age is measured against the instant the child
+   * started, which is seconds after the parent wrote the file, which is the only
+   * comparison the bound was ever meaningful for.
+   */
+  function anchorOnce(agentId: string): AnchorVerdict {
+    if (anchorVerdict === null) {
+      anchorVerdict = readAnchor(merrymenHome(), { tenantId: agentId });
+    }
+    return anchorVerdict;
+  }
+
+  /**
+   * Read the anchor and put the peak back, in that order, as one step.
+   *
+   * ONE FUNCTION because the two halves are not separable. The anchor is what
+   * knows the peak, and a restore that runs at a different point in the arm from
+   * the read is a window in which a funded account sits at a zero high-water
+   * mark. It is called immediately after `ensureAgent`, which is the first
+   * moment the row it writes to exists.
+   *
+   * `setAgentHwm` is `MAX(hwm_usdg, ?)` in SQL, a one-way door — so a restored
+   * peak can only ever be raised. Too high suppresses a fee; too low charges the
+   * owner for their own principal. Between those two the monotonic direction is
+   * the safe one, and the store already enforces it.
+   */
+  async function restoreAnchoredHighWaterMark(agentId: string): Promise<void> {
+    applyAccountingAnchor(agentId, anchorOnce(agentId));
+
+    // THE EPOCH COMES BACK FIRST, because every row this child is about to write
+    // is stamped with it.
+    //
+    // `ensureAgent` inserts only the grant columns, so a rebuilt container starts
+    // at the schema default of 1 while durable state may be on 2 — and nothing
+    // corrects it, because the bump is gated on pre-fix history that an empty
+    // database does not have. The child would then file its whole run under a
+    // closed epoch, invisible to the web's epoch-scoped readers AND to the next
+    // anchor derivation, which would read zero contributions and harden the fee
+    // gate on a healthy account.
+    if (anchorEpoch !== null) await setAgentEpoch(agentId, anchorEpoch);
+
+    if (anchorHwmUsdg === null || anchorHwmUsdg <= 0n) return;
+    const local = usdg((await getAgentFinancials(agentId)).hwmUsdg);
+    if (anchorHwmUsdg > local) {
+      await setAgentHwm(agentId, usdgNum(anchorHwmUsdg));
+      console.log(`[anchor] restored high-water mark ${fmt(anchorHwmUsdg)} USDG (local was ${fmt(local)})`);
+    }
+  }
+
+  /** Raise a doubt that no later anchor read may lift. */
+  function doubtContributions(why: string): void {
+    setTruth(doubt(why));
+  }
+
+  /** One place that writes the three fields, so they cannot drift apart. */
+  function setTruth(t: ContributionTruth): void {
+    truth = t;
+    accounting.contributionsKnown = t.known;
+    accounting.contributionsDoubted = t.doubted;
+    accounting.why = t.why;
+  }
   /**
    * The block the deposit scan has read up to, for this process.
    *
@@ -2171,6 +2415,25 @@ async function main() {
           })
         : undefined;
     const agentId = await ensureAgent(grant);
+
+    // THE PEAK COMES BACK IMMEDIATELY AFTER THE ROW EXISTS, and before anything
+    // that can fail.
+    //
+    // `ensureAgent` creates the local `agents` row, and on a hosted child the
+    // SQLite is empty, so `hwm_usdg` takes its schema default of 0. Between that
+    // moment and the restore there must be nothing that can throw, return early,
+    // or get mirrored — every one of those leaves a funded account sitting at a
+    // zero peak, which is the state that charges a performance fee on the
+    // owner's own principal.
+    //
+    // It was originally placed beside the other arm-time reads, a dozen awaits
+    // and several network calls later. Any of those failing — a bundler key
+    // rotated, an RPC 5xx — would return before the restore ran, and the mirror
+    // would then carry the local zero up to the shared database as the new
+    // durable truth. (The mirror's own upsert is monotonic now, so that second
+    // half is closed too; this is the first half.)
+    await restoreAnchoredHighWaterMark(agentId);
+
     // The soul's name is the source of truth — mirror it onto the roster. The
     // configured name was reconciled into the soul above the short-circuit, so
     // by here `getName()` is already what the owner asked for.
@@ -2522,6 +2785,15 @@ async function main() {
           `(they predate flow tracking and receipt-derived fills, so they cannot be audited)`,
       );
     }
+    // WHAT THIS AGENT MAY CLAIM ABOUT ITS OWN CAPITAL, decided once, here.
+    //
+    // Read before the HWM, because in hosted mode the anchor is where the HWM
+    // comes from: the local `agents` row is in a container directory that a
+    // redeploy empties, so `getAgentFinancials` returns a confident zero for an
+    // account that has been funded for weeks.
+    // The anchor was read and the peak restored right after `ensureAgent`, above
+    // everything that can fail. Nothing to do here but pick the figure up.
+    //
     // HWM is persistent — a restart must not forget the peak, or the breaker
     // re-arms low and the fee ledger double-charges old profit.
     highWaterMarkUsdg = usdg((await getAgentFinancials(agentId)).hwmUsdg);
@@ -4687,9 +4959,35 @@ async function main() {
           ? { chain: makeReconcileChain(client), smartAccount: grant.smartAccount as `0x${string}` }
           : undefined,
       );
+      // A PERFORMANCE FEE NEEDS TO KNOW WHAT WAS CONTRIBUTED.
+      //
+      // "Profit" here means equity above the peak, and the peak only means
+      // anything if every deposit that raised it was seen. When contributions
+      // are unknown — no usable accounting anchor, or cash that moved across a
+      // downtime window nothing could price — the difference between profit and
+      // the owner's own principal is exactly what is not established, so the
+      // fee is zeroed for this tick.
+      //
+      // THE HIGH-WATER MARK STILL RATCHETS, deliberately. Passing 0 bps rather
+      // than skipping the accrual keeps `newHwmUsdg` moving, because the peak
+      // is also what the drawdown breaker measures against: freezing it would
+      // make the breaker LESS likely to halt a falling book, which is the wrong
+      // direction to fail in. Refusing the money movement and keeping the safety
+      // signal is the split that matters.
+      const feeBpsThisTick = accounting.contributionsKnown ? effFeeBps : 0;
+      if (!accounting.contributionsKnown && effFeeBps > 0 && !feeSuppressionLogged) {
+        feeSuppressionLogged = true;
+        await addEvent(
+          agentId,
+          "warn",
+          `performance fee suppressed — contributions are not established (${accounting.why}), so equity above the ` +
+            `high-water mark cannot be distinguished from the owner's own capital. The peak still ratchets, so the ` +
+            `drawdown breaker is unaffected.`,
+        );
+      }
       // The Merry Circle discount is applied to the REAL fee here, so holders
       // actually accrue less — the perk is in the ledger, not just the marketing.
-      const accrual = accrueAboveHwm(equityUsdg, highWaterMarkUsdg, effFeeBps);
+      const accrual = accrueAboveHwm(equityUsdg, highWaterMarkUsdg, feeBpsThisTick);
       // A CURVE-VALUED POSITION MAY NOT RATCHET THE PEAK.
       //
       // `setAgentHwm` is MAX(hwm_usdg, ?) — a one-way door in SQL, with a real
@@ -4772,6 +5070,10 @@ async function main() {
         // The SAME total the fee and the breaker are judged against — the row
         // no longer re-derives its own, lower one.
         equityUsdg: usdgNum(equityUsdg),
+        // And the fourth term of that composition, so an auditor summing the
+        // parts closes on the total instead of finding a discrepancy exactly
+        // equal to the quarantined cost and having no way to name it.
+        quarantinedCostUsdg: usdgNum(quarantine.totalCostUsdg),
         // The prices this valuation was made at, journalled so the figure can
         // be re-derived rather than merely believed. `positions` carries these
         // but is overwritten every tick, so without this each snapshot destroyed

--- a/worker/src/ledger-mirror.ts
+++ b/worker/src/ledger-mirror.ts
@@ -487,9 +487,29 @@ export async function mirrorTenant(args: {
              expires_at = excluded.expires_at, mode = excluded.mode,
              beat_at = excluded.beat_at, sponsor_gas = excluded.sponsor_gas,
              x_handle = excluded.x_handle,
-             epoch = excluded.epoch,
-             hwm_usdg = excluded.hwm_usdg,
-             accrued_fee_usdg = excluded.accrued_fee_usdg`,
+             -- MONOTONIC, NOT OVERWRITTEN. These three are RATCHETS, and the
+             -- child that supplies them lives in a container whose database a
+             -- redeploy empties. A fresh child recreates its local agents row at
+             -- the schema defaults — epoch 1, hwm 0, fee 0 — and an unconditional
+             -- assignment here wrote those defaults straight over the durable
+             -- history: the peak the performance fee is measured against reset to
+             -- zero, the accounting epoch regressed to 1 (readmitting the very
+             -- epoch-1 rows the epoch mechanism exists to exclude), and the
+             -- accrued-fee total forgot what the house had earned.
+             --
+             -- The direction matters more than the loss. A peak that resets to 0
+             -- means the next mark hands the whole principal to accrueAboveHwm as
+             -- profit and charges a performance fee on the owner's own capital —
+             -- the exact failure the accounting anchor was built to prevent,
+             -- arriving through the mirror instead of through the worker.
+             --
+             -- CASE rather than MAX/GREATEST because this statement is written
+             -- once for both backends: MAX is scalar in sqlite and an aggregate
+             -- in Postgres, and GREATEST does not exist in sqlite.
+             epoch = CASE WHEN excluded.epoch > agents.epoch THEN excluded.epoch ELSE agents.epoch END,
+             hwm_usdg = CASE WHEN excluded.hwm_usdg > agents.hwm_usdg THEN excluded.hwm_usdg ELSE agents.hwm_usdg END,
+             accrued_fee_usdg = CASE WHEN excluded.accrued_fee_usdg > agents.accrued_fee_usdg
+                                     THEN excluded.accrued_fee_usdg ELSE agents.accrued_fee_usdg END`,
         );
         for (const a of agents) {
           await ins.run(
@@ -506,6 +526,7 @@ export async function mirrorTenant(args: {
             // means a pre-migration child rather than an absent value — fall back
             // to the same defaults the schema would have applied.
             a.epoch ?? 1, a.hwm_usdg ?? 0, a.accrued_fee_usdg ?? 0,
+
           );
         }
       });

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -47,6 +47,8 @@ import { getSettingsStore } from "./settings-store";
 import { acquireTenantLease, type TenantLease } from "./tenant-lease";
 import { isHostedMode, type MerrymenSettings } from "../../packages/core/src/index";
 import { makePgDb, translateSchema, type Db } from "./db";
+import { BOOTSTRAP_FILE, BOOTSTRAP_SCHEMA_VERSION, type TenantBootstrapState } from "./bootstrap-state";
+import { deriveBootstrapAccounting } from "./bootstrap-source";
 import { getFollowStore, MAX_FOLLOWS } from "./follow-store";
 import { MIRROR_STATE_DDL, mirrorTenant, openChildLedger } from "./ledger-mirror";
 import { writePeersForChild } from "./peer-files";
@@ -210,9 +212,9 @@ function heartbeatAt(tenant: string): number | null {
 }
 
 /** Write the tenant's session-key-only grant into its child's grant.json. */
-async function writeGrantForChild(tenant: `0x${string}`): Promise<boolean> {
+async function writeGrantForChild(tenant: `0x${string}`): Promise<`0x${string}` | null> {
   const grant = await getGrantStore().get(tenant);
-  if (!grant) return false;
+  if (!grant) return null;
 
   // BACKFILL THE PUBLIC ID.
   //
@@ -243,7 +245,11 @@ async function writeGrantForChild(tenant: `0x${string}`): Promise<boolean> {
   // so keep it owner-only. chmod is a POSIX no-op that throws on Windows — the
   // container is Linux, and self-hosted never runs the orchestrator.
   writeFileSync(path.join(home, "grant.json"), JSON.stringify(grant, null, 2), { encoding: "utf8", mode: 0o600 });
-  return true;
+  // The SMART ACCOUNT, returned rather than discarded: it is the key every
+  // ledger table is on, the caller needs it to derive the accounting anchor, and
+  // the grant is the only place the orchestrator can learn it without a second
+  // decrypting read.
+  return grant.smartAccount as `0x${string}`;
 }
 
 /**
@@ -276,6 +282,78 @@ async function writeSettingsForChild(
   }
 }
 
+/**
+ * Write the tenant's accounting anchor into its child's home.
+ *
+ * WHY THIS RUNS EVEN WHEN IT FAILS. The child's home survives a child restart
+ * but not a deploy, so a file left over from a previous pass can be both
+ * present and wrong. Writing the `unknown` arm on failure REPLACES that
+ * leftover with an explicit "the parent could not establish this", which the
+ * child fails closed on. Skipping the write on failure would leave the stale
+ * file in place and let a child resume from figures nobody re-verified — the
+ * strictly less safe of the two options, so the write is unconditional.
+ *
+ * Best-effort in the sense that it never throws and never blocks a spawn: an
+ * agent that cannot get an anchor still arms, still runs its risk controls and
+ * still reconciles. What it does not do is book contributions.
+ */
+async function writeBootstrapForChild(
+  tenant: `0x${string}`,
+  /**
+   * The tenant's SMART ACCOUNT — the key every ledger table is actually on, and
+   * the identity the child checks the file against. The tenant address names
+   * WHOSE anchor this is; the smart account names WHICH BOOK it describes, and
+   * they are not the same string.
+   */
+  smartAccount: `0x${string}`,
+  shared?: Db,
+): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  let accounting: TenantBootstrapState["accounting"];
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    // No shared database configured at all. That is a deployment fact, not a
+    // fact about the tenant, and it is reported as such rather than as an
+    // empty account.
+    accounting = { kind: "unknown", why: "no DATABASE_URL on the orchestrator", observedAt: now };
+  } else {
+    try {
+      accounting = await deriveBootstrapAccounting(shared ?? (await makePgDb(url)), smartAccount, now);
+    } catch (e) {
+      accounting = { kind: "unknown", why: e instanceof Error ? e.message : String(e), observedAt: now };
+    }
+  }
+
+  const state: TenantBootstrapState = {
+    schemaVersion: BOOTSTRAP_SCHEMA_VERSION,
+    // THE SMART ACCOUNT IS THE IDENTITY THE CHILD CHECKS, because it is the key
+    // the figures below were read under. Stamping the tenant here while the
+    // child compares against its smart account made every hosted anchor read as
+    // malformed — the mechanism was inert, and inert in the safe direction only
+    // by luck. The owner address rides along for provenance.
+    tenantId: smartAccount.toLowerCase(),
+    generatedAt: now,
+    accounting,
+    // `outstandingOps` is deliberately NOT written. The field is reserved in
+    // the schema so adding it later is not a break; populating it here would
+    // change which blocks a child scans, which is a different change.
+  };
+
+  try {
+    const home = childHome(tenant);
+    mkdirSync(home, { recursive: true });
+    writeFileSync(path.join(home, BOOTSTRAP_FILE), JSON.stringify(state, null, 2), {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    if (accounting.kind === "unknown") {
+      log(`${tenant}: accounting anchor UNKNOWN — ${accounting.why} (child will not book contributions)`);
+    }
+  } catch (e) {
+    log(`${tenant}: could not write ${BOOTSTRAP_FILE} — ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
 async function spawnChild(tenant: `0x${string}`, restarts = 0): Promise<void> {
   if (stopping) return;
   // The advisory lease is a precondition, taken by reconcile() before the FIRST
@@ -288,7 +366,8 @@ async function spawnChild(tenant: `0x${string}`, restarts = 0): Promise<void> {
     log(`${tenant}: no healthy lease — not spawning (another replica may hold it)`);
     return;
   }
-  if (!(await writeGrantForChild(tenant))) {
+  const smartAccount = await writeGrantForChild(tenant);
+  if (!smartAccount) {
     log(`${tenant}: no grant in the store — not spawning`);
     return;
   }
@@ -296,6 +375,11 @@ async function spawnChild(tenant: `0x${string}`, restarts = 0): Promise<void> {
   // patience to the tick that child will actually run. `tickSeconds` resolves
   // file-before-env (settings.ts), and the file is what we just wrote.
   const settings = await writeSettingsForChild(tenant);
+  // BEFORE spawn(), not after. The child reads its anchor while arming, and an
+  // anchor that lands a moment later would be read as absent — which fails
+  // closed, so the agent would run with contributions marked unknown for no
+  // reason other than a race.
+  await writeBootstrapForChild(tenant, smartAccount);
   const tickSeconds = typeof settings?.tickSeconds === "number" ? settings.tickSeconds : envTickSeconds();
   const staleSec = staleThresholdSec(tickSeconds);
   const proc = spawn(

--- a/worker/src/store.ts
+++ b/worker/src/store.ts
@@ -98,16 +98,22 @@ const SQLITE_SCHEMA = `
     -- and positions.price_source. The three are not equally good evidence:
     --   'chain-log'       a Transfer log naming this account. Exact, has a tx.
     --   'transfer-intent' our own outbound transfer. Exact, has a tx.
+    --   'epoch-carry'     the closing equity of the epoch just closed, bridged
+    --                     forward as the new one's opening balance. No tx, but
+    --                     not guesswork either: it is a deterministic function of
+    --                     a figure already in the journal, and it is CHECKABLE
+    --                     against the prior epoch's final equity mark.
     --   'inferred'        a cash change no fill explains. Honest guesswork; only
     --                     ever recorded when NO trade ran in the interval, so it
     --                     cannot be confused with a fill, and it carries no tx.
-    -- An audit that needs a chain-verifiable figure keeps the first two.
+    -- An audit that needs a chain-verifiable figure keeps the first two. One that
+    -- needs a SUPPORTABLE figure keeps the first three; see accounting-scope.ts.
     CREATE TABLE IF NOT EXISTS flows (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       agent_id TEXT NOT NULL,
       direction TEXT NOT NULL,       -- 'in' | 'out'
       amount_usdg REAL NOT NULL,     -- always positive; direction carries the sign
-      tx_hash TEXT,                  -- null only when source = 'inferred'
+      tx_hash TEXT,                  -- null for 'inferred' and 'epoch-carry'
       block_number INTEGER,
       source TEXT NOT NULL,
       at INTEGER NOT NULL DEFAULT (unixepoch())
@@ -722,6 +728,36 @@ export async function getAgentFinancials(
 }
 
 /** Ratchet the persisted HWM (monotonic — ignores values below the stored peak). */
+/**
+ * Adopt the durable accounting epoch on a child whose database was discarded.
+ *
+ * THE REGRESSION THIS CLOSES. `ensureAgent` inserts only the grant columns, so a
+ * hosted child rebuilt by a redeploy takes the schema DEFAULT of epoch 1 — while
+ * the shared `agents` row is on 2. The only bump path is gated by
+ * `hasEpochOneHistory`, which counts rows written before the accounting fix and
+ * is therefore false on an empty database, so nothing corrects it.
+ *
+ * The child then writes every trade, flow and equity row stamped epoch 1. The
+ * web's readers are epoch-scoped and the anchor derivation now is too, so those
+ * rows are invisible to BOTH: contributions and the evidenced total both read
+ * zero, and the fee gate hardens permanently on an account that is fine.
+ *
+ * MONOTONIC, like the peak. `MAX` rather than assignment, because an epoch is a
+ * one-way door — going backwards would readmit the quarantined rows the boundary
+ * exists to exclude, which is the failure the mirror's own upsert had.
+ */
+export async function setAgentEpoch(agentId: string, epoch: number): Promise<boolean> {
+  if (!Number.isInteger(epoch) || epoch < 1) return false;
+  try {
+    await getDb()
+      .prepare("UPDATE agents SET epoch = MAX(epoch, ?) WHERE smart_account = ?")
+      .run(epoch, agentId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function setAgentHwm(agentId: string, hwmUsdg: number): Promise<boolean> {
   try {
     await getDb()
@@ -943,9 +979,12 @@ export async function hasEpochOneHistory(agentId: string): Promise<boolean> {
  * what "reporting starts clean" has to mean — epoch 1's performance is
  * unmeasurable, which is precisely why it was quarantined.
  *
- * Booked 'inferred' because it is: a balance observed at a boundary, not a
- * transfer anybody witnessed. The flow ledger has that column so this kind of
- * row can never be mistaken for a receipt.
+ * Booked 'epoch-carry', which is its own source rather than 'inferred'. It is
+ * not a transfer anybody witnessed, so it is not a receipt — but it is also not
+ * guesswork: it is the closing equity of the epoch just closed, a figure already
+ * in the journal, and reconcileEpochCarry() checks it against that mark. Sharing
+ * a source with real inference made every agent that crossed a boundary
+ * permanently unable to evidence its contributions, with no recovery possible.
  */
 export async function openNextEpoch(agentId: string, openingBalanceUsdg?: number): Promise<number> {
   const next = (await getAgentEpoch(agentId)) + 1;
@@ -958,14 +997,22 @@ export async function openNextEpoch(agentId: string, openingBalanceUsdg?: number
       agentId,
       direction: "in",
       amountUsdg: openingBalanceUsdg,
-      source: "inferred",
+      // NOT 'inferred'. This is the closing equity of the epoch just closed,
+      // which is a figure already in the journal — a deterministic bridge, not a
+      // deduction from a balance nobody can point at. Sharing a source value with
+      // real inference condemned every agent that had ever crossed a boundary to
+      // permanent contributionsKnown=false, with no recovery that could exist:
+      // no deposit scan can retroactively give a bookkeeping entry a transaction
+      // hash it never had. A carry is checkable against the prior epoch's own
+      // closing mark instead — see reconcileEpochCarry in accounting-scope.ts.
+      source: "epoch-carry",
     });
   }
   return next;
 }
 
 /** How the ledger came to know about a flow. See the flows DDL — these are not equal evidence. */
-export type FlowSource = "chain-log" | "transfer-intent" | "inferred";
+export type FlowSource = "chain-log" | "epoch-carry" | "transfer-intent" | "inferred";
 
 export interface FlowRow {
   agentId: string;
@@ -1029,15 +1076,64 @@ export async function addFlow(flow: FlowRow): Promise<void> {
  * P&L at all rather than a confident wrong one.
  */
 export async function getNetContributionsUsdg(agentId: string): Promise<number | null> {
+  // EPOCH-SCOPED, and it was not.
+  //
+  // The boundary bridges two epochs by writing the closing equity of the old one
+  // as an opening balance in the new one (`openNextEpoch`). Summing across the
+  // boundary therefore counts the same capital twice — once as the original
+  // deposit, once as the bridge derived from it — so contributions double and
+  // P&L goes as negative as the deposit was large.
+  //
+  // It never fired because the only agents ever bumped were those with pre-fix
+  // rows, and pre-fix rows predate the flows table: epoch 1 held no flows, so a
+  // lifetime sum happened to equal the current epoch's. Fund an agent on today's
+  // code and bump it for any future reason and the accident stops holding.
+  //
+  // The web's identical query already carried the predicate (scoreboard
+  // route.ts). This is the reader that did not. See accounting-scope.ts.
+  const epoch = await epochOf(agentId);
   const row = await getDb()
     .prepare(
       `SELECT COUNT(*) AS n,
               COALESCE(SUM(CASE WHEN direction = 'in' THEN amount_usdg ELSE -amount_usdg END), 0) AS net
-       FROM flows WHERE agent_id = ?`,
+       FROM flows WHERE agent_id = ? AND epoch = ?`,
     )
-    .get(agentId) as { n: number; net: number } | undefined;
+    .get(agentId, epoch) as { n: number; net: number } | undefined;
   if (!row || row.n === 0) return null;
   return row.net;
+}
+
+/**
+ * The evidence behind this epoch's contributions, so a caller can say whether
+ * the total is a receipt, a bridge, or an opinion.
+ *
+ * Returns counts by source rather than a verdict: deciding what counts as
+ * evidence is `accounting-scope.ts`'s job, and a store read that also judged
+ * would put the policy in two places.
+ */
+export async function getFlowEvidence(
+  agentId: string,
+): Promise<{ source: string; n: number; netUsdg: number }[]> {
+  const epoch = await epochOf(agentId);
+  return (await getDb()
+    .prepare(
+      `SELECT source,
+              COUNT(*) AS n,
+              COALESCE(SUM(CASE WHEN direction = 'in' THEN amount_usdg ELSE -amount_usdg END), 0) AS netUsdg
+       FROM flows WHERE agent_id = ? AND epoch = ? GROUP BY source`,
+    )
+    .all(agentId, epoch)) as unknown as { source: string; n: number; netUsdg: number }[];
+}
+
+/** The last equity figure recorded in a SPECIFIC epoch — what a carry must match. */
+export async function closingEquityOfEpoch(agentId: string, epoch: number): Promise<number | null> {
+  const row = (await getDb()
+    .prepare(
+      `SELECT equity_usdg FROM equity WHERE agent_id = ? AND epoch = ?
+       ORDER BY at DESC, id DESC LIMIT 1`,
+    )
+    .get(agentId, epoch)) as { equity_usdg: number } | undefined;
+  return row?.equity_usdg ?? null;
 }
 
 /**
@@ -1619,6 +1715,21 @@ export async function addEquity(
      */
     equityUsdg: number;
     /**
+     * The fourth term of that composition, recorded so the total can be CHECKED.
+     *
+     * `composeEquityUsdg` is cash + vault + positions + quarantinedCost, and the
+     * journal carried only the first three beside the total. That is enough to
+     * publish a number and not enough to verify one: an auditor summing what is
+     * written finds a discrepancy exactly equal to the quarantined cost and
+     * cannot tell it from a book that does not add up. Writing the term makes the
+     * identity closed.
+     *
+     * Optional because every mark written before this existed lacks it, and the
+     * verifier must treat those as UNCHECKABLE rather than as zero — assuming
+     * zero is how the missing term became invisible in the first place.
+     */
+    quarantinedCostUsdg?: number;
+    /**
      * The prices this valuation was made at, and how good each one is.
      *
      * Without them a historical equity figure cannot be re-derived by anyone,
@@ -1649,6 +1760,10 @@ export async function addEquity(
           symbol: m.symbol,
         })),
         positionsUsdg: b.positionsUsdg,
+        // Written only when the caller knows it, so an auditor can tell "there
+        // was none" from "nobody said". Undefined is dropped by JSON.stringify,
+        // which is exactly the distinction we want on the wire.
+        quarantinedCostUsdg: b.quarantinedCostUsdg,
         vaultUsdg: b.vaultUsdg,
       },
       async (db: Db) => {


### PR DESCRIPTION
**PR A of two.** Accounting safety and runtime correctness only. Nothing here publishes a figure, so it can be reviewed and deployed without deciding anything about what the dashboard shows. PR B (portfolio truth and publication) stacks on top.

## The bug

A hosted child's SQLite lives in an ephemeral container directory, so every redeploy handed the worker an empty database — and the accounting read that emptiness as a fact about the world:

```ts
if (equityUsdg > 0n && highWaterMarkUsdg === 0n) record(equityUsdg, "opening balance")
```

Sound self-hosted, where the database outlives the process. False on every hosted deploy. **The canary held 10 USDG, never received another cent, and its ledger said 30 had been contributed.**

Nobody saw it because `record()` also raises the high-water mark by the same amount, so the phantom contribution and the phantom peak cancelled and no fee was wrongly charged. That cancellation is also the trap: deleting the contribution alone would leave the peak at zero and hand the whole principal to `accrueAboveHwm` as profit.

## The fix

The orchestrator holds `DATABASE_URL` and the child never will, so the parent derives the tenant's durable position from Postgres and writes a versioned bootstrap contract into the child's home, beside `grant.json` and `settings.json`. Three answers, kept apart: durable state exists (resume), the query succeeded and found nothing (the only thing that licenses an opening balance), or the query did not succeed. Missing, malformed, stale, wrong-tenant or unknown all fail closed.

## What an adversarial review found in the first draft

It shipped **inert**, and one fix away from being worse than the bug.

| | |
|---|---|
| **Identity** | Keyed on the tenant (owner EOA) while every ledger table keys on the smart account. A lookup by the wrong key finds nothing for a *funded* account — and "no history" is the arm that licenses booking the balance. It never fired only because the parent stamped one address while the child validated the other. Two bugs cancelling is not a safety property. |
| **Sticky doubt** | `applyAccountingAnchor` runs inside `syncGrant`, which re-enters on any re-arm. The two places that clear `contributionsKnown` fire at most once per process. One-way false against two-way true meant the doubt always lost — and it is the sole gate on the performance fee. |
| **Monotonic shared state** | The mirror assigned `hwm_usdg`, `epoch` and `accrued_fee_usdg` unconditionally, so a rebuilt container's schema defaults overwrote the durable peak with zero, which the next anchor read back as truth. |
| **Restart-safe anchor** | Read once, at the first arm. Re-reading on every re-arm made a healthy child fail its own correct anchor closed past the six-hour bound. |
| **Epoch correctness** | `getNetContributionsUsdg` summed every row while the boundary writes an opening balance equal to what was carried — a lifetime sum counts the same capital twice. It only ever worked by accident. And `ensureAgent` never wrote `epoch`, so a rebuilt child filed its whole run under a closed epoch, invisible to every epoch-scoped reader including its own next anchor. |
| **Epoch-carry** | The bridge is its own flow source now. Sharing `inferred` with real guesswork condemned every agent past a boundary to permanently unevidenced contributions, with no recovery that could exist. Checked against the prior epoch's own closing mark instead. |

## Deploy safety

The shared database is **not clean** — one genuine tx-hashed deposit plus three inferred phantom openings. Four tests drive the derivation against that exact fixture and prove it reports 40 as present and 10 as evidenced, refuses to call contributions known, books nothing new across five consecutive deploys, and never mistakes junk history for a new account.

No historical repair is run by this PR. Journal continuity remains `unrecoverable` and is stated as such.

2024 tests, worker and web typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)