### PR TITLE
Read contributed capital off the chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prepublishOnly": "node cli/prepublish.mjs",
     "dev:web": "cd web && next dev -p 3100 -H 127.0.0.1",
     "dev:worker": "tsx worker/src/index.ts",
-    "test": "tsx --test \"worker/src/**/*.test.ts\" \"web/src/**/*.test.ts\"",
+    "test": "tsx --test \"worker/src/**/*.test.ts\" \"web/src/**/*.test.ts\" \"packages/*/src/**/*.test.ts\"",
     "test:contracts": "cd contracts && npm test",
     "typecheck": "tsc --noEmit -p worker && tsc --noEmit -p web && tsc --noEmit -p browser"
   },

--- a/packages/core/src/capital-classify.test.ts
+++ b/packages/core/src/capital-classify.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { classifyUsdgMovement, totalCapital, type TransferLeg } from "./capital-classify";
+
+/**
+ * THE CANARY IS THE REFERENCE FIXTURE, and it is the case a naive rule gets
+ * wrong: one inbound 10.000000 USDG transfer and four outbound 1.666500 USDG
+ * transfers. Inbound-is-a-deposit / outbound-is-a-withdrawal reports 10 in and
+ * 6.666 out — a 6.666 USDG withdrawal that is really four TSLA purchases, and a
+ * contributed-capital figure of 3.334 instead of 10.
+ */
+
+const ACCOUNT = "0x3E34E58e39DC6614e047dFD3BAD5B7DEA45DCd62";
+const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
+const TSLA = "0x322F0929c4625eD5bAd873c95208D54E1c003b2d";
+const ROUTER = "0xf4acdaeeb7022862a763c9b1b885e11191c889e3";
+const OWNER_WALLET = "0xac563ac23bac8d803992502088ebf46ab892f95c";
+
+const leg = (token: string, from: string, to: string, amountRaw: string): TransferLeg => ({
+  token,
+  from,
+  to,
+  amountRaw,
+});
+
+describe("C1 — the canary's five transfers", () => {
+  it("the funding transfer is CAPITAL", () => {
+    const usdg = leg(USDG, OWNER_WALLET, ACCOUNT, "10000000");
+    const c = classifyUsdgMovement({ account: ACCOUNT, usdg, txLegs: [usdg], usdgToken: USDG });
+    assert.equal(c.kind, "capital-in");
+    assert.match(c.why, /external capital/);
+  });
+
+  it("a router outflow paired with TSLA arriving is a TRADE, not a withdrawal", () => {
+    // The whole point. This is the movement a naive rule books as the owner
+    // taking money out.
+    const usdg = leg(USDG, ACCOUNT, ROUTER, "1666500");
+    const tsla = leg(TSLA, ROUTER, ACCOUNT, "4420417473624633");
+    const c = classifyUsdgMovement({ account: ACCOUNT, usdg, txLegs: [usdg, tsla], usdgToken: USDG });
+    assert.equal(c.kind, "trade-out");
+    assert.equal(c.pairedToken, TSLA);
+    assert.match(c.why, /bought something, it did not leave/);
+  });
+
+  it("and it does so WITHOUT the router being on any list", () => {
+    // 0xf4acdaee… appears in no protocol table in this repo. An allowlist would
+    // have called this a withdrawal.
+    const usdg = leg(USDG, ACCOUNT, ROUTER, "1666500");
+    const tsla = leg(TSLA, ROUTER, ACCOUNT, "4420417473624633");
+    const c = classifyUsdgMovement({
+      account: ACCOUNT,
+      usdg,
+      txLegs: [usdg, tsla],
+      usdgToken: USDG,
+      protocolAddresses: ["0x8366a39cc670b4001a1121b8f6a443a643e40951"], // the V4 PoolManager, not this router
+    });
+    assert.equal(c.kind, "trade-out");
+  });
+
+  it("THE WHOLE FIXTURE totals to exactly 10.000000 USDG contributed", () => {
+    const tsla = (raw: string) => leg(TSLA, ROUTER, ACCOUNT, raw);
+    const movements = [
+      { usdg: leg(USDG, OWNER_WALLET, ACCOUNT, "10000000"), other: [] as TransferLeg[] },
+      { usdg: leg(USDG, ACCOUNT, ROUTER, "1666500"), other: [tsla("4420417473624633")] },
+      { usdg: leg(USDG, ACCOUNT, ROUTER, "1666500"), other: [tsla("4420460174801013")] },
+      { usdg: leg(USDG, ACCOUNT, ROUTER, "1666500"), other: [tsla("4420470491247900")] },
+      { usdg: leg(USDG, ACCOUNT, ROUTER, "1666500"), other: [tsla("4422869427188655")] },
+    ];
+    const classified = movements.map((m) => ({
+      amountRaw: m.usdg.amountRaw,
+      classification: classifyUsdgMovement({
+        account: ACCOUNT,
+        usdg: m.usdg,
+        txLegs: [m.usdg, ...m.other],
+        usdgToken: USDG,
+      }),
+    }));
+    const t = totalCapital(classified);
+
+    assert.equal(t.grossContributionsRaw, "10000000", "contributed capital is 10.000000 USDG");
+    assert.equal(t.grossWithdrawalsRaw, "0", "nothing was ever withdrawn");
+    assert.equal(t.netContributionsRaw, "10000000");
+    assert.equal(t.tradeLegs, 4);
+    assert.equal(t.ambiguous, 0);
+
+    // What the naive rule would have said, pinned so the difference is explicit.
+    const naiveNet = 10_000_000n - 4n * 1_666_500n;
+    assert.equal(naiveNet, 3_334_000n);
+    assert.notEqual(t.netContributionsRaw, naiveNet.toString());
+  });
+});
+
+describe("C2 — a sale is not a deposit", () => {
+  it("USDG arriving while a token leaves is sale proceeds", () => {
+    const usdg = leg(USDG, ROUTER, ACCOUNT, "5000000");
+    const tsla = leg(TSLA, ACCOUNT, ROUTER, "13000000000000000");
+    const c = classifyUsdgMovement({ account: ACCOUNT, usdg, txLegs: [usdg, tsla], usdgToken: USDG });
+    assert.equal(c.kind, "trade-in");
+    assert.match(c.why, /sale proceeds, not a deposit/);
+  });
+
+  it("a genuine withdrawal to an outside wallet is capital-out", () => {
+    const usdg = leg(USDG, ACCOUNT, OWNER_WALLET, "1010000000");
+    const c = classifyUsdgMovement({ account: ACCOUNT, usdg, txLegs: [usdg], usdgToken: USDG });
+    assert.equal(c.kind, "capital-out");
+  });
+});
+
+describe("C3 — it refuses rather than guesses", () => {
+  it("a protocol address with NOTHING coming back is ambiguous, not a trade", () => {
+    // Removing it from capital on the strength of a list would be a guess; so
+    // would booking it as a withdrawal. Neither is available.
+    const usdg = leg(USDG, ACCOUNT, ROUTER, "1666500");
+    const c = classifyUsdgMovement({
+      account: ACCOUNT,
+      usdg,
+      txLegs: [usdg],
+      usdgToken: USDG,
+      protocolAddresses: [ROUTER],
+    });
+    assert.equal(c.kind, "ambiguous");
+    assert.match(c.why, /either capital or a completed trade/);
+  });
+
+  it("a self-transfer says nothing about capital", () => {
+    const usdg = leg(USDG, ACCOUNT, ACCOUNT, "1000000");
+    assert.equal(classifyUsdgMovement({ account: ACCOUNT, usdg, txLegs: [usdg], usdgToken: USDG }).kind, "ambiguous");
+  });
+
+  it("a movement between two accounts this system controls is internal", () => {
+    const other = "0x47Bab4113ba596dC84E5654A400074D7e0ae2F3D";
+    const usdg = leg(USDG, ACCOUNT, other, "1000000");
+    const c = classifyUsdgMovement({
+      account: ACCOUNT,
+      usdg,
+      txLegs: [usdg],
+      usdgToken: USDG,
+      knownAccounts: [other],
+    });
+    assert.equal(c.kind, "internal");
+  });
+
+  it("a zero-amount paired leg does not make a swap", () => {
+    // An approval or a dust log must not turn a real deposit into a trade.
+    const usdg = leg(USDG, OWNER_WALLET, ACCOUNT, "10000000");
+    const dust = leg(TSLA, ACCOUNT, ROUTER, "0");
+    const c = classifyUsdgMovement({ account: ACCOUNT, usdg, txLegs: [usdg, dust], usdgToken: USDG });
+    assert.equal(c.kind, "capital-in");
+  });
+
+  it("another USDG leg in the same tx is not a 'different token'", () => {
+    const usdg = leg(USDG, OWNER_WALLET, ACCOUNT, "10000000");
+    const otherUsdg = leg(USDG, ACCOUNT, ROUTER, "1000");
+    const c = classifyUsdgMovement({ account: ACCOUNT, usdg, txLegs: [usdg, otherUsdg], usdgToken: USDG });
+    assert.equal(c.kind, "capital-in", "a same-token leg cannot be the other half of a swap");
+  });
+});
+
+describe("C4 — gross and net are separately derivable", () => {
+  it("funded 1010 then withdrawn 1010 is NOT 'no contribution ever happened'", () => {
+    // The exact shape of 0xfd58500678406D33293EcAd9976c6c5EE653ECa1 on chain.
+    const inLeg = leg(USDG, OWNER_WALLET, ACCOUNT, "1010000000");
+    const outLeg = leg(USDG, ACCOUNT, OWNER_WALLET, "1010000000");
+    const t = totalCapital([
+      {
+        amountRaw: inLeg.amountRaw,
+        classification: classifyUsdgMovement({ account: ACCOUNT, usdg: inLeg, txLegs: [inLeg], usdgToken: USDG }),
+      },
+      {
+        amountRaw: outLeg.amountRaw,
+        classification: classifyUsdgMovement({ account: ACCOUNT, usdg: outLeg, txLegs: [outLeg], usdgToken: USDG }),
+      },
+    ]);
+    assert.equal(t.netContributionsRaw, "0", "net is zero");
+    assert.equal(t.grossContributionsRaw, "1010000000", "but 1010 really was contributed");
+    assert.equal(t.grossWithdrawalsRaw, "1010000000", "and really was taken back");
+  });
+
+  it("an account with no transfers at all has zero of everything", () => {
+    const t = totalCapital([]);
+    assert.equal(t.grossContributionsRaw, "0");
+    assert.equal(t.grossWithdrawalsRaw, "0");
+    assert.equal(t.netContributionsRaw, "0");
+    assert.equal(t.ambiguous, 0);
+  });
+
+  it("money crosses as base-unit strings, never floats", () => {
+    const big = leg(USDG, OWNER_WALLET, ACCOUNT, "123456789012345678901234");
+    const t = totalCapital([
+      {
+        amountRaw: big.amountRaw,
+        classification: classifyUsdgMovement({ account: ACCOUNT, usdg: big, txLegs: [big], usdgToken: USDG }),
+      },
+    ]);
+    assert.equal(t.grossContributionsRaw, "123456789012345678901234", "exact past 2^53");
+  });
+});

--- a/packages/core/src/capital-classify.ts
+++ b/packages/core/src/capital-classify.ts
@@ -1,0 +1,221 @@
+/**
+ * WHICH TOKEN MOVEMENTS ARE THE OWNER'S CAPITAL, AND WHICH ARE THE AGENT TRADING.
+ *
+ * A contribution total is a claim about money the OWNER put in. Every USDG
+ * transfer touching the account looks the same at the ERC-20 level, so treating
+ * inbound as a deposit and outbound as a withdrawal produces a number that is
+ * mostly trading volume. On the canary that rule would report 10 in and 6.666
+ * out — a 6.666 USDG "withdrawal" that is actually four TSLA purchases.
+ *
+ * WHY NOT AN ADDRESS ALLOWLIST. It was the obvious first answer and it is wrong
+ * in the direction that matters: the canary's four outflows go to
+ * 0xf4acdaee…, which appears in NO protocol table in this repo. Venues are
+ * added, pools are created per pair, and a list that is merely stale silently
+ * reclassifies trading as withdrawals — which is the same class of confident
+ * wrong number this whole effort is about. An allowlist can only ever add
+ * certainty on the addresses it already knows.
+ *
+ * SO THE PRIMARY TEST IS TRANSACTION CONTEXT. A swap moves two tokens in
+ * opposite directions within ONE transaction. If the same transaction that took
+ * USDG out of the account also put a different token IN to it, that is a
+ * purchase, whoever the counterparty was. Nothing about a deposit looks like
+ * that: an owner funding an account sends one token and receives none.
+ *
+ * The address list is kept as a secondary signal for the case the primary test
+ * cannot see — an approval-style leg with no paired movement — and never as the
+ * thing that makes a movement capital.
+ */
+
+/** What a single USDG movement turned out to be. */
+export type CapitalKind =
+  /** External capital arriving. Counts toward gross contributions. */
+  | "capital-in"
+  /** Capital leaving to an outside address. Counts toward gross withdrawals. */
+  | "capital-out"
+  /** USDG spent buying something — the sell leg of a swap. Not capital. */
+  | "trade-out"
+  /** USDG received selling something — the buy leg of a swap. Not capital. */
+  | "trade-in"
+  /** A movement between accounts this system controls. Not external capital. */
+  | "internal"
+  /**
+   * The classifier could not decide.
+   *
+   * A distinct arm rather than a default, because the whole point is that an
+   * unclassifiable movement must not be quietly counted as a contribution. A
+   * repair tool is expected to refuse these rather than guess.
+   */
+  | "ambiguous";
+
+/** One ERC-20 Transfer, reduced to what classification needs. */
+export interface TransferLeg {
+  token: string;
+  from: string;
+  to: string;
+  /** Base units as a decimal string — never a float across this boundary. */
+  amountRaw: string;
+}
+
+export interface ClassifyInput {
+  /** The account whose book this is. */
+  account: string;
+  /** The USDG movement being classified. */
+  usdg: TransferLeg;
+  /** EVERY ERC-20 Transfer in the same transaction, including the one above. */
+  txLegs: readonly TransferLeg[];
+  /** The cash token's address, so a paired leg can be told from another USDG leg. */
+  usdgToken: string;
+  /** Addresses this system controls — other hosted smart accounts. */
+  knownAccounts?: readonly string[];
+  /** Protocol addresses, used only as a fallback signal. */
+  protocolAddresses?: readonly string[];
+}
+
+export interface Classification {
+  kind: CapitalKind;
+  /** The sentence an auditor reads. Always populated, including on the happy path. */
+  why: string;
+  /** The token that moved the other way, when this was a swap. */
+  pairedToken?: string;
+}
+
+const eq = (a: string | undefined, b: string | undefined) =>
+  (a ?? "").toLowerCase() === (b ?? "").toLowerCase();
+
+const has = (list: readonly string[] | undefined, a: string) =>
+  (list ?? []).some((x) => eq(x, a));
+
+/**
+ * Classify one USDG movement. PURE.
+ *
+ * Takes the whole transaction's legs rather than fetching them, so the rule can
+ * be tested against hand-built transactions and an auditor can re-run it against
+ * a receipt they fetched themselves.
+ */
+export function classifyUsdgMovement(input: ClassifyInput): Classification {
+  const { account, usdg, txLegs, usdgToken } = input;
+  const outbound = eq(usdg.from, account);
+  const inbound = eq(usdg.to, account);
+
+  if (outbound === inbound) {
+    return {
+      kind: "ambiguous",
+      why: outbound
+        ? "the account is both sender and recipient — a self-transfer says nothing about capital"
+        : "the movement does not touch this account at all",
+    };
+  }
+
+  const counterparty = outbound ? usdg.to : usdg.from;
+
+  // ── PRIMARY: did a DIFFERENT token move the other way in the same tx? ──────
+  //
+  // That is a swap, and it is the only signal here that does not depend on
+  // knowing the venue. Checked before everything else for exactly that reason.
+  const paired = txLegs.find(
+    (l) =>
+      !eq(l.token, usdgToken) &&
+      (outbound ? eq(l.to, account) : eq(l.from, account)) &&
+      BigInt(l.amountRaw || "0") > 0n,
+  );
+  if (paired) {
+    return {
+      kind: outbound ? "trade-out" : "trade-in",
+      pairedToken: paired.token,
+      why: outbound
+        ? `the same transaction moved ${paired.token} INTO the account — this USDG bought something, it did not leave`
+        : `the same transaction moved ${paired.token} OUT of the account — this USDG is sale proceeds, not a deposit`,
+    };
+  }
+
+  // ── Movements between accounts this system controls are not external. ─────
+  if (has(input.knownAccounts, counterparty)) {
+    return {
+      kind: "internal",
+      why: `the counterparty ${counterparty} is another account this system controls`,
+    };
+  }
+
+  // ── FALLBACK: a known protocol address with no paired leg. ────────────────
+  //
+  // Deliberately AMBIGUOUS rather than "trade". A USDG movement to a venue with
+  // nothing coming back is not a purchase that this function can see — it may be
+  // a failed route, a multi-transaction fill, or a venue this list has wrong.
+  // Calling it a trade would remove it from capital on the strength of a list;
+  // calling it capital would book a deposit that never happened.
+  if (has(input.protocolAddresses, counterparty)) {
+    return {
+      kind: "ambiguous",
+      why:
+        `the counterparty ${counterparty} is a known protocol address, but nothing moved the other way in ` +
+        `this transaction — it cannot be read as either capital or a completed trade`,
+    };
+  }
+
+  return {
+    kind: outbound ? "capital-out" : "capital-in",
+    why:
+      `${outbound ? "sent to" : "received from"} ${counterparty}, an address outside this system, with no ` +
+      `paired token movement — external capital`,
+  };
+}
+
+/** The three figures a contribution claim is made of, kept separately. */
+export interface CapitalTotals {
+  /** Σ external capital in. Non-zero even for an account that later withdrew it all. */
+  grossContributionsRaw: string;
+  /** Σ external capital out. */
+  grossWithdrawalsRaw: string;
+  /** in − out. May be zero while both figures above are large. */
+  netContributionsRaw: string;
+  /** Movements the classifier refused to decide. A repair must not touch these. */
+  ambiguous: number;
+  tradeLegs: number;
+  internal: number;
+}
+
+/**
+ * Total a classified set. PURE, and in BASE UNITS as decimal strings.
+ *
+ * Gross and net are kept apart because they answer different questions and
+ * collapsing them loses history: an account funded 1010 and withdrawn 1010 nets
+ * to zero, and "no contribution ever happened" is a different and false claim.
+ */
+export function totalCapital(
+  legs: readonly { amountRaw: string; classification: Classification }[],
+): CapitalTotals {
+  let inRaw = 0n;
+  let outRaw = 0n;
+  let ambiguous = 0;
+  let tradeLegs = 0;
+  let internal = 0;
+  for (const l of legs) {
+    const amt = BigInt(l.amountRaw || "0");
+    switch (l.classification.kind) {
+      case "capital-in":
+        inRaw += amt;
+        break;
+      case "capital-out":
+        outRaw += amt;
+        break;
+      case "trade-in":
+      case "trade-out":
+        tradeLegs += 1;
+        break;
+      case "internal":
+        internal += 1;
+        break;
+      case "ambiguous":
+        ambiguous += 1;
+        break;
+    }
+  }
+  return {
+    grossContributionsRaw: inRaw.toString(),
+    grossWithdrawalsRaw: outRaw.toString(),
+    netContributionsRaw: (inRaw - outRaw).toString(),
+    ambiguous,
+    tradeLegs,
+    internal,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,3 +12,4 @@ export * from "./mcp";
 export * from "./safe-url";
 export * from "./robinhood-oauth";
 export * from "./flow-evidence";
+export * from "./capital-classify";

--- a/worker/src/accounting-reconstruction.ts
+++ b/worker/src/accounting-reconstruction.ts
@@ -1,0 +1,278 @@
+/**
+ * THE DRY RUN: what the ledger says, what the chain says, and exactly what would
+ * change. Nothing here writes.
+ *
+ * The diagnosis established that quarantine-only is not a repair: all 363 hosted
+ * flow rows are `inferred` with no transaction, so removing them leaves every
+ * agent at zero contributions and the tool refuses on all of them. The rows that
+ * SHOULD be there were never written, because `chain-log` has no producer in
+ * production — the deposit scan defaults off.
+ *
+ * So a repair has two halves and an order that cannot be reversed:
+ *
+ *   1. INSERT the evidence-backed capital flows read off the chain.
+ *   2. THEN quarantine the legacy inferred rows.
+ *
+ * Backwards, there is a window in which an agent has no contribution record at
+ * all, and anything reading it in that window publishes the owner's principal as
+ * profit. Same reason the high-water mark and the phantom contribution had to be
+ * restored together rather than one at a time.
+ *
+ * PAPER IS NOT REAL. An account with no on-chain USDG history has contributed
+ * exactly nothing, whatever its simulated book says — and the simulated book is
+ * where the −59,000 / −26,000 / −7,900 USDG "contributions" came from. This
+ * refuses to manufacture a real capital row from a paper balance, and says so.
+ */
+import type { Db } from "./db";
+import { isEvidencedFlow } from "./accounting-scope";
+import type { AccountCapital } from "./chain-capital";
+
+/** A row the repair would INSERT, with the evidence that justifies it. */
+export interface ProposedFlowRow {
+  agentId: string;
+  epoch: number;
+  direction: "in" | "out";
+  /** Decimal USDG, matching the column's type. The raw figure travels beside it. */
+  amountUsdg: number;
+  amountRaw: string;
+  source: "chain-log";
+  txHash: string;
+  blockNumber: number;
+  logIndex: number;
+}
+
+/** A row the repair would MOVE to quarantine. Never deleted. */
+export interface ProposedQuarantine {
+  id: number;
+  direction: string;
+  amountUsdg: number;
+  source: string;
+  reason: string;
+}
+
+export interface AccountPlan {
+  smartAccount: string;
+  ownerAddress: string | null;
+  /** The orchestrator's key for this agent's child, which is neither of the above. */
+  tenant: string | null;
+  mode: string | null;
+  isPaper: boolean;
+  epoch: number;
+
+  /** On-chain USDG right now, decimal. Null when the balance could not be read. */
+  onchainCashUsdg: number | null;
+  navUsdg: number | null;
+
+  chainGrossInUsdg: number;
+  chainGrossOutUsdg: number;
+  chainNetUsdg: number;
+  chainTradeLegs: number;
+  chainAmbiguous: number;
+  chainComplete: boolean;
+
+  existingInferredRows: number;
+  existingInferredUsdg: number;
+  existingTotalUsdg: number;
+
+  insert: ProposedFlowRow[];
+  quarantine: ProposedQuarantine[];
+
+  contributionsAfterUsdg: number;
+  contributionsKnownAfter: boolean;
+  pnlPublishableAfter: boolean;
+
+  /** Set when this account must NOT be mutated. */
+  blocked: string | null;
+}
+
+const num = (v: unknown): number => {
+  if (v === null || v === undefined) return 0;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : 0;
+};
+
+/** Base units to decimal USDG. Six places, which is all the column can hold. */
+const toUsdg = (raw: string): number => Number(BigInt(raw)) / 1e6;
+
+/**
+ * Build the plan. PURE with respect to the world — it takes the chain scan and
+ * the database rows and decides, so the decision can be tested without either.
+ */
+export function planReconstruction(args: {
+  agents: readonly Record<string, unknown>[];
+  flows: readonly Record<string, unknown>[];
+  equityByAccountEpoch: ReadonlyMap<string, number>;
+  chain: ReadonlyMap<string, AccountCapital>;
+  onchainCash: ReadonlyMap<string, number>;
+  tenantByAccount?: ReadonlyMap<string, string>;
+}): AccountPlan[] {
+  const plans: AccountPlan[] = [];
+
+  for (const a of args.agents) {
+    const account = String(a.smart_account ?? "");
+    const key = account.toLowerCase();
+    const epoch = num(a.epoch) || 1;
+    const mode = typeof a.mode === "string" ? a.mode : null;
+    const cap = args.chain.get(key);
+
+    const rows = args.flows.filter(
+      (f) => String(f.agent_id ?? "").toLowerCase() === key && num(f.epoch) === epoch,
+    );
+    const inferredRows = rows.filter(
+      (f) => !(isEvidencedFlow(String(f.source ?? "")) || (typeof f.tx_hash === "string" && f.tx_hash)),
+    );
+    const signed = (f: Record<string, unknown>) =>
+      String(f.direction) === "in" ? num(f.amount_usdg) : -num(f.amount_usdg);
+
+    const chainIn = cap ? toUsdg(cap.totals.grossContributionsRaw) : 0;
+    const chainOut = cap ? toUsdg(cap.totals.grossWithdrawalsRaw) : 0;
+    const chainNet = cap ? toUsdg(cap.totals.netContributionsRaw) : 0;
+    const onchainCash = args.onchainCash.get(key) ?? null;
+
+    // PAPER IS ITS OWN DOMAIN. An account with no on-chain USDG history has
+    // contributed nothing real, and its simulated book must not be able to
+    // create, alter or offset a real capital-flow record. This is where that
+    // invariant is enforced for the repair; the runtime half lives in index.ts.
+    const noChainHistory = !cap || cap.movements.length === 0;
+    const isPaper = mode === "paper" || (noChainHistory && (onchainCash ?? 0) === 0);
+
+    const insert: ProposedFlowRow[] = [];
+    if (cap && cap.complete) {
+      for (const m of cap.movements) {
+        if (m.classification.kind !== "capital-in" && m.classification.kind !== "capital-out") continue;
+        insert.push({
+          agentId: account,
+          epoch,
+          direction: m.classification.kind === "capital-in" ? "in" : "out",
+          amountUsdg: toUsdg(m.amountRaw),
+          amountRaw: m.amountRaw,
+          source: "chain-log",
+          txHash: m.txHash,
+          blockNumber: m.blockNumber,
+          logIndex: m.logIndex,
+        });
+      }
+    }
+
+    const quarantine: ProposedQuarantine[] = inferredRows.map((f) => ({
+      id: num(f.id),
+      direction: String(f.direction),
+      amountUsdg: num(f.amount_usdg),
+      source: String(f.source ?? ""),
+      reason:
+        "inferred from a balance change, not read from a Transfer log — superseded by the chain-derived rows above",
+    }));
+
+    // WHAT WOULD BLOCK THE MUTATION. Each of these leaves the account in a state
+    // the repair cannot justify, so it is skipped rather than half-corrected.
+    let blocked: string | null = null;
+    if (!cap) {
+      blocked = "no chain scan result for this account";
+    } else if (!cap.complete) {
+      blocked =
+        "the chain scan did not cover every window or could not read a receipt — inserting a contribution " +
+        "history with holes in it would look authoritative while being incomplete";
+    } else if (cap.totals.ambiguous > 0) {
+      blocked = `${cap.totals.ambiguous} movement(s) could not be classified as capital or trade`;
+    } else if (isPaper && insert.length === 0 && inferredRows.length > 0) {
+      // Not an error — the correct outcome — but still a mutation that needs
+      // saying out loud, because it takes a visible figure to zero.
+      blocked = null;
+    }
+
+    const contributionsAfter = insert.reduce(
+      (s, r) => s + (r.direction === "in" ? r.amountUsdg : -r.amountUsdg),
+      0,
+    );
+    // Every surviving row is chain-log, so contributions are evidenced by
+    // construction — PROVIDED the scan was complete and unambiguous.
+    const known = blocked === null && cap !== undefined && cap.complete && cap.totals.ambiguous === 0;
+
+    plans.push({
+      smartAccount: account,
+      ownerAddress: typeof a.owner_address === "string" ? a.owner_address : null,
+      tenant: args.tenantByAccount?.get(key) ?? null,
+      mode,
+      isPaper,
+      epoch,
+      onchainCashUsdg: onchainCash,
+      navUsdg: args.equityByAccountEpoch.get(`${key}#${epoch}`) ?? null,
+      chainGrossInUsdg: chainIn,
+      chainGrossOutUsdg: chainOut,
+      chainNetUsdg: chainNet,
+      chainTradeLegs: cap?.totals.tradeLegs ?? 0,
+      chainAmbiguous: cap?.totals.ambiguous ?? 0,
+      chainComplete: cap?.complete ?? false,
+      existingInferredRows: inferredRows.length,
+      existingInferredUsdg: inferredRows.reduce((s, f) => s + signed(f), 0),
+      existingTotalUsdg: rows.reduce((s, f) => s + signed(f), 0),
+      insert,
+      quarantine,
+      contributionsAfterUsdg: contributionsAfter,
+      contributionsKnownAfter: known,
+      // A publishable P&L needs contributions AND a mark to measure against.
+      pnlPublishableAfter: known && (args.equityByAccountEpoch.get(`${key}#${epoch}`) ?? null) !== null,
+      blocked,
+    });
+  }
+
+  plans.sort((a, b) => Math.abs(b.existingInferredUsdg) - Math.abs(a.existingInferredUsdg));
+  return plans;
+}
+
+/**
+ * Render the plan. EVERY LINE IS SELF-CONTAINED, prefixed with the account.
+ *
+ * Railway's log aggregation reorders lines from a busy service, and the first
+ * version of this preview relied on grouping — so per-agent blocks arrived
+ * interleaved and a reader could not tell which rows belonged to which account.
+ * A preview whose meaning depends on line order is not a preview.
+ */
+export function reconstructionLines(plans: readonly AccountPlan[]): string[] {
+  const L: string[] = [];
+  const f = (n: number | null) => (n === null ? "unknown" : n.toFixed(6));
+  const tag = (p: AccountPlan) => p.smartAccount.slice(0, 10);
+
+  L.push(
+    `PLAN summary · ${plans.length} account(s) · ` +
+      `insert ${plans.reduce((s, p) => s + p.insert.length, 0)} chain-log row(s) · ` +
+      `quarantine ${plans.reduce((s, p) => s + p.quarantine.length, 0)} inferred row(s) · ` +
+      `blocked ${plans.filter((p) => p.blocked !== null).length}`,
+  );
+
+  for (const p of plans) {
+    const t = tag(p);
+    L.push(`${t} account ${p.smartAccount}`);
+    L.push(`${t} owner ${p.ownerAddress ?? "unknown"} · tenant ${p.tenant ?? "unknown"}`);
+    L.push(`${t} mode ${p.mode ?? "unknown"} · ${p.isPaper ? "PAPER" : "LIVE"} · epoch ${p.epoch}`);
+    L.push(`${t} on-chain USDG ${f(p.onchainCashUsdg)} · NAV(ledger) ${f(p.navUsdg)}`);
+    L.push(
+      `${t} chain: in ${f(p.chainGrossInUsdg)} out ${f(p.chainGrossOutUsdg)} NET ${f(p.chainNetUsdg)} · ` +
+        `trade legs ${p.chainTradeLegs} · ambiguous ${p.chainAmbiguous} · complete ${p.chainComplete}`,
+    );
+    L.push(
+      `${t} ledger now: ${p.existingInferredRows} inferred row(s) worth ${f(p.existingInferredUsdg)} · ` +
+        `total ${f(p.existingTotalUsdg)}`,
+    );
+    for (const r of p.insert) {
+      L.push(
+        `${t} INSERT ${r.direction} ${f(r.amountUsdg)} src chain-log tx ${r.txHash} blk ${r.blockNumber} log ${r.logIndex}`,
+      );
+    }
+    for (const q of p.quarantine) {
+      L.push(`${t} QUARANTINE id ${q.id} ${q.direction} ${f(q.amountUsdg)} src ${q.source}`);
+    }
+    L.push(
+      `${t} AFTER: contributions ${f(p.existingTotalUsdg)} -> ${f(p.contributionsAfterUsdg)} · ` +
+        `contributionsKnown ${p.contributionsKnownAfter} · PnL publishable ${p.pnlPublishableAfter}`,
+    );
+    if (p.blocked) L.push(`${t} BLOCKED — ${p.blocked}`);
+    if (p.isPaper && p.insert.length === 0 && p.quarantine.length > 0) {
+      L.push(
+        `${t} NOTE paper account with no on-chain USDG history — its real contributed capital is 0, and the ` +
+          `figure being removed came from its simulated book`,
+      );
+    }
+  }
+  return L;
+}

--- a/worker/src/chain-capital.ts
+++ b/worker/src/chain-capital.ts
@@ -1,0 +1,233 @@
+/**
+ * READING CONTRIBUTED CAPITAL OFF THE CHAIN, for every hosted account at once.
+ *
+ * This is the evidence source the ledger should always have had. `chain-log` has
+ * no producer in production — the deposit scan defaults off — so every one of the
+ * 363 flow rows in the shared database is `inferred` with no transaction, and a
+ * quarantine-only repair would leave every agent at zero contributions. The rows
+ * that SHOULD be there have to come from somewhere, and this is where.
+ *
+ * TWO PASSES, AND THE SECOND IS THE EXPENSIVE ONE.
+ *
+ *   1. One `eth_getLogs` sweep for the whole fleet. Topic positions accept an
+ *      OR-list, so twenty-four accounts cost what one costs.
+ *   2. One receipt per DISTINCT transaction the sweep touched. That is what
+ *      `classifyUsdgMovement` needs: a swap is two tokens moving opposite ways in
+ *      one transaction, and the second leg is only visible in the receipt.
+ *
+ * The receipts are what make this correct rather than merely cheap. Without them
+ * the canary's four router outflows read as a 6.666 USDG withdrawal, and its
+ * contributed capital comes out at 3.334 instead of 10.
+ *
+ * COVERAGE IS PART OF THE ANSWER. A sweep that could not read a window returns
+ * `complete: false`, and a caller that writes rows on an incomplete scan would
+ * be inserting a contribution history with holes in it — which is worse than the
+ * inferred rows it replaces, because it would look authoritative.
+ */
+import { classifyUsdgMovement, totalCapital, type CapitalTotals, type Classification, type TransferLeg } from "../../packages/core/src/index";
+
+/** `Transfer(address,address,uint256)`. */
+export const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+export interface RawChainLog {
+  address: string;
+  topics: string[];
+  data: string;
+  blockNumber: string;
+  transactionHash: string;
+  logIndex: string;
+}
+
+/** The JSON-RPC seam, injected so this is testable without a node. */
+export type RpcCall = (method: string, params: unknown[]) => Promise<unknown>;
+
+/** One classified USDG movement, with everything a durable row needs. */
+export interface CapitalMovement {
+  txHash: string;
+  blockNumber: number;
+  logIndex: number;
+  direction: "in" | "out";
+  /** Base units, decimal string. Never a float. */
+  amountRaw: string;
+  counterparty: string;
+  classification: Classification;
+}
+
+export interface AccountCapital {
+  account: string;
+  movements: CapitalMovement[];
+  totals: CapitalTotals;
+  /** False when any window or receipt could not be read. */
+  complete: boolean;
+  notes: string[];
+}
+
+const pad32 = (a: string) => "0x" + a.toLowerCase().replace(/^0x/, "").padStart(64, "0");
+const addrOfTopic = (t: string) => "0x" + t.slice(-40);
+const hexNum = (h: string) => Number(BigInt(h));
+
+/** Every ERC-20 Transfer in a receipt, as classification legs. */
+export function legsFromReceipt(logs: readonly RawChainLog[]): TransferLeg[] {
+  const out: TransferLeg[] = [];
+  for (const l of logs) {
+    if ((l.topics?.[0] ?? "").toLowerCase() !== TRANSFER_TOPIC) continue;
+    // A Transfer has exactly three topics; anything else is a different event
+    // that happens to share the signature's first word (ERC-721 has four).
+    if (l.topics.length !== 3) continue;
+    out.push({
+      token: l.address.toLowerCase(),
+      from: addrOfTopic(l.topics[1]!),
+      to: addrOfTopic(l.topics[2]!),
+      amountRaw: BigInt(l.data || "0x0").toString(),
+    });
+  }
+  return out;
+}
+
+/**
+ * Scan and classify every USDG movement for a set of accounts.
+ *
+ * `maxSpan` matches what the chain's public RPC actually serves; a window it
+ * refuses is retried at the same size rather than halved, because a rate limit
+ * is not a hint about the question (see inflight-reconcile for the incident that
+ * rule came from).
+ */
+export async function scanFleetCapital(
+  rpc: RpcCall,
+  args: {
+    accounts: readonly string[];
+    usdgToken: string;
+    fromBlock: bigint;
+    toBlock: bigint;
+    maxSpan?: bigint;
+    protocolAddresses?: readonly string[];
+    log?: (m: string) => void;
+  },
+): Promise<Map<string, AccountCapital>> {
+  const span = args.maxSpan ?? 1_000_000n;
+  const wanted = new Map(args.accounts.map((a) => [pad32(a), a]));
+  const topicList = [...wanted.keys()];
+  const usdg = args.usdgToken.toLowerCase();
+
+  const result = new Map<string, AccountCapital>();
+  for (const a of args.accounts) {
+    result.set(a.toLowerCase(), { account: a, movements: [], totals: totalCapital([]), complete: true, notes: [] });
+  }
+
+  const hits: RawChainLog[] = [];
+  let short = false;
+
+  for (const [pos, dir] of [
+    [1, "out"],
+    [2, "in"],
+  ] as const) {
+    for (let from = args.fromBlock; from <= args.toBlock; from += span) {
+      const to = from + span - 1n > args.toBlock ? args.toBlock : from + span - 1n;
+      const topics: (string | string[] | null)[] = [TRANSFER_TOPIC, null, null];
+      topics[pos] = topicList;
+      let ok = false;
+      for (let attempt = 0; attempt < 4 && !ok; attempt++) {
+        try {
+          const logs = (await rpc("eth_getLogs", [
+            {
+              address: args.usdgToken,
+              fromBlock: "0x" + from.toString(16),
+              toBlock: "0x" + to.toString(16),
+              topics: topics.slice(0, pos + 1),
+            },
+          ])) as RawChainLog[];
+          for (const l of logs) hits.push(l);
+          ok = true;
+        } catch (e) {
+          if (attempt === 3) {
+            short = true;
+            args.log?.(`window ${from}-${to} (${dir}) UNREAD after 4 attempts — coverage is short`);
+          } else {
+            await new Promise((r) => setTimeout(r, 700 * (attempt + 1)));
+          }
+        }
+      }
+    }
+  }
+
+  if (short) for (const v of result.values()) v.complete = false;
+
+  // ONE RECEIPT PER TRANSACTION, not per log. A swap puts both legs in the same
+  // receipt, and several accounts can appear in one batched transaction.
+  const byTx = new Map<string, RawChainLog[]>();
+  for (const l of hits) {
+    const k = l.transactionHash.toLowerCase();
+    const list = byTx.get(k);
+    if (list) list.push(l);
+    else byTx.set(k, [l]);
+  }
+
+  for (const [txHash, logsForTx] of byTx) {
+    let legs: TransferLeg[] = [];
+    let readable = true;
+    try {
+      const receipt = (await rpc("eth_getTransactionReceipt", [txHash])) as { logs?: RawChainLog[] } | null;
+      legs = legsFromReceipt(receipt?.logs ?? []);
+      if (!receipt) readable = false;
+    } catch {
+      readable = false;
+    }
+
+    for (const l of logsForTx) {
+      const fromAddr = addrOfTopic(l.topics[1]!);
+      const toAddr = addrOfTopic(l.topics[2]!);
+      for (const [padded, account] of wanted) {
+        const isOut = pad32(fromAddr) === padded;
+        const isIn = pad32(toAddr) === padded;
+        if (!isOut && !isIn) continue;
+        const entry = result.get(account.toLowerCase())!;
+        const usdgLeg: TransferLeg = {
+          token: l.address.toLowerCase(),
+          from: fromAddr,
+          to: toAddr,
+          amountRaw: BigInt(l.data || "0x0").toString(),
+        };
+        if (usdgLeg.token !== usdg) continue;
+
+        // A RECEIPT WE COULD NOT READ MAKES THE MOVEMENT AMBIGUOUS, not capital.
+        // Classifying on the single log we have would book every trade leg as a
+        // withdrawal, which is the exact error this module exists to avoid.
+        const classification: Classification = readable
+          ? classifyUsdgMovement({
+              account,
+              usdg: usdgLeg,
+              txLegs: legs.length ? legs : [usdgLeg],
+              usdgToken: usdg,
+              knownAccounts: args.accounts,
+              protocolAddresses: args.protocolAddresses,
+            })
+          : {
+              kind: "ambiguous",
+              why: `the receipt for ${txHash} could not be read, so the other half of this transaction is unknown`,
+            };
+        if (!readable) {
+          entry.complete = false;
+          entry.notes.push(`unreadable receipt ${txHash}`);
+        }
+
+        entry.movements.push({
+          txHash,
+          blockNumber: hexNum(l.blockNumber),
+          logIndex: hexNum(l.logIndex),
+          direction: isOut ? "out" : "in",
+          amountRaw: usdgLeg.amountRaw,
+          counterparty: isOut ? toAddr : fromAddr,
+          classification,
+        });
+      }
+    }
+  }
+
+  for (const entry of result.values()) {
+    entry.movements.sort((a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex);
+    entry.totals = totalCapital(
+      entry.movements.map((m) => ({ amountRaw: m.amountRaw, classification: m.classification })),
+    );
+  }
+  return result;
+}

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -45,11 +45,13 @@ import { getGrantStore } from "./grant-store";
 import { getIdentityStore } from "./identity-store";
 import { getSettingsStore } from "./settings-store";
 import { acquireTenantLease, type TenantLease } from "./tenant-lease";
-import { isHostedMode, type MerrymenSettings } from "../../packages/core/src/index";
+import { CASH, isHostedMode, type MerrymenSettings } from "../../packages/core/src/index";
 import { makePgDb, translateSchema, type Db } from "./db";
 import { BOOTSTRAP_FILE, BOOTSTRAP_SCHEMA_VERSION, type TenantBootstrapState } from "./bootstrap-state";
 import { deriveBootstrapAccounting } from "./bootstrap-source";
 import { diagnoseAccounting, diagnosisLines } from "./accounting-diagnosis";
+import { planReconstruction, reconstructionLines } from "./accounting-reconstruction";
+import { scanFleetCapital } from "./chain-capital";
 import { getFollowStore, MAX_FOLLOWS } from "./follow-store";
 import { MIRROR_STATE_DDL, mirrorTenant, openChildLedger } from "./ledger-mirror";
 import { writePeersForChild } from "./peer-files";
@@ -684,6 +686,86 @@ async function runAccountingDiagnosisIfAsked(): Promise<void> {
   }
 }
 
+/**
+ * The DRY RUN: chain truth joined to the ledger, and the exact mutation it
+ * implies. Read-only, off by default, and it writes nothing anywhere.
+ *
+ * It lives here rather than in the spike beside it for the same reason the
+ * diagnosis does — the shared Postgres answers only from inside Railway's
+ * private network — and because this half additionally needs the RPC, which the
+ * orchestrator already has configured.
+ */
+async function runReconstructionDryRunIfAsked(): Promise<void> {
+  if ((process.env.MERRYMEN_ACCOUNTING_RECONSTRUCT ?? "").trim() !== "1") return;
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    log("reconstruction dry run asked for, but there is no DATABASE_URL");
+    return;
+  }
+  try {
+    const shared = await makePgDb(url);
+    const agents = (await shared
+      .prepare("SELECT smart_account, owner_address, epoch, mode, hwm_usdg FROM agents")
+      .all()) as unknown as Record<string, unknown>[];
+    const flows = (await shared
+      .prepare("SELECT id, agent_id, epoch, direction, amount_usdg, source, tx_hash, at FROM flows")
+      .all()) as unknown as Record<string, unknown>[];
+    const equityRows = (await shared
+      .prepare("SELECT agent_id, epoch, equity_usdg, at FROM equity ORDER BY agent_id, epoch, at DESC, id DESC")
+      .all()) as unknown as Record<string, unknown>[];
+    const equityByAccountEpoch = new Map<string, number>();
+    for (const e of equityRows) {
+      const k = `${String(e.agent_id).toLowerCase()}#${Number(e.epoch ?? 1)}`;
+      if (!equityByAccountEpoch.has(k)) equityByAccountEpoch.set(k, Number(e.equity_usdg ?? 0));
+    }
+
+    const accounts = agents.map((a) => String(a.smart_account)).filter((a) => a.startsWith("0x"));
+    const rpcUrl = process.env.MERRYMEN_RPC_MAINNET ?? "https://rpc.mainnet.chain.robinhood.com";
+    let rpcId = 1;
+    const rpc = async (method: string, params: unknown[]): Promise<unknown> => {
+      const r = await fetch(rpcUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: rpcId++, method, params }),
+      });
+      const j = (await r.json()) as { result?: unknown; error?: { message?: string } };
+      if (j.error) throw new Error(j.error.message ?? "rpc error");
+      return j.result ?? null;
+    };
+
+    const usdgToken = String(CASH.USDG);
+    const head = BigInt((await rpc("eth_blockNumber", [])) as string);
+    log(`recon| scanning ${accounts.length} account(s) to block ${head}`);
+    const chain = await scanFleetCapital(rpc, {
+      accounts,
+      usdgToken,
+      fromBlock: 0n,
+      toBlock: head,
+      log: (m) => log(`recon| ${m}`),
+    });
+
+    // Current on-chain cash, one call each — the figure a NAV is built from.
+    const onchainCash = new Map<string, number>();
+    for (const a of accounts) {
+      try {
+        const hex = (await rpc("eth_call", [
+          { to: usdgToken, data: "0x70a08231" + a.toLowerCase().replace(/^0x/, "").padStart(64, "0") },
+          "latest",
+        ])) as string;
+        onchainCash.set(a.toLowerCase(), Number(BigInt(hex)) / 1e6);
+      } catch {
+        /* left absent, which renders as unknown rather than as zero */
+      }
+    }
+
+    const plans = planReconstruction({ agents, flows, equityByAccountEpoch, chain, onchainCash });
+    for (const line of reconstructionLines(plans)) log(`recon| ${line}`);
+  } catch (e) {
+    log(`reconstruction dry run failed — ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+
 async function mirrorLedgers(): Promise<void> {
   const url = process.env.DATABASE_URL;
   if (!url || children.size === 0) return;
@@ -832,6 +914,7 @@ export async function runOrchestrator(): Promise<void> {
   }
   log(`starting — home ${merrymenHome()}, worker ${WORKER_ENTRY}`);
   await runAccountingDiagnosisIfAsked();
+  await runReconstructionDryRunIfAsked();
 
   const stop = () => {
     stopping = true;


### PR DESCRIPTION
Prerequisite for any repair. **No mutation runs in this PR** — it adds the classifier, the scanner and a read-only dry run.

## Why quarantine-only cannot work

All **363** hosted flow rows are `inferred` with no transaction. `chain-log` has no producer in production because the deposit scan defaults off. Quarantining leaves every agent at zero contributions, and the tool correctly refuses on all of them.

## Reading the chain correctly is harder than it looks

Naive inbound/outbound reports the canary as 10 in and 6.666 out — a "withdrawal" that is really four TSLA purchases, giving contributed capital of **3.334 instead of 10**.

**An address allowlist was the obvious answer and it fails in the direction that matters.** The canary's four outflows go to `0xf4acdaee…`, which appears in *no* protocol table in this repo. Venues get added, pools are per-pair, and a merely stale list silently reclassifies trading as withdrawals.

So the primary test is **transaction context**: a swap moves two tokens in opposite directions within one transaction. If the transaction that took USDG out also put a different token *in*, that is a purchase, whoever the counterparty was. Nothing about a deposit looks like that.

The address list survives only as a weak secondary signal — and a protocol address with **nothing coming back** is `ambiguous`, not assumed. Removing it from capital on the strength of a list would be a guess; so would booking it as a withdrawal.

## Gross and net stay separate

An account funded 1010 and withdrawn 1010 nets to zero. "No contribution ever happened" is a different and false claim about it.

## Refusals are built in

- a receipt that cannot be read makes the movement `ambiguous`, never capital;
- an incomplete sweep **blocks** the account — a contribution history with holes would look authoritative while being wrong;
- a paper account with no on-chain USDG history has real contributed capital of **0**, and its simulated book may not manufacture one.

## Dry run

Behind `MERRYMEN_ACCOUNTING_RECONSTRUCT=1`, off by default, read-only. Every line is self-contained and prefixed with its account — Railway reorders lines from a busy service, and the first preview relied on grouping, so per-agent blocks arrived interleaved.

Also fixes `package.json`: `packages/*/src` was missing from the test glob, so the fourteen classifier tests would not have run in CI at all.

2083 tests, typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)