### PR TITLE
PR 1/3 — read-only repair preview, and a roster with no missing tenants

### DIFF
--- a/packages/core/src/capital-classify.ts
+++ b/packages/core/src/capital-classify.ts
@@ -39,6 +39,14 @@ export type CapitalKind =
   /** A movement between accounts this system controls. Not external capital. */
   | "internal"
   /**
+   * A movement to or from chain infrastructure — an EntryPoint, Permit2, a
+   * deployer. Definitionally not capital and not a trade, and separated from
+   * `internal` because "another of our accounts" and "the 4337 EntryPoint" are
+   * different facts that a reader of an audit trail should not have to guess
+   * between.
+   */
+  | "protocol"
+  /**
    * The classifier could not decide.
    *
    * A distinct arm rather than a default, because the whole point is that an
@@ -67,8 +75,44 @@ export interface ClassifyInput {
   usdgToken: string;
   /** Addresses this system controls — other hosted smart accounts. */
   knownAccounts?: readonly string[];
-  /** Protocol addresses, used only as a fallback signal. */
+  /**
+   * Trading venues: routers, pools, launchpads.
+   *
+   * A weak signal on purpose. A venue here with NOTHING paired is `ambiguous`,
+   * never "trade" — see the fallback below.
+   */
   protocolAddresses?: readonly string[];
+  /**
+   * Chain INFRASTRUCTURE — EntryPoints, Permit2, deployers, multicall.
+   *
+   * Unlike a venue, these are definitionally not the owner's capital whatever
+   * else the transaction did, so a movement to one is `protocol` rather than
+   * ambiguous. Kept as a separate list because the two lists carry different
+   * amounts of authority and merging them would silently promote a router.
+   */
+  systemAddresses?: readonly string[];
+}
+
+/**
+ * Everything needed to explain the verdict without re-fetching the transaction.
+ *
+ * A classification an auditor cannot re-derive is an assertion, and this whole
+ * exercise exists because assertions got believed. Carried on every arm,
+ * including the ones that decided nothing.
+ */
+export interface ClassificationEvidence {
+  counterparty: string;
+  direction: "in" | "out" | "self" | "none";
+  /** How many ERC-20 Transfers the deciding transaction contained. */
+  txLegCount: number;
+  /** The rule that fired, so two verdicts can be compared without reading prose. */
+  rule:
+    | "paired-token-movement"
+    | "known-account"
+    | "system-address"
+    | "venue-without-pair"
+    | "no-pair-external"
+    | "not-this-account";
 }
 
 export interface Classification {
@@ -77,6 +121,7 @@ export interface Classification {
   why: string;
   /** The token that moved the other way, when this was a swap. */
   pairedToken?: string;
+  evidence: ClassificationEvidence;
 }
 
 const eq = (a: string | undefined, b: string | undefined) =>
@@ -103,10 +148,17 @@ export function classifyUsdgMovement(input: ClassifyInput): Classification {
       why: outbound
         ? "the account is both sender and recipient — a self-transfer says nothing about capital"
         : "the movement does not touch this account at all",
+      evidence: {
+        counterparty: outbound ? usdg.to : "none",
+        direction: outbound ? "self" : "none",
+        txLegCount: txLegs.length,
+        rule: "not-this-account",
+      },
     };
   }
 
   const counterparty = outbound ? usdg.to : usdg.from;
+  const base = { counterparty, direction: outbound ? ("out" as const) : ("in" as const), txLegCount: txLegs.length };
 
   // ── PRIMARY: did a DIFFERENT token move the other way in the same tx? ──────
   //
@@ -125,6 +177,7 @@ export function classifyUsdgMovement(input: ClassifyInput): Classification {
       why: outbound
         ? `the same transaction moved ${paired.token} INTO the account — this USDG bought something, it did not leave`
         : `the same transaction moved ${paired.token} OUT of the account — this USDG is sale proceeds, not a deposit`,
+      evidence: { ...base, rule: "paired-token-movement" },
     };
   }
 
@@ -133,10 +186,26 @@ export function classifyUsdgMovement(input: ClassifyInput): Classification {
     return {
       kind: "internal",
       why: `the counterparty ${counterparty} is another account this system controls`,
+      evidence: { ...base, rule: "known-account" },
     };
   }
 
-  // ── FALLBACK: a known protocol address with no paired leg. ────────────────
+  // ── Chain infrastructure is never the owner's capital. ───────────────────
+  //
+  // An EntryPoint or a Permit2 is not a person who could have deposited, so this
+  // is safe to decide on the address alone — unlike a VENUE, where the same
+  // reasoning would silently reclassify a trade the primary test could not see.
+  // The two lists are separate so that promoting a router into this one has to
+  // be a deliberate act rather than an append.
+  if (has(input.systemAddresses, counterparty)) {
+    return {
+      kind: "protocol",
+      why: `the counterparty ${counterparty} is chain infrastructure, which cannot be a source of capital`,
+      evidence: { ...base, rule: "system-address" },
+    };
+  }
+
+  // ── FALLBACK: a known trading venue with no paired leg. ───────────────────
   //
   // Deliberately AMBIGUOUS rather than "trade". A USDG movement to a venue with
   // nothing coming back is not a purchase that this function can see — it may be
@@ -149,6 +218,7 @@ export function classifyUsdgMovement(input: ClassifyInput): Classification {
       why:
         `the counterparty ${counterparty} is a known protocol address, but nothing moved the other way in ` +
         `this transaction — it cannot be read as either capital or a completed trade`,
+      evidence: { ...base, rule: "venue-without-pair" },
     };
   }
 
@@ -157,6 +227,7 @@ export function classifyUsdgMovement(input: ClassifyInput): Classification {
     why:
       `${outbound ? "sent to" : "received from"} ${counterparty}, an address outside this system, with no ` +
       `paired token movement — external capital`,
+    evidence: { ...base, rule: "no-pair-external" },
   };
 }
 
@@ -172,6 +243,8 @@ export interface CapitalTotals {
   ambiguous: number;
   tradeLegs: number;
   internal: number;
+  /** Movements to chain infrastructure. Never capital, never a trade. */
+  protocol: number;
 }
 
 /**
@@ -189,6 +262,7 @@ export function totalCapital(
   let ambiguous = 0;
   let tradeLegs = 0;
   let internal = 0;
+  let protocol = 0;
   for (const l of legs) {
     const amt = BigInt(l.amountRaw || "0");
     switch (l.classification.kind) {
@@ -205,6 +279,9 @@ export function totalCapital(
       case "internal":
         internal += 1;
         break;
+      case "protocol":
+        protocol += 1;
+        break;
       case "ambiguous":
         ambiguous += 1;
         break;
@@ -217,5 +294,6 @@ export function totalCapital(
     ambiguous,
     tradeLegs,
     internal,
+    protocol,
   };
 }

--- a/worker/src/accounting-preview.test.ts
+++ b/worker/src/accounting-preview.test.ts
@@ -1,0 +1,301 @@
+/**
+ * THE PREVIEW, AND THE PROOF THAT IT IS ONLY A PREVIEW.
+ *
+ * Two things are pinned here. The first is arithmetic: the canary's numbers, in
+ * the four-part shape the report is read in. The second is structural, and it is
+ * the one that matters before a production run — this module cannot write,
+ * because it has no way to. The last test reads the file and says so.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import {
+  accountPreviewLines,
+  parsePreviewRequest,
+  previewAccount,
+  rosterLines,
+  rosterOutcome,
+  runPreview,
+} from "./accounting-preview";
+import type { AccountPlan } from "./accounting-reconstruction";
+
+const CANARY = "0x3E34E58e1E1b52A6cbE2Bd7C6e0C1B1e1e1e1e1e";
+const PAPER = "0x00000000000000000000000000000000000000a1";
+const TX = "0xfund000000000000000000000000000000000000000000000000000000000000";
+
+const plan = (over: Partial<AccountPlan> & { smartAccount: string }): AccountPlan => ({
+  ownerAddress: null,
+  tenant: null,
+  mode: "live",
+  isPaper: false,
+  epoch: 1,
+  onchainCashUsdg: null,
+  navUsdg: null,
+  chainGrossInUsdg: 0,
+  chainGrossOutUsdg: 0,
+  chainNetUsdg: 0,
+  chainTradeLegs: 0,
+  chainAmbiguous: 0,
+  chainComplete: true,
+  existingInferredRows: 0,
+  existingInferredUsdg: 0,
+  existingTotalUsdg: 0,
+  insert: [],
+  quarantine: [],
+  contributionsKnownBefore: false,
+  contributionsAfterUsdg: 0,
+  contributionsKnownAfter: false,
+  pnlPublishableAfter: false,
+  blocked: null,
+  ...over,
+});
+
+/** The canary exactly as the ledger and the chain have it. */
+const canaryPlan = () =>
+  plan({
+    smartAccount: CANARY,
+    tenant: "0xa233a3",
+    onchainCashUsdg: 3.334,
+    navUsdg: 9.884,
+    chainGrossInUsdg: 10,
+    chainGrossOutUsdg: 0,
+    chainNetUsdg: 10,
+    chainTradeLegs: 4,
+    chainAmbiguous: 0,
+    chainComplete: true,
+    existingInferredRows: 3,
+    existingInferredUsdg: 30,
+    existingTotalUsdg: 30,
+    contributionsKnownBefore: false,
+    insert: [
+      {
+        agentId: CANARY,
+        epoch: 1,
+        direction: "in",
+        amountUsdg: 10,
+        amountRaw: "10000000",
+        source: "chain-log",
+        txHash: TX,
+        blockNumber: 4_100_000,
+        logIndex: 0,
+      },
+    ],
+    quarantine: [1, 2, 3].map((id) => ({
+      id,
+      direction: "in",
+      amountUsdg: 10,
+      source: "inferred",
+      reason: "inferred from a balance change",
+    })),
+    contributionsAfterUsdg: 10,
+    contributionsKnownAfter: true,
+    pnlPublishableAfter: true,
+  });
+
+// ── THE MODE ───────────────────────────────────────────────────────────────
+
+describe("what this build will accept", () => {
+  it("does nothing at all unless asked", () => {
+    assert.equal(parsePreviewRequest({}), null);
+    assert.equal(parsePreviewRequest({ MERRYMEN_REPAIR: "" }), null);
+  });
+
+  it("previews on dry-run", () => {
+    const r = parsePreviewRequest({ MERRYMEN_REPAIR: "dry-run" })!;
+    assert.equal(r.kind, "preview");
+  });
+
+  it("REFUSES a mutation rather than quietly downgrading it", () => {
+    // Silently turning commit into a dry run would leave an operator reading a
+    // preview while believing they had repaired production.
+    for (const mode of ["commit", "verify-only", "1", "true", "COMMIT"]) {
+      const r = parsePreviewRequest({ MERRYMEN_REPAIR: mode })!;
+      assert.equal(r.kind, "refused", `${mode} must be refused, not reinterpreted`);
+      assert.match(r.kind === "refused" ? r.why : "", /no mutation path/);
+    }
+  });
+
+  it("carries the selected account and a timestamped run id", () => {
+    const r = parsePreviewRequest(
+      { MERRYMEN_REPAIR: "dry-run", MERRYMEN_REPAIR_ACCOUNT: ` ${CANARY} ` },
+      0,
+    )!;
+    assert.equal(r.kind === "preview" ? r.account : null, CANARY);
+    assert.match(r.kind === "preview" ? r.runId : "", /^run-1970-01-01/);
+  });
+});
+
+// ── THE THREE OUTCOMES, TOTAL OVER EVERY ACCOUNT ───────────────────────────
+
+describe("every tenant is classified", () => {
+  it("puts an evidence-backed account in EVIDENCE-BACKED-REPAIR", () => {
+    assert.equal(rosterOutcome(canaryPlan()), "EVIDENCE-BACKED-REPAIR");
+  });
+
+  it("puts an account with no chain history in NO-CHAIN-HISTORY", () => {
+    assert.equal(rosterOutcome(plan({ smartAccount: PAPER, isPaper: true })), "NO-CHAIN-HISTORY");
+    // Including one whose simulated rows are being removed — there is still no
+    // chain history behind it, which is the fact the label names.
+    assert.equal(
+      rosterOutcome(
+        plan({
+          smartAccount: PAPER,
+          isPaper: true,
+          quarantine: [{ id: 9, direction: "out", amountUsdg: 59_000, source: "inferred", reason: "paper" }],
+        }),
+      ),
+      "NO-CHAIN-HISTORY",
+    );
+  });
+
+  it("puts an unresolvable account in BLOCKED-AMBIGUOUS, even when it has evidence to insert", () => {
+    // Blocked is checked FIRST. An account the classifier could not resolve must
+    // not read as a repair merely because it also has rows to insert.
+    const p = canaryPlan();
+    p.blocked = "2 movement(s) could not be classified as capital or trade";
+    assert.equal(rosterOutcome(p), "BLOCKED-AMBIGUOUS");
+  });
+
+  it("tallies the whole fleet, and the tally adds up", () => {
+    const plans = [
+      canaryPlan(),
+      plan({ smartAccount: PAPER, isPaper: true }),
+      plan({ smartAccount: "0xbbb", blocked: "ambiguous" }),
+      plan({ smartAccount: "0xccc" }),
+    ];
+    const previews = runPreview(plans, { account: null });
+    const total = rosterLines(previews).find((l) => l.startsWith("ROSTER TOTAL"))!;
+    assert.match(total, /4 account\(s\)/);
+    assert.match(total, /NO-CHAIN-HISTORY 2/);
+    assert.match(total, /EVIDENCE-BACKED-REPAIR 1/);
+    assert.match(total, /BLOCKED-AMBIGUOUS 1/);
+    assert.equal(previews.length, plans.length, "no account is dropped from the roster");
+  });
+
+  it("classifies an account --account did not select, rather than omitting it", () => {
+    // "Not in the mutation list" must never be readable as "safe".
+    const previews = runPreview([canaryPlan(), plan({ smartAccount: PAPER, isPaper: true })], {
+      account: CANARY,
+    });
+    assert.equal(previews.length, 2);
+    assert.equal(previews[1]!.selected, false);
+    assert.equal(previews[1]!.outcome, "NO-CHAIN-HISTORY");
+  });
+});
+
+// ── THE CANARY'S NUMBERS ───────────────────────────────────────────────────
+
+describe("the canary preview", () => {
+  const p = previewAccount(canaryPlan(), CANARY);
+
+  it("reports the ledger's 30 USDG as what is there now, unevidenced", () => {
+    assert.equal(p.contributionsBeforeUsdg, 30);
+    assert.equal(p.contributionsKnownBefore, false);
+    assert.equal(p.quarantines, 3);
+  });
+
+  it("reports the chain's 10 USDG as what would be left, evidenced", () => {
+    assert.equal(p.inserts, 1);
+    assert.equal(p.grossContributionsAfterUsdg, 10);
+    assert.equal(p.grossWithdrawalsAfterUsdg, 0);
+    assert.equal(p.contributionsAfterUsdg, 10);
+    assert.equal(p.contributionsKnownAfter, true);
+  });
+
+  it("does NOT count the four router legs as withdrawals", () => {
+    // The whole reason the classifier exists. Direction-only netting gives
+    // 3.334 — the cash balance — and calls it contributed capital.
+    assert.notEqual(p.contributionsAfterUsdg, 3.334);
+    assert.equal(p.grossWithdrawalsAfterUsdg, 0);
+  });
+
+  it("renders the four parts, each line carrying the account", () => {
+    const lines = accountPreviewLines(canaryPlan(), p);
+    const body = lines.join("\n");
+    assert.ok(
+      lines.every((l) => l.startsWith(CANARY.slice(0, 10))),
+      "Railway reorders lines from a busy service, so each must stand alone",
+    );
+    for (const heading of ["BEFORE", "CHAIN EVIDENCE", "PROPOSED", "AFTER"]) {
+      assert.ok(body.includes(` ${heading}`), `missing ${heading}`);
+    }
+    assert.match(body, /3 inferred inbound row\(s\) × 10\.000000 USDG/);
+    assert.match(body, /contribution total = 30\.000000 USDG/);
+    assert.match(body, /contributionsKnown = false/);
+    assert.match(body, /1 external inbound = 10\.000000 USDG/);
+    assert.match(body, /4 router\/trade leg\(s\) excluded from capital flows/);
+    assert.match(body, /ambiguous = 0/);
+    assert.match(body, /insert 1 chain-log contribution row\(s\)/);
+    assert.match(body, /quarantine 3 legacy row\(s\) — moved, never deleted/);
+    assert.match(body, /gross contributions = 10\.000000/);
+    assert.match(body, /gross withdrawals = 0\.000000/);
+    assert.match(body, /net contributions = 10\.000000/);
+    assert.match(body, /contributionsKnown = true/);
+  });
+});
+
+describe("a funded-then-withdrawn account", () => {
+  it("keeps gross apart from net, because net zero is not 'never funded'", () => {
+    const p = previewAccount(
+      plan({
+        smartAccount: "0xddd",
+        insert: [
+          { agentId: "0xddd", epoch: 1, direction: "in", amountUsdg: 1010, amountRaw: "1010000000", source: "chain-log", txHash: "0x1", blockNumber: 1, logIndex: 0 },
+          { agentId: "0xddd", epoch: 1, direction: "out", amountUsdg: 1010, amountRaw: "1010000000", source: "chain-log", txHash: "0x2", blockNumber: 2, logIndex: 0 },
+        ],
+        contributionsAfterUsdg: 0,
+        contributionsKnownAfter: true,
+      }),
+      null,
+    );
+    assert.equal(p.grossContributionsAfterUsdg, 1010);
+    assert.equal(p.grossWithdrawalsAfterUsdg, 1010);
+    assert.equal(p.contributionsAfterUsdg, 0);
+    assert.equal(p.outcome, "EVIDENCE-BACKED-REPAIR");
+  });
+});
+
+// ── THE STRUCTURAL GUARANTEE ───────────────────────────────────────────────
+
+describe("read-only by construction", () => {
+  // COMMENTS STRIPPED FIRST. The module's own header explains what it will not
+  // do, and matching on prose would make the check fail for saying so — a test
+  // that punishes documentation. What is under review is the CODE.
+  const src = readFileSync(new URL("./accounting-preview.ts", import.meta.url), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/[^\n]*/g, "");
+
+  it("has no write SQL anywhere in it", () => {
+    // The claim under review is "MERRYMEN_REPAIR=dry-run is genuinely read-only".
+    // A gated mutation path would need a reviewer to trust the gate. An absent
+    // one needs nothing, and this is what makes the absence checkable.
+    for (const verb of [/\bINSERT\s+INTO\b/i, /\bUPDATE\s+\w+\s+SET\b/i, /\bDELETE\s+FROM\b/i, /\bDROP\s+/i, /\bALTER\s+TABLE\b/i]) {
+      assert.doesNotMatch(src, verb, `found write SQL matching ${verb}`);
+    }
+  });
+
+  it("is never handed a database", () => {
+    // Stronger than "does not write": it has nothing to write TO. No Db import,
+    // no prepare/run/exec call, no parameter that could carry a connection.
+    assert.doesNotMatch(src, /from "\.\/db"/, "imports the database seam");
+    assert.doesNotMatch(src, /\bDb\b/, "mentions the Db type");
+    assert.doesNotMatch(src, /\.prepare\(/, "prepares a statement");
+    assert.doesNotMatch(src, /\.exec\(/, "executes SQL");
+    assert.doesNotMatch(src, /\.tx\(/, "opens a transaction");
+  });
+});
+
+describe("the run id is a real timestamp in production", () => {
+  it("is not left at the pure-function default", () => {
+    // `parsePreviewRequest` may not read a clock, so its `now` defaults to 0 for
+    // the tests above. Leaving that default in place at the call site stamped
+    // every production run `run-1970-01-01T00-00-00-000Z` — the one property the
+    // id exists to provide, absent exactly where it was needed. The unit tests
+    // could not catch it because they pass `now` explicitly, so the pin is on
+    // the CALL SITE.
+    const src = readFileSync(new URL("./orchestrator.ts", import.meta.url), "utf8");
+    const call = src.match(/parsePreviewRequest\([^)]*\)/);
+    assert.ok(call, "the orchestrator still calls parsePreviewRequest");
+    assert.match(call[0], /Date\.now\(\)/, "and hands it a clock");
+  });
+});

--- a/worker/src/accounting-preview.ts
+++ b/worker/src/accounting-preview.ts
@@ -1,0 +1,235 @@
+/**
+ * WHAT A REPAIR WOULD DO. Nothing here can do it.
+ *
+ * READ-ONLY BY CONSTRUCTION, not by a flag. This module is never handed a `Db`,
+ * imports no database type, and contains no INSERT, UPDATE or DELETE — so
+ * "MERRYMEN_REPAIR=dry-run is genuinely read-only" is a property a reviewer can
+ * check by reading one file, rather than a promise about how a branch is
+ * exercised. A gated mutation path would need the reader to trust the gate; an
+ * absent one needs nothing.
+ *
+ * Every figure below is computed from an `AccountPlan` the planner already
+ * derived from rows the orchestrator read. The plan is the only input; there is
+ * no second source of truth to disagree with.
+ *
+ * The mutation that consumes these plans lands separately, and until it does
+ * this build cannot repair anything at all — which is what `parsePreviewRequest`
+ * says out loud when it is asked to.
+ */
+import type { AccountPlan } from "./accounting-reconstruction";
+
+/**
+ * WHERE EACH TENANT LANDED. Three arms, closed, and every account gets exactly
+ * one — the report is meant to be read as "all 24 are accounted for", which it
+ * cannot be if an account can fall through.
+ */
+export type RosterOutcome = "NO-CHAIN-HISTORY" | "EVIDENCE-BACKED-REPAIR" | "BLOCKED-AMBIGUOUS";
+
+export type PreviewRequest =
+  /** A dry run was asked for. There is no other kind in this build. */
+  | { kind: "preview"; account: string | null; runId: string }
+  /**
+   * Something this build cannot do was asked for.
+   *
+   * A DISTINCT ARM RATHER THAN A SILENT DOWNGRADE. Quietly turning
+   * `MERRYMEN_REPAIR=commit` into a dry run would leave an operator reading a
+   * preview while believing they had repaired production — the same class of
+   * confident-wrong-state this whole effort is about. It refuses and says why.
+   */
+  | { kind: "refused"; why: string };
+
+/**
+ * Read the request off an environment. PURE.
+ *
+ * Environment rather than argv because this runs INSIDE the orchestrator: the
+ * shared Postgres is on Railway's private network with no public proxy, so
+ * nothing on a laptop can reach it and a command-line tool would have nothing to
+ * connect to. The variable names mirror the eventual flags one-for-one:
+ *
+ *   MERRYMEN_REPAIR=dry-run              --dry-run   (the only mode here)
+ *   MERRYMEN_REPAIR_ACCOUNT=0x…          --account <smartAccount>
+ *   MERRYMEN_REPAIR_RUN_ID=…             --run-id
+ */
+export function parsePreviewRequest(
+  env: Record<string, string | undefined>,
+  now = 0,
+): PreviewRequest | null {
+  const raw = (env.MERRYMEN_REPAIR ?? "").trim().toLowerCase();
+  if (!raw) return null;
+  if (raw !== "dry-run") {
+    return {
+      kind: "refused",
+      why:
+        `MERRYMEN_REPAIR=${raw} asks for something this build does not contain. There is no mutation path ` +
+        `here at all — no INSERT, no UPDATE, no DELETE — so nothing was written and nothing was previewed. ` +
+        `Use dry-run.`,
+    };
+  }
+  return {
+    kind: "preview",
+    account: (env.MERRYMEN_REPAIR_ACCOUNT ?? "").trim() || null,
+    // Timestamped rather than random so a preview can be placed in time from its
+    // own log line. `now` is injected because a pure function may not read a clock.
+    runId: (env.MERRYMEN_REPAIR_RUN_ID ?? "").trim() || `run-${new Date(now).toISOString().replace(/[:.]/g, "-")}`,
+  };
+}
+
+/** Which of the three outcomes this account falls into. Total over every plan. */
+export function rosterOutcome(plan: AccountPlan): RosterOutcome {
+  // BLOCKED FIRST. An account the classifier could not resolve must not be
+  // reported as a repair merely because it also has rows to insert.
+  if (plan.blocked !== null) return "BLOCKED-AMBIGUOUS";
+  if (plan.insert.length > 0) return "EVIDENCE-BACKED-REPAIR";
+  return "NO-CHAIN-HISTORY";
+}
+
+export interface AccountPreview {
+  account: string;
+  tenant: string | null;
+  outcome: RosterOutcome;
+  /** False when --account named someone else. Still classified, never omitted. */
+  selected: boolean;
+  isPaper: boolean;
+  epoch: number;
+
+  inserts: number;
+  quarantines: number;
+
+  /** What the ledger holds now, and what it would hold after. Decimal USDG. */
+  contributionsBeforeUsdg: number;
+  contributionsAfterUsdg: number;
+  contributionsKnownBefore: boolean;
+  contributionsKnownAfter: boolean;
+
+  /** Kept apart: an account funded 1010 and withdrawn 1010 nets to zero, and
+   *  "no contribution ever happened" is a different and false claim. */
+  grossContributionsAfterUsdg: number;
+  grossWithdrawalsAfterUsdg: number;
+
+  /** Why this account is not being mutated, when it is not. */
+  blocked: string | null;
+}
+
+const round6 = (n: number) => Number(n.toFixed(6));
+
+/** What a repair would do to one account. PURE — it is handed a plan, not a database. */
+export function previewAccount(plan: AccountPlan, selectedAccount: string | null): AccountPreview {
+  let grossIn = 0;
+  let grossOut = 0;
+  for (const r of plan.insert) {
+    if (r.direction === "in") grossIn += r.amountUsdg;
+    else grossOut += r.amountUsdg;
+  }
+  return {
+    account: plan.smartAccount,
+    tenant: plan.tenant,
+    outcome: rosterOutcome(plan),
+    selected: !selectedAccount || selectedAccount.toLowerCase() === plan.smartAccount.toLowerCase(),
+    isPaper: plan.isPaper,
+    epoch: plan.epoch,
+    inserts: plan.insert.length,
+    quarantines: plan.quarantine.length,
+    contributionsBeforeUsdg: round6(plan.existingTotalUsdg),
+    contributionsAfterUsdg: round6(plan.contributionsAfterUsdg),
+    contributionsKnownBefore: plan.contributionsKnownBefore,
+    contributionsKnownAfter: plan.contributionsKnownAfter,
+    grossContributionsAfterUsdg: round6(grossIn),
+    grossWithdrawalsAfterUsdg: round6(grossOut),
+    blocked: plan.blocked,
+  };
+}
+
+/**
+ * THE ROSTER. One line per account, and a tally that must add up to the fleet.
+ *
+ * Every line is self-contained and carries the account, because Railway's log
+ * aggregation reorders lines from a busy service — a report whose meaning
+ * depends on line order is not a report.
+ */
+export function rosterLines(previews: readonly AccountPreview[]): string[] {
+  const L: string[] = [];
+  const tally: Record<RosterOutcome, number> = {
+    "NO-CHAIN-HISTORY": 0,
+    "EVIDENCE-BACKED-REPAIR": 0,
+    "BLOCKED-AMBIGUOUS": 0,
+  };
+  for (const p of previews) {
+    tally[p.outcome] += 1;
+    L.push(
+      `ROSTER ${p.account} tenant ${p.tenant ?? "unknown"} · ${p.outcome} · ` +
+        `${p.isPaper ? "PAPER" : "LIVE"} epoch ${p.epoch} · insert ${p.inserts} quarantine ${p.quarantines} · ` +
+        `contributions ${p.contributionsBeforeUsdg.toFixed(6)} -> ${p.contributionsAfterUsdg.toFixed(6)} · ` +
+        `known ${p.contributionsKnownBefore} -> ${p.contributionsKnownAfter}` +
+        (p.blocked ? ` · BLOCKED: ${p.blocked}` : ""),
+    );
+  }
+  L.push(
+    `ROSTER TOTAL ${previews.length} account(s) — ` +
+      `NO-CHAIN-HISTORY ${tally["NO-CHAIN-HISTORY"]} · ` +
+      `EVIDENCE-BACKED-REPAIR ${tally["EVIDENCE-BACKED-REPAIR"]} · ` +
+      `BLOCKED-AMBIGUOUS ${tally["BLOCKED-AMBIGUOUS"]}`,
+  );
+  return L;
+}
+
+/**
+ * The four-part account preview: what the ledger says, what the chain says, what
+ * would change, and what would be left.
+ *
+ * Tagged per line rather than emitted as a block, for the log-reordering reason
+ * above — the tag is what lets the four parts be reassembled.
+ */
+export function accountPreviewLines(plan: AccountPlan, p: AccountPreview): string[] {
+  const t = plan.smartAccount.slice(0, 10);
+  const L: string[] = [`${t} ┌── PREVIEW ${plan.smartAccount} · tenant ${plan.tenant ?? "unknown"} · ${p.outcome}`];
+
+  L.push(`${t} BEFORE`);
+  // Grouped by (direction, amount) so "the same 10 USDG booked three times"
+  // reads as what it is rather than as three unrelated rows.
+  const groups = new Map<string, { n: number; direction: string; amount: number; source: string }>();
+  for (const q of plan.quarantine) {
+    const k = `${q.source}|${q.direction}|${q.amountUsdg.toFixed(6)}`;
+    const g = groups.get(k);
+    if (g) g.n += 1;
+    else groups.set(k, { n: 1, direction: q.direction, amount: q.amountUsdg, source: q.source });
+  }
+  if (groups.size === 0) L.push(`${t}   no rows to remove`);
+  for (const g of groups.values()) {
+    L.push(
+      `${t}   ${g.n} ${g.source} ${g.direction === "in" ? "inbound" : "outbound"} row(s) × ${g.amount.toFixed(6)} USDG`,
+    );
+  }
+  L.push(`${t}   contribution total = ${p.contributionsBeforeUsdg.toFixed(6)} USDG`);
+  L.push(`${t}   contributionsKnown = ${p.contributionsKnownBefore}`);
+
+  L.push(`${t} CHAIN EVIDENCE`);
+  const ins = plan.insert.filter((r) => r.direction === "in").length;
+  const outs = plan.insert.filter((r) => r.direction === "out").length;
+  L.push(`${t}   ${ins} external inbound = ${p.grossContributionsAfterUsdg.toFixed(6)} USDG`);
+  L.push(`${t}   ${outs} external outbound = ${p.grossWithdrawalsAfterUsdg.toFixed(6)} USDG`);
+  L.push(`${t}   ${plan.chainTradeLegs} router/trade leg(s) excluded from capital flows`);
+  L.push(`${t}   ambiguous = ${plan.chainAmbiguous} · scan complete = ${plan.chainComplete}`);
+
+  L.push(`${t} PROPOSED`);
+  L.push(`${t}   insert ${p.inserts} chain-log contribution row(s)`);
+  L.push(`${t}   quarantine ${p.quarantines} legacy row(s) — moved, never deleted`);
+  if (!p.selected) L.push(`${t}   NOT SELECTED by --account: nothing would run for this tenant`);
+  if (p.blocked) L.push(`${t}   BLOCKED — ${p.blocked}`);
+
+  L.push(`${t} AFTER`);
+  L.push(`${t}   gross contributions = ${p.grossContributionsAfterUsdg.toFixed(6)}`);
+  L.push(`${t}   gross withdrawals = ${p.grossWithdrawalsAfterUsdg.toFixed(6)}`);
+  L.push(`${t}   net contributions = ${p.contributionsAfterUsdg.toFixed(6)}`);
+  L.push(`${t}   contributionsKnown = ${p.contributionsKnownAfter}`);
+  L.push(`${t}   PnL publishable = ${plan.pnlPublishableAfter}`);
+  L.push(`${t} └── END PREVIEW ${plan.smartAccount}`);
+  return L;
+}
+
+/** Preview every account. PURE, and the fleet total is part of the answer. */
+export function runPreview(
+  plans: readonly AccountPlan[],
+  req: { account: string | null },
+): AccountPreview[] {
+  return plans.map((p) => previewAccount(p, req.account));
+}

--- a/worker/src/accounting-reconstruction.ts
+++ b/worker/src/accounting-reconstruction.ts
@@ -77,6 +77,16 @@ export interface AccountPlan {
   insert: ProposedFlowRow[];
   quarantine: ProposedQuarantine[];
 
+  /**
+   * What the ledger CURRENTLY claims about this account's capital, read from the
+   * durable `agents.contributions_known` flag rather than re-derived here.
+   *
+   * That flag is what the web tier publishes against, so it is the honest
+   * "before" figure — re-deriving it from the rows would produce a number that
+   * agrees with the repair's arithmetic while disagreeing with what an owner is
+   * actually being shown, which is the wrong half of the comparison to get right.
+   */
+  contributionsKnownBefore: boolean;
   contributionsAfterUsdg: number;
   contributionsKnownAfter: boolean;
   pnlPublishableAfter: boolean;
@@ -208,6 +218,10 @@ export function planReconstruction(args: {
       existingTotalUsdg: rows.reduce((s, f) => s + signed(f), 0),
       insert,
       quarantine,
+      // NULL is not false here — it is "the worker has never written a verdict"
+      // — but both mean the same thing to a reader: nothing on record licenses
+      // publishing a percentage. Only an explicit 1 counts as known.
+      contributionsKnownBefore: num(a.contributions_known) === 1,
       contributionsAfterUsdg: contributionsAfter,
       contributionsKnownAfter: known,
       // A PUBLISHABLE P&L NEEDS A DENOMINATOR, not just an evidenced one.

--- a/worker/src/chain-capital.ts
+++ b/worker/src/chain-capital.ts
@@ -204,6 +204,12 @@ export async function scanFleetCapital(
           : {
               kind: "ambiguous",
               why: `the receipt for ${txHash} could not be read, so the other half of this transaction is unknown`,
+              evidence: {
+                counterparty: isOut ? toAddr : fromAddr,
+                direction: isOut ? "out" : "in",
+                txLegCount: 0,
+                rule: "not-this-account",
+              },
             };
         if (!readable) {
           entry.complete = false;

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -51,6 +51,8 @@ import { BOOTSTRAP_FILE, BOOTSTRAP_SCHEMA_VERSION, type TenantBootstrapState } f
 import { deriveBootstrapAccounting } from "./bootstrap-source";
 import { diagnoseAccounting, diagnosisLines } from "./accounting-diagnosis";
 import { planReconstruction, reconstructionLines } from "./accounting-reconstruction";
+import type { AccountPlan } from "./accounting-reconstruction";
+import { accountPreviewLines, parsePreviewRequest, rosterLines, runPreview } from "./accounting-preview";
 import { scanFleetCapital } from "./chain-capital";
 import { getFollowStore, MAX_FOLLOWS } from "./follow-store";
 import { MIRROR_STATE_DDL, mirrorTenant, openChildLedger } from "./ledger-mirror";
@@ -704,9 +706,61 @@ async function runReconstructionDryRunIfAsked(): Promise<void> {
   }
   try {
     const shared = await makePgDb(url);
-    const agents = (await shared
-      .prepare("SELECT smart_account, owner_address, epoch, mode, hwm_usdg FROM agents")
+    const ledgerAgents = (await shared
+      .prepare("SELECT smart_account, owner_address, epoch, mode, hwm_usdg, contributions_known FROM agents")
       .all()) as unknown as Record<string, unknown>[];
+
+    // THE ROSTER IS THE GRANT STORE, NOT THE LEDGER.
+    //
+    // The first dry run covered 22 of 24 tenants and could not say what happened
+    // to the other two, because it enumerated `agents` — a table a tenant only
+    // reaches once its child has armed AND mirrored. A tenant missing from the
+    // report is indistinguishable from a tenant the repair found nothing to do
+    // for, and "not in the mutation list" must never be read as "safe".
+    //
+    // So every tenant with a grant gets a plan row. One with no ledger row is
+    // synthesised from its grant and comes out of the planner as exactly what it
+    // is — no chain history, no rows to remove, nothing to do — recorded rather
+    // than absent.
+    const tenantByAccount = new Map<string, string>();
+    const byAccount = new Map<string, Record<string, unknown>>();
+    for (const a of ledgerAgents) byAccount.set(String(a.smart_account ?? "").toLowerCase(), a);
+
+    let rosterOnly = 0;
+    let rosterRead = true;
+    try {
+      const gs = getGrantStore();
+      for (const tenant of await gs.listTenants()) {
+        const g = await gs.get(tenant);
+        const acct = g?.smartAccount ? String(g.smartAccount) : null;
+        if (!acct) {
+          log(`recon| tenant ${tenant} holds a grant with no smart account — it cannot be planned`);
+          continue;
+        }
+        tenantByAccount.set(acct.toLowerCase(), tenant);
+        if (byAccount.has(acct.toLowerCase())) continue;
+        rosterOnly += 1;
+        byAccount.set(acct.toLowerCase(), {
+          smart_account: acct,
+          owner_address: g?.owner ?? null,
+          epoch: 1,
+          mode: null,
+          hwm_usdg: 0,
+          contributions_known: null,
+        });
+      }
+    } catch (e) {
+      // LOUD, and the run continues on the ledger roster alone — but the count
+      // below will then not add up to the fleet, which is the point of printing
+      // both halves rather than just the total.
+      rosterRead = false;
+      log(`recon| GRANT ROSTER UNREADABLE (${e instanceof Error ? e.message : String(e)}) — tenants may be missing`);
+    }
+    const agents = [...byAccount.values()];
+    log(
+      `recon| roster: ${agents.length} account(s) — ${ledgerAgents.length} from the ledger, ` +
+        `${rosterOnly} from the grant store with no ledger row · grant store read ${rosterRead}`,
+    );
     const flows = (await shared
       .prepare("SELECT id, agent_id, epoch, direction, amount_usdg, source, tx_hash, at FROM flows")
       .all()) as unknown as Record<string, unknown>[];
@@ -758,11 +812,46 @@ async function runReconstructionDryRunIfAsked(): Promise<void> {
       }
     }
 
-    const plans = planReconstruction({ agents, flows, equityByAccountEpoch, chain, onchainCash });
+    const plans = planReconstruction({ agents, flows, equityByAccountEpoch, chain, onchainCash, tenantByAccount });
     for (const line of reconstructionLines(plans)) log(`recon| ${line}`);
+
+    runPreviewIfAsked(plans);
   } catch (e) {
     log(`reconstruction dry run failed — ${e instanceof Error ? e.message : String(e)}`);
   }
+}
+
+/**
+ * The preview, gated behind its own variable and read-only in the strongest
+ * sense available: the module it calls is never handed a database.
+ *
+ * Deliberately downstream of the plan rather than a separate entry point, so the
+ * preview is always of a plan just derived from the live database in this
+ * process — a stale preview is worse than none.
+ */
+function runPreviewIfAsked(plans: readonly AccountPlan[]): void {
+  // The clock is passed IN because parsePreviewRequest is pure and may not read
+  // one. Its default of 0 exists for the tests; leaving it to default here stamped
+  // every production run `run-1970-01-01T00-00-00-000Z`, which is precisely the
+  // property the id exists to provide.
+  const req = parsePreviewRequest(process.env, Date.now());
+  if (!req) return;
+  if (req.kind === "refused") {
+    log(`preview| REFUSED — ${req.why}`);
+    return;
+  }
+
+  log(`preview| run ${req.runId} · account ${req.account ?? "ALL"} · READ-ONLY (this build has no mutation path)`);
+  const previews = runPreview(plans, req);
+
+  // The selected account first and in full; then every tenant on one line, so
+  // the report can be read as "all N are accounted for".
+  for (const p of previews) {
+    if (!p.selected) continue;
+    const plan = plans.find((x) => x.smartAccount === p.account)!;
+    for (const line of accountPreviewLines(plan, p)) log(`preview| ${line}`);
+  }
+  for (const line of rosterLines(previews)) log(`preview| ${line}`);
 }
 
 


### PR DESCRIPTION
**PR 1 of 3.** Everything needed to run the production reconstruction and produce the 24/24 fleet preview — and nothing else. Deploys first, alone.

### It changes none of the six things it must not

`worker/src/index.ts`, `worker/src/store.ts`, `worker/src/ledger-mirror.ts` and `worker/src/deposit-log.ts` are **byte-identical to main**. Six files change:

| file | why it's here |
|---|---|
| `worker/src/accounting-preview.ts` | new — the preview |
| `worker/src/accounting-preview.test.ts` | new — its tests |
| `worker/src/orchestrator.ts` | both hunks are inside `runReconstructionDryRunIfAsked`, gated on `MERRYMEN_ACCOUNTING_RECONSTRUCT=1` |
| `worker/src/accounting-reconstruction.ts` | one new field, `contributionsKnownBefore` |
| `packages/core/src/capital-classify.ts` | classifier upgrade — see below |
| `worker/src/chain-capital.ts` | the type change that follows from it |

The classifier upgrade rides here because `classifyUsdgMovement` and `scanFleetCapital` have exactly one caller on main: this dry run. Nothing live reaches them.

### Read-only by construction, not by a flag

`accounting-preview.ts` is never handed a `Db`, imports no database type, and contains no `INSERT`, `UPDATE` or `DELETE`. A *gated* mutation path would need a reviewer to trust the gate; an absent one needs nothing. Two tests read the module back and assert the absence, so it is checkable rather than promised:

```
✓ has no write SQL anywhere in it
✓ is never handed a database
```

`MERRYMEN_REPAIR=commit` is **refused**, not quietly downgraded — silently turning it into a dry run would leave an operator reading a preview while believing they had repaired production.

### The missing two tenants

The first dry run covered 22 of 24 because it enumerated `agents`, a table a tenant only reaches once its child has armed **and** mirrored. A tenant absent from the report is indistinguishable from one the repair found nothing to do for, and "not in the mutation list" must never read as "safe".

The roster is now the grant store. Every tenant with a grant gets a plan row; one with no ledger row is synthesised from its grant and reported as what it is. Each account carries exactly one of:

- `NO-CHAIN-HISTORY`
- `EVIDENCE-BACKED-REPAIR`
- `BLOCKED-AMBIGUOUS`

Blocked is checked **first**, so an unresolvable account cannot read as a repair merely because it also has rows to insert. The tally must add up to the fleet, and an account `--account` did not select is still classified.

`contributionsKnownBefore` comes from the durable `agents.contributions_known` flag rather than being re-derived — that flag is what the web tier publishes against, so re-deriving it would produce a number that agrees with the repair's arithmetic while disagreeing with what an owner is actually shown.

### How it runs

```
MERRYMEN_ACCOUNTING_RECONSTRUCT=1
MERRYMEN_REPAIR=dry-run
MERRYMEN_REPAIR_ACCOUNT=0x3E34E58e…    # omit for the whole roster
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
