### PR TITLE
Print the evidenced contribution total beside the claimed one

### DIFF
--- a/worker/src/accounting-truth.test.ts
+++ b/worker/src/accounting-truth.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 import {
   accountingLicence,
+  anchorLine,
   BOOTSTRAP_MAX_AGE_SEC,
   BOOTSTRAP_SCHEMA_VERSION,
   classifyAnchor,
@@ -419,6 +420,44 @@ describe("P3c — a doubt raised by watching the account is never lifted by a fi
   });
 });
 
+describe("P3d — the operator line shows the EVIDENCED total, not just the claimed one", () => {
+  it("prints both totals and the unevidenced row count", () => {
+    // Fail-closed is the most important property this file has, and in
+    // production the only other place it surfaced was a fee-suppression event
+    // that needs a clean tick to fire. On a rate-limited fleet that can be hours
+    // away, so the line said "contributions 30000000" and stopped — the number
+    // the phantom bookings produced, with no hint that only a third of it is a
+    // receipt.
+    const line = anchorLine(
+      TENANT,
+      read(
+        anchorFile(
+          established({
+            netContributionsUsdg: "30000000",
+            anchoredContributionsUsdg: "10000000",
+            unanchoredFlowCount: 2,
+          }),
+        ),
+      ),
+    );
+    assert.match(line, /contributions 30000000/);
+    assert.match(line, /evidenced 10000000/, "the receipts-only total must be on the line");
+    assert.match(line, /unevidenced-rows 2/, "and how many rows are not receipts");
+  });
+
+  it("says so when the totals were never computed, rather than implying agreement", () => {
+    const line = anchorLine(
+      TENANT,
+      read(anchorFile(established({ anchoredContributionsUsdg: undefined, unanchoredFlowCount: undefined } as never))),
+    );
+    assert.match(line, /evidenced not-computed/);
+  });
+
+  it("carries a rejected epoch bridge onto the line", () => {
+    const line = anchorLine(TENANT, read(anchorFile(established({ carryNote: "opening balance does not match" } as never))));
+    assert.match(line, /epoch carry rejected: opening balance does not match/);
+  });
+});
 describe("P4 — self-hosted keeps the behaviour whose premise is true there", () => {
   it("a self-hosted worker takes the legacy local path, anchor or no anchor", () => {
     for (const raw of [null, anchorFile(established())]) {

--- a/worker/src/bootstrap-state.ts
+++ b/worker/src/bootstrap-state.ts
@@ -644,7 +644,23 @@ export function anchorLine(tenantId: string, v: AnchorVerdict): string {
   if (a.kind === "established") {
     return (
       `${head} ESTABLISHED — hwm ${a.highWaterMarkUsdg} contributions ${a.netContributionsUsdg} ` +
-      `cash ${a.lastObservedCashUsdg ?? "unknown"} epoch ${a.accountingEpoch} (micro-USDG)`
+      // THE EVIDENCED TOTAL, BESIDE THE CLAIMED ONE.
+      //
+      // Without these two the line said "contributions 30000000" and stopped —
+      // which is the number the phantom bookings produced, printed with no hint
+      // that only 10000000 of it is a receipt. Fail-closed is the single most
+      // important property this file has, and the only other place it surfaced
+      // was a fee-suppression event that needs a clean tick to fire. On a
+      // rate-limited fleet that event can be hours away, so the safety property
+      // was effectively invisible in production at the moment it mattered most.
+      //
+      // `evidenced` counts chain-log receipts and reconciling epoch bridges;
+      // `unevidenced` is everything else. They must agree for contributions to
+      // be believed, and now an operator can see at a glance whether they do.
+      `evidenced ${a.anchoredContributionsUsdg ?? "not-computed"} ` +
+      `unevidenced-rows ${a.unanchoredFlowCount ?? "?"} ` +
+      `cash ${a.lastObservedCashUsdg ?? "unknown"} epoch ${a.accountingEpoch} (micro-USDG)` +
+      (a.carryNote ? ` · epoch carry rejected: ${a.carryNote}` : "")
     );
   }
   if (a.kind === "no-prior-accounting") {


### PR DESCRIPTION
Follow-up to #64, found by deploying it.

The canary's live anchor line reads:

```
[anchor] 0x3E34E58e ESTABLISHED — hwm 9912617 contributions 30000000 cash 3334000 epoch 1
```

That `30000000` is the number the phantom bookings produced. Only `10000000` of it is a chain-log receipt — and the line gives an operator no way to tell.

Fail-closed is the most important property the anchor has, and the only other place it surfaces in production is a fee-suppression event that needs a clean tick to fire. The fleet was rate-limited right after the deploy (`market unreadable … no trading this tick`), so that event was hours away and the safety property was effectively invisible at the moment it mattered most.

Now:

```
contributions 30000000 evidenced 10000000 unevidenced-rows 2
```

`not-computed` rather than an implied agreement when an older anchor never carried the field, and a rejected epoch bridge names itself.

2027 tests, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)