### PR TITLE
PR 2/3 — runtime accounting: paper money, flow identity, and the peak that must move with it

### DIFF
--- a/worker/src/deposit-log.test.ts
+++ b/worker/src/deposit-log.test.ts
@@ -29,8 +29,11 @@ function transferLog(a: {
   txHash: string;
   blockNumber?: number;
   logIndex?: number;
+  /** The ERC-20 that moved. Defaults to USDG; a swap fixture names the other side. */
+  token?: string;
 }): RawLog {
   return {
+    ...(a.token === undefined ? {} : { address: a.token }),
     topics: [TRANSFER_TOPIC, addressTopic(a.from), addressTopic(a.to)],
     data: `0x${a.value.toString(16).padStart(64, "0")}` as Hex,
     transactionHash: a.txHash as Hex,
@@ -39,10 +42,30 @@ function transferLog(a: {
   };
 }
 
-/** A chain that serves a fixed log set, honouring the address and topic filter. */
-function fakeChain(logs: RawLog[], head = 1000n): ReconcileChain {
+/**
+ * A chain that serves a fixed log set, honouring the address and topic filter.
+ *
+ * `receiptExtra` carries the OTHER legs of a transaction — the ones a USDG-only
+ * `eth_getLogs` filter never returns. That distinction is the whole reason the
+ * scanner reads receipts: a swap's second leg is a different token, so it is
+ * invisible to the filter that found the first, and classifying on the filtered
+ * view alone books every purchase as a withdrawal.
+ */
+function fakeChain(logs: RawLog[], head = 1000n, receiptExtra: RawLog[] = []): ReconcileChain {
   return {
     getBlockNumber: async () => head,
+    async getReceiptLogs(txHash) {
+      const all = [...logs, ...receiptExtra].filter(
+        (l) => String(l.transactionHash).toLowerCase() === String(txHash).toLowerCase(),
+      );
+      return all.length
+        ? all.map((l) => ({
+            address: (l as { address?: string }).address ?? USDG,
+            topics: l.topics as string[],
+            data: l.data,
+          }))
+        : null;
+    },
     async getLogs(args) {
       return logs.filter((l) => {
         if (args.address.toLowerCase() !== USDG.toLowerCase()) return false;
@@ -54,7 +77,6 @@ function fakeChain(logs: RawLog[], head = 1000n): ReconcileChain {
         });
       });
     },
-    getReceiptLogs: async () => null,
   };
 }
 
@@ -212,5 +234,103 @@ describe("where the next scan starts", () => {
   it("never scans further back than the lookback allows", () => {
     // A long outage must not turn one tick into an unbounded historical scan.
     assert.equal(resumeFrom(10, 5_000n, 1_000n), 4_000n);
+  });
+});
+
+/**
+ * THE CANARY, AS THE CHAIN ACTUALLY HAS IT.
+ *
+ * Ground truth for 0x3E34E58e…: one 10.000000 USDG deposit, then four 1.666500
+ * USDG outflows to 0xf4acdaee… that are TSLA purchases, leaving 3.334000 in
+ * cash. `capital-classify.test.ts` already pins that the correct contributed
+ * capital is 10000000 raw and that the naive answer — netting every movement by
+ * direction — is 3_334_000. This asserts the SCANNER reaches the same answer,
+ * because the classifier being right is no use if the thing that writes rows
+ * does not consult it.
+ *
+ * The router is on NO list here, deliberately. Only transaction context
+ * separates a purchase from a withdrawal, and an address allowlist that is
+ * merely stale reclassifies trading as capital in exactly the direction that
+ * matters.
+ */
+describe("the canary's real movements", () => {
+  const ROUTER = "0xf4acdaee1234567890123456789012345678abcd";
+  const TSLA = "0x00000000000000000000000000000000000ee511";
+
+  /** One trade: USDG out to the router, TSLA back in, same transaction. */
+  const trade = (tx: string, block: number) => ({
+    usdg: transferLog({ from: ACCT, to: ROUTER, value: 1_666_500n, txHash: tx, blockNumber: block, logIndex: 0 }),
+    paired: transferLog({
+      from: ROUTER, to: ACCT, value: 4_420_417_000_000_000n, txHash: tx, blockNumber: block, logIndex: 1, token: TSLA,
+    }),
+  });
+
+  const TRADES = [trade("0xt1", 601), trade("0xt2", 602), trade("0xt3", 603), trade("0xt4", 604)];
+  const DEPOSIT = transferLog({
+    from: OTHER, to: ACCT, value: 10_000_000n, txHash: "0xfund", blockNumber: 600, logIndex: 0,
+  });
+
+  it("books the deposit and NONE of the four trade legs", async () => {
+    const flows = await findTransferFlows({
+      chain: fakeChain(
+        [DEPOSIT, ...TRADES.map((t) => t.usdg)],
+        1000n,
+        TRADES.map((t) => t.paired),
+      ),
+      smartAccount: ACCT,
+      usdgToken: USDG,
+      fromBlock: 0n,
+      toBlock: 1000n,
+      knownKeys: new Set<string>(),
+      // EMPTY. This is the set the old rule depended on entirely, and a redeploy
+      // empties it — so the fixture reproduces the state the fleet was actually
+      // in when the scanner would have been enabled.
+      tradeTxHashes: new Set<string>(),
+    });
+
+    assert.equal(flows.length, 1, "four purchases are not four withdrawals");
+    assert.equal(flows[0]!.txHash, "0xfund");
+    const net = flows.reduce((s, f) => s + (f.direction === "in" ? f.amountUsdg6 : -f.amountUsdg6), 0n);
+    assert.equal(net, 10_000_000n, "10.000000 USDG contributed");
+    assert.notEqual(net, 3_334_000n, "and NOT the cash balance, which is what direction-only netting gives");
+  });
+
+  it("refuses the whole pass when a receipt cannot be read", async () => {
+    // An unreadable receipt is not an absent second leg. Booking on the single
+    // log we can see is precisely the error above, so the pass refuses and the
+    // caller leaves its cursor where it was.
+    const blind: ReconcileChain = { ...fakeChain([TRADES[0]!.usdg]), getReceiptLogs: async () => null };
+    await assert.rejects(
+      () =>
+        findTransferFlows({
+          chain: blind,
+          smartAccount: ACCT,
+          usdgToken: USDG,
+          fromBlock: 0n,
+          toBlock: 1000n,
+          knownKeys: new Set<string>(),
+          tradeTxHashes: new Set<string>(),
+        }),
+      /receipt for 0xt1 could not be read/,
+    );
+  });
+
+  it("BLOCKS rather than guesses when a movement cannot be classified", async () => {
+    // A known venue with nothing coming back is neither a completed trade nor a
+    // deposit. Unknown means blocked, never "probably a contribution".
+    await assert.rejects(
+      () =>
+        findTransferFlows({
+          chain: fakeChain([TRADES[0]!.usdg]),
+          smartAccount: ACCT,
+          usdgToken: USDG,
+          fromBlock: 0n,
+          toBlock: 1000n,
+          knownKeys: new Set<string>(),
+          tradeTxHashes: new Set<string>(),
+          protocolAddresses: [ROUTER],
+        }),
+      /could not be classified/,
+    );
   });
 });

--- a/worker/src/deposit-log.ts
+++ b/worker/src/deposit-log.ts
@@ -38,6 +38,29 @@
  */
 import { decodeEventLog, parseAbi, type Hex } from "viem";
 import { addressTopic, getLogsAdaptive, type RawLog, type ReconcileChain } from "./inflight-reconcile";
+// The one rule that decides whether a USDG movement is the owner's capital or
+// the agent trading. Imported rather than restated so the scanner and the
+// accounting backfill cannot reach different answers about the same transfer.
+import { classifyUsdgMovement, type TransferLeg } from "../../packages/core/src/index";
+import type { ReceiptLog } from "./fills";
+
+/** Every ERC-20 Transfer in a receipt, as classification legs. */
+function legsFromReceiptLogs(logs: readonly ReceiptLog[]): TransferLeg[] {
+  const out: TransferLeg[] = [];
+  for (const l of logs) {
+    if ((l.topics?.[0] ?? "").toLowerCase() !== TRANSFER_TOPIC) continue;
+    // A Transfer has exactly three topics; ERC-721 has four and shares the
+    // signature's first word, so a token id would otherwise read as an amount.
+    if (l.topics.length !== 3) continue;
+    out.push({
+      token: l.address.toLowerCase(),
+      from: `0x${l.topics[1]!.slice(-40)}`.toLowerCase(),
+      to: `0x${l.topics[2]!.slice(-40)}`.toLowerCase(),
+      amountRaw: BigInt(l.data || "0x0").toString(),
+    });
+  }
+  return out;
+}
 
 /** The ERC-20 event. `value` is not indexed, so it is read from `data`. */
 const TRANSFER_ABI = parseAbi([
@@ -102,6 +125,12 @@ export async function findTransferFlows(opts: {
    * trade rows with transaction hashes.
    */
   tradeTxHashes: Set<string>;
+  /** Other accounts this system controls — a movement between them is internal. */
+  knownAccounts?: readonly string[];
+  /** Trading venues. A WEAK signal: a venue with no paired leg is ambiguous, never a trade. */
+  protocolAddresses?: readonly string[];
+  /** Chain infrastructure — EntryPoints, Permit2. Never a source of capital. */
+  systemAddresses?: readonly string[];
   maxSpan?: bigint;
   log?: (m: string) => void;
 }): Promise<TransferFlow[]> {
@@ -149,7 +178,8 @@ export async function findTransferFlows(opts: {
     );
   }
 
-  const out: TransferFlow[] = [];
+  /** A USDG movement that touches this account, before the receipt decides what it IS. */
+  const candidates: (TransferFlow & { from: string; to: string })[] = [];
   const seen = new Set<string>();
   for (const l of raw) {
     const blockNumber = num(l.blockNumber);
@@ -182,17 +212,104 @@ export async function findTransferFlows(opts: {
     // scans and would otherwise be booked as a deposit of its own size.
     if (from === to) continue;
     if (value === 0n) continue;
+    // A SECONDARY skip, kept because it is free and sometimes right, but it is
+    // no longer what decides the question. See the classification below.
     if (tradeTxHashes.has(l.transactionHash.toLowerCase())) continue;
 
     const mine = smartAccount.toLowerCase();
     if (to !== mine && from !== mine) continue; // neither leg is ours
-    out.push({
+    candidates.push({
       direction: to === mine ? "in" : "out",
       amountUsdg6: value,
       txHash: l.transactionHash,
       blockNumber,
       logIndex,
+      from,
+      to,
     });
+  }
+
+  // ── WHICH OF THESE IS ACTUALLY THE OWNER'S CAPITAL ────────────────────────
+  //
+  // THIS USED TO BE DECIDED BY LEDGER MEMBERSHIP, and that is not evidence. The
+  // only thing separating a contribution from a trade leg was whether the
+  // transaction hash appeared in `recentTradeTxHashes` — this worker's OWN
+  // sqlite, bounded by row recency rather than block range, living in an
+  // ephemeral container that a redeploy empties. Any trade that set missed —
+  // older than the bound, from a previous container, made by the owner's own
+  // wallet — had its USDG leg written as a `chain-log` flow, the highest-trust
+  // source in the schema, with the sign taken from direction alone.
+  //
+  // On the canary that is not hypothetical: its four 1.6665 USDG outflows to
+  // 0xf4acdaee… are TSLA purchases, and after the redeploys that emptied the
+  // child ledger nothing here could tell. They would have been booked as a
+  // 6.666 USDG withdrawal — contributed capital 3.334 instead of 10.000000,
+  // stamped chain-log, hash-chained into the journal and mirrored up. Strictly
+  // worse than the inferred rows this file exists to replace, because it would
+  // look authoritative.
+  //
+  // So the receipt decides. A swap moves two tokens in opposite directions
+  // within ONE transaction, and that test needs no address list and cannot go
+  // stale — see capital-classify.ts.
+  const out: TransferFlow[] = [];
+  const legsByTx = new Map<string, TransferLeg[]>();
+  for (const c of candidates) {
+    const k = c.txHash.toLowerCase();
+    if (legsByTx.has(k)) continue;
+    const receipt = await chain.getReceiptLogs(c.txHash as Hex).catch(() => null);
+    if (!receipt) {
+      // AN UNREADABLE RECEIPT IS NOT AN ABSENT SECOND LEG. Booking on the one
+      // log we can see is exactly the error above, so the whole pass refuses
+      // and the caller leaves the cursor where it is — the same handling a
+      // window nobody could read already gets.
+      throw new Error(
+        `deposit scan: the receipt for ${c.txHash} could not be read, so the other half of that transaction is ` +
+          `unknown — refusing to classify its USDG leg as capital`,
+      );
+    }
+    legsByTx.set(k, legsFromReceiptLogs(receipt));
+  }
+
+  for (const c of candidates) {
+    const legs = legsByTx.get(c.txHash.toLowerCase()) ?? [];
+    const usdgLeg: TransferLeg = {
+      token: usdgToken.toLowerCase(),
+      from: c.from,
+      to: c.to,
+      amountRaw: c.amountUsdg6.toString(),
+    };
+    const v = classifyUsdgMovement({
+      account: smartAccount,
+      usdg: usdgLeg,
+      txLegs: legs.length ? legs : [usdgLeg],
+      usdgToken: usdgToken.toLowerCase(),
+      knownAccounts: opts.knownAccounts,
+      protocolAddresses: opts.protocolAddresses,
+      systemAddresses: opts.systemAddresses,
+    });
+
+    if (v.kind === "capital-in" || v.kind === "capital-out") {
+      out.push({
+        direction: c.direction,
+        amountUsdg6: c.amountUsdg6,
+        txHash: c.txHash,
+        blockNumber: c.blockNumber,
+        logIndex: c.logIndex,
+      });
+      continue;
+    }
+
+    if (v.kind === "ambiguous") {
+      // UNKNOWN MEANS BLOCKED, never "probably a contribution". Refusing the
+      // whole pass leaves the cursor where it is, so an operator sees the same
+      // message every tick until they resolve it — which is the point. A
+      // permanently ambiguous movement should stop this scanner for this agent
+      // rather than quietly become a number in someone's P&L.
+      throw new Error(`deposit scan: ${c.txHash}#${c.logIndex} could not be classified — ${v.why}`);
+    }
+
+    // trade-in / trade-out / internal / protocol: real movements, not capital.
+    opts.log?.(`not capital: ${c.txHash.slice(0, 10)}…#${c.logIndex} is ${v.kind} — ${v.why}`);
   }
 
   // Chronological, so the flows are booked in the order they happened and the

--- a/worker/src/flows.integration.test.ts
+++ b/worker/src/flows.integration.test.ts
@@ -255,3 +255,79 @@ describe("readPnl reports the agent's own money", () => {
     assert.doesNotMatch(out, /change: \$999\.48/);
   });
 });
+
+/**
+ * A FLOW'S IDENTITY, written the same way by every writer.
+ *
+ * Two processes write chain-derived flows into the same shared table: the
+ * deposit scanner via this function, and the accounting repair directly. The
+ * unique index that stops them booking one deposit twice is over
+ * `(chain_id, agent_id, tx_hash, log_index)` — so if the two disagree about the
+ * chain (NULL vs 4663) or the case of the hash (0xAB… vs 0xab…), the constraint
+ * never fires and the owner's deposit is counted twice, both rows stamped with
+ * the schema's highest-trust source.
+ */
+describe("the identity of a chain-derived flow", () => {
+  const D = "0x000000000000000000000000000000000000000d";
+
+  it("carries the chain from the agent's own grant, without being told", async () => {
+    initStore();
+    await ensureAgent(grant(D));
+    await addFlow({
+      agentId: D,
+      direction: "in",
+      amountUsdg: 10,
+      source: "chain-log",
+      txHash: "0xAbCdEf0123",
+      blockNumber: 100,
+      logIndex: 0,
+    });
+    const db = new DatabaseSync(homePaths.db());
+    const row = db
+      .prepare("SELECT chain_id, tx_hash FROM flows WHERE agent_id = ? ORDER BY id DESC LIMIT 1")
+      .get(D) as { chain_id: number; tx_hash: string };
+    db.close();
+    assert.equal(Number(row.chain_id), 46630, "read from agents.chain_id, which ensureAgent wrote from the grant");
+    assert.equal(row.tx_hash, "0xabcdef0123", "normalised, so two writers cannot disagree about the same hash");
+  });
+
+  it("writes an identity a unique index can be built over", async () => {
+    // WHAT THIS CHANGE IS FOR, and the reason it ships one deploy ahead of the
+    // constraint. The index that stops a double-booked deposit is over
+    // (chain_id, agent_id, tx_hash, log_index) — and it cannot be created safely
+    // over rows that are half-NULL and mixed-case, because NULLs are distinct in
+    // a unique index on both engines and 0xAB… is not 0xab…. Every row written
+    // from here on carries the full identity in one canonical form, so by the
+    // time the constraint arrives there is nothing left for it to trip over.
+    //
+    // The dedup PROOF belongs with the index, not here: without a constraint
+    // there is nothing for `ON CONFLICT DO NOTHING` to catch.
+    const db = new DatabaseSync(homePaths.db());
+    const rows = db
+      .prepare("SELECT chain_id, tx_hash, log_index FROM flows WHERE agent_id = ? AND tx_hash IS NOT NULL")
+      .all(D) as { chain_id: number | null; tx_hash: string; log_index: number | null }[];
+    db.close();
+    assert.ok(rows.length > 0);
+    for (const r of rows) {
+      assert.ok(r.chain_id !== null, "a chain-derived row names its chain");
+      assert.ok(r.log_index !== null, "…and its position in the block");
+      assert.equal(r.tx_hash, r.tx_hash.toLowerCase(), "…in one canonical case");
+    }
+  });
+
+  it("reports whether the row landed, so the caller can refuse to move the peak", async () => {
+    // addFlow used to return void and swallow its own failures while the caller
+    // went straight on to adjustAgentHwm — so a failed insert shifted the peak
+    // by the full deposit with no row to explain it and no way to retry.
+    assert.equal(
+      await addFlow({ agentId: D, direction: "in", amountUsdg: 1, source: "inferred" }),
+      true,
+      "a live agent's inferred flow lands, and says so",
+    );
+    assert.equal(
+      await addFlow({ agentId: D, direction: "in", amountUsdg: 1, source: "inferred", mode: "paper" }),
+      false,
+      "a refusal is reported, not swallowed",
+    );
+  });
+});

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -964,7 +964,24 @@ async function main() {
       if (deltaUsdg === 0n) return;
       const inbound = deltaUsdg > 0n;
       const amount = inbound ? deltaUsdg : -deltaUsdg;
-      await addFlow({
+      // PAPER NEVER WRITES REAL CAPITAL. `paperActive()` is synchronous and
+      // always known here, which is why the authoritative answer is passed in
+      // rather than left to addFlow's fallback read of `agents.mode` — that
+      // column is written by the heartbeat and may not exist on the first tick,
+      // which is precisely the tick that books an opening balance.
+      const mode = paperActive() ? ("paper" as const) : ("live" as const);
+      if (mode === "paper" && !evidence) {
+        // Refused here as well as in the store so the HIGH-WATER MARK below is
+        // never moved by a simulated balance either: the flow and the peak are
+        // one decision, and letting the peak move on a refused flow would leave
+        // the pair in exactly the split state the anchor work existed to fix.
+        console.log(
+          `[flows] paper agent — not booking ${inbound ? "+" : "-"}${fmt(amount)} USDG as capital (${why}); ` +
+            `a simulated balance change is not a deposit`,
+        );
+        return;
+      }
+      const landed = await addFlow({
         agentId,
         direction: inbound ? "in" : "out",
         amountUsdg: usdgNum(amount),
@@ -972,7 +989,25 @@ async function main() {
         txHash: evidence?.txHash,
         blockNumber: evidence?.blockNumber,
         logIndex: evidence?.logIndex,
+        mode,
+        // The chain is left to addFlow's own read of `agents.chain_id`, which
+        // ensureAgent writes from the signed grant. That is the chain the grant
+        // authorises, so it is the chain any transaction touching this account
+        // is on — and reading it there means every writer gets it, not just
+        // the ones that remembered to pass it.
       });
+      if (!landed) {
+        // THE PEAK AND THE CONTRIBUTION MOVE TOGETHER OR NOT AT ALL.
+        //
+        // This used to run unconditionally against an addFlow that returned void
+        // and swallowed its own failures, so a transient insert error shifted the
+        // high-water mark by the full deposit with no row to explain it and no
+        // way to retry — the exact split the anchor design exists to prevent,
+        // reached silently. The caller now throws so the scan treats it as a
+        // failed pass and leaves its cursor where it is, which is what the
+        // RPC-failure path already does.
+        throw new Error(`flow not recorded for ${agentId} — refusing to move the high-water mark without it`);
+      }
       await adjustAgentHwm(agentId, usdgNum(deltaUsdg));
       highWaterMarkUsdg = usdg((await getAgentFinancials(agentId)).hwmUsdg);
       await addEvent(
@@ -1143,6 +1178,35 @@ async function main() {
 
     lastCashUsdg = cashUsdg;
     ledgerWritesAtSnapshot = ledgerWrites;
+  };
+
+  /**
+   * The same reconciliation, with a failed WRITE treated exactly like a failed
+   * READ: retry it, do not paper over it.
+   *
+   * `record` now throws when the flow row did not land, because moving the peak
+   * for money the ledger has no record of is the split this whole design exists
+   * to prevent. That throw has to stop three things, and stopping it here stops
+   * all three at once: `chainScanCursor` is left where it was (the assignment
+   * that advances it is downstream of the throw), `lastCashUsdg` is not updated
+   * so the next tick sees the same unexplained delta and tries again, and the
+   * tick itself survives — an accounting write that failed is not a reason to
+   * take an armed agent down.
+   */
+  const reconcileFlowsOrRetry = async (
+    agentId: string,
+    cashUsdg: bigint,
+    equityUsdg: bigint,
+    scan?: { chain: ReconcileChain; smartAccount: `0x${string}` },
+  ): Promise<void> => {
+    try {
+      await reconcileFlows(agentId, cashUsdg, equityUsdg, scan);
+    } catch (e) {
+      console.log(
+        `[flows] reconcile aborted (${e instanceof Error ? e.message : String(e)}) — the scan cursor and the ` +
+          `cash baseline are left where they were, so the next tick retries the same window`,
+      );
+    }
   };
   let highWaterMarkUsdg = 0n;
   // Cash as of the last live snapshot, and how many rows the ledger had then.
@@ -4185,18 +4249,46 @@ async function main() {
       // profit home reads as a loss of precisely that size, and the drawdown
       // breaker eventually fires on it.
       if (intent.kind === "transfer") {
-        await addFlow({
+        const landed = await addFlow({
           agentId,
           direction: "out",
           amountUsdg: usdgNum(intent.amountUsdg),
           source: "transfer-intent",
           txHash,
+          // EXPLICIT, because this site is reached only on the live rail — an
+          // executed on-chain transfer. Left to the store's fallback read of
+          // `agents.mode` it would be judged by whatever the heartbeat last
+          // wrote, which on an agent that has just been switched to paper is
+          // the wrong answer about a transaction that really happened.
+          mode: "live",
         });
-        await adjustAgentHwm(agentId, -usdgNum(intent.amountUsdg));
-        highWaterMarkUsdg = usdg((await getAgentFinancials(agentId)).hwmUsdg);
-        // The next tick's cash reading already reflects this, and it now has an
-        // explanation, so inference must not double-count it.
-        if (lastCashUsdg !== null) lastCashUsdg -= intent.amountUsdg;
+        // THE SECOND CALL SITE, and it has the same rule as the first.
+        //
+        // This block used to discard addFlow's answer and adjust the peak
+        // regardless — the exact split that the deposit-side fix above exists
+        // to prevent, in the withdrawal direction. It matters more here than it
+        // looks: lowering the peak for a withdrawal the ledger has no row for
+        // leaves net contributions permanently too high, so every P&L figure
+        // measured against them understates by the amount taken home, with no
+        // retry path.
+        if (landed) {
+          await adjustAgentHwm(agentId, -usdgNum(intent.amountUsdg));
+          highWaterMarkUsdg = usdg((await getAgentFinancials(agentId)).hwmUsdg);
+          // The next tick's cash reading already reflects this, and it now has
+          // an explanation, so inference must not double-count it.
+          if (lastCashUsdg !== null) lastCashUsdg -= intent.amountUsdg;
+        } else {
+          // Durable, not just stderr: the transfer LANDED on chain and the
+          // ledger does not know. That is a discrepancy an owner may notice
+          // before anyone else does, so it belongs on their event log.
+          await addEvent(
+            agentId,
+            "err",
+            `withdrawal of ${fmt(intent.amountUsdg)} USDG landed on chain (${txHash.slice(0, 10)}…) but its flow ` +
+              `row could not be written — the high-water mark was left where it was rather than moved for a ` +
+              `figure the ledger cannot show. Contributions will read high until this is reconciled.`,
+          ).catch(() => {});
+        }
       }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -4953,7 +5045,7 @@ async function main() {
       // it a transaction hash, instead of a balance change nobody can point at.
       // Off by default: it changes how CONTRIBUTIONS are counted, and every P&L
       // figure is measured against those.
-      await reconcileFlows(
+      await reconcileFlowsOrRetry(
         agentId,
         balances.cashUsdg,
         equityUsdg,

--- a/worker/src/ledger-mirror.test.ts
+++ b/worker/src/ledger-mirror.test.ts
@@ -25,7 +25,7 @@ const SRC = [
   "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT NOT NULL, level TEXT, message TEXT, created_at INTEGER);",
   "CREATE TABLE trades (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT, kind TEXT, target TEXT, sell_token TEXT, buy_token TEXT, amount_usdg REAL, user_op_hash TEXT, tx_hash TEXT, status TEXT, reject_rule TEXT, decision_id TEXT, fill_side TEXT, fill_qty_raw TEXT, fill_price_usd REAL, realized_pnl_usdg REAL, basis_source TEXT, gas_wei TEXT, sponsored_gas_wei TEXT, gas_usdg REAL, fill_cash_usdg REAL, epoch INTEGER DEFAULT 1, created_at INTEGER);",
   "CREATE TABLE equity (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT, eth_wei TEXT, cash_usdg REAL, vault_usdg REAL, positions_usdg REAL, equity_usdg REAL, epoch INTEGER DEFAULT 1, at INTEGER);",
-  "CREATE TABLE flows (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT, direction TEXT, amount_usdg REAL, tx_hash TEXT, block_number INTEGER, log_index INTEGER, source TEXT, epoch INTEGER DEFAULT 1, at INTEGER);",
+  "CREATE TABLE flows (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT, direction TEXT, amount_usdg REAL, tx_hash TEXT, block_number INTEGER, log_index INTEGER, source TEXT, epoch INTEGER DEFAULT 1, chain_id INTEGER, at INTEGER);",
   "CREATE TABLE fee_accruals (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT, profit_usdg REAL, fee_usdg REAL, hwm_before_usdg REAL, hwm_after_usdg REAL, epoch INTEGER DEFAULT 1, at INTEGER);",
   "CREATE TABLE decisions (id TEXT PRIMARY KEY, agent_id TEXT, source TEXT, strategy TEXT, provider TEXT, model TEXT, symbol TEXT, action TEXT, size_usdg REAL, reason TEXT, dropped_rule TEXT, signals_json TEXT, at INTEGER);",
   "CREATE TABLE agents (smart_account TEXT PRIMARY KEY, name TEXT, owner_address TEXT, session_key_address TEXT, chain_id INTEGER, caps TEXT, granted_at INTEGER, expires_at INTEGER, status TEXT, created_at INTEGER, mode TEXT, beat_at INTEGER, sponsor_gas INTEGER, x_handle TEXT, epoch INTEGER DEFAULT 1, hwm_usdg REAL DEFAULT 0, accrued_fee_usdg REAL DEFAULT 0, contributions_known INTEGER, contributions_why TEXT, gas_accounting TEXT, quality_at INTEGER);",
@@ -34,7 +34,15 @@ const SRC = [
 ].join("\n");
 
 /** The destination, with the same shape a Postgres ledger has. */
-const DEST = SRC + MIRROR_STATE_DDL;
+// The shared side carries the identity index the child does not: it is where
+// two writers meet — the mirror copying a child up, and the accounting repair
+// writing chain-derived rows directly — so it is where a duplicate log has to
+// be impossible rather than merely unlikely.
+const FLOW_IDENTITY =
+  "CREATE UNIQUE INDEX flows_chain_identity ON flows (chain_id, agent_id, tx_hash, log_index) " +
+  "WHERE tx_hash IS NOT NULL AND log_index IS NOT NULL;";
+
+const DEST = SRC + MIRROR_STATE_DDL + FLOW_IDENTITY;
 
 const mem = (ddl: string) => {
   const db = new DatabaseSync(":memory:");
@@ -478,6 +486,63 @@ describe("the ledger mirror", () => {
     const second = await mirrorTenant({ tenant: "0xten", child, shared });
     assert.equal(second.restarted, undefined, "an idle pass is not a rebuild");
     assert.equal(await count(shared, "trades"), 5, "and nothing was copied twice");
+  });
+
+  it("survives re-copying a flow row it already carried", async () => {
+    // THE TRAP THAT SITS ACROSS THE chain_id FIX.
+    //
+    // The watermark was the only exactly-once mechanism here, and that was safe
+    // precisely BECAUSE no unique constraint existed to violate — a re-copied
+    // row landed as a silent duplicate. Populating chain_id makes the identity
+    // index bite, and the rebirth path deliberately rewinds to id 0 after a
+    // redeploy. Without ON CONFLICT the first re-copied flow raises a unique
+    // violation, the whole batch rolls back, the watermark never moves, and
+    // `flows` stops mirroring for that tenant FOREVER while every other table
+    // keeps going — the same silent stall that already cost this fleet its
+    // entire trade tape once.
+    const raw = new DatabaseSync(":memory:");
+    raw.exec(SRC);
+    raw.exec(
+      `INSERT INTO flows (agent_id, direction, amount_usdg, tx_hash, block_number, log_index, source, epoch, chain_id, at)
+       VALUES ('0xagent', 'in', 10, '0xdeposit', 100, 0, 'chain-log', 1, 4663, 1)`,
+    );
+    const child = wrapSqlite(raw);
+    const shared = mem(DEST);
+
+    const first = await mirrorTenant({ tenant: "0xten", child, shared });
+    assert.equal(first.copied["flows"], 1);
+    assert.equal(await count(shared, "flows"), 1);
+
+    // A REBIRTH: the child's ledger is rebuilt, the watermark's row is gone, and
+    // the mirror rewinds to 0 and re-reads the same log.
+    const rebornRaw = new DatabaseSync(":memory:");
+    rebornRaw.exec(SRC);
+    rebornRaw.exec(
+      `INSERT INTO flows (agent_id, direction, amount_usdg, tx_hash, block_number, log_index, source, epoch, chain_id, at)
+       VALUES ('0xagent', 'in', 10, '0xdeposit', 100, 0, 'chain-log', 1, 4663, 1)`,
+    );
+    const second = await mirrorTenant({ tenant: "0xten", child: wrapSqlite(rebornRaw), shared });
+
+    assert.equal(second.failed?.["flows"], undefined, "the batch must not fail");
+    assert.equal(await count(shared, "flows"), 1, "one deposit, copied twice, is still one deposit");
+  });
+
+  it("carries the chain a flow's transaction is on", async () => {
+    // A tx hash is unique only WITHIN a chain, and this codebase runs 4663 and
+    // 46630 against one schema. Dropping the column on the way up left every
+    // mirrored row's chain NULL, and NULLs are distinct in a unique index — so
+    // the constraint could never fire on the shared side no matter what the
+    // child wrote.
+    const raw = new DatabaseSync(":memory:");
+    raw.exec(SRC);
+    raw.exec(
+      `INSERT INTO flows (agent_id, direction, amount_usdg, tx_hash, block_number, log_index, source, epoch, chain_id, at)
+       VALUES ('0xagent', 'in', 10, '0xdeposit', 100, 0, 'chain-log', 1, 4663, 1)`,
+    );
+    const shared = mem(DEST);
+    await mirrorTenant({ tenant: "0xten", child: wrapSqlite(raw), shared });
+    const f = (await shared.prepare("SELECT chain_id FROM flows").get()) as { chain_id: number };
+    assert.equal(Number(f.chain_id), 4663);
   });
 
   it("carries the positions leg of the equity identity", async () => {

--- a/worker/src/ledger-mirror.ts
+++ b/worker/src/ledger-mirror.ts
@@ -101,9 +101,27 @@ const LOG_TABLES = [
   // is why hosted P&L was not merely wrong but permanently null: zero rows means
   // contributions are UNKNOWN, and equity.ts refuses to publish a number it
   // cannot back. Every hosted agent showed a dash, forever, by design.
+  //
+  // `chain_id` is carried because it is the first component of the flow's
+  // IDENTITY (`flows_chain_identity`), and a tx hash is unique only within a
+  // chain — this codebase runs 4663 and 46630 against one schema. Omitting it
+  // left every mirrored row with chain_id NULL, and NULLs are distinct in a
+  // unique index on both engines, so the constraint could never fire on the
+  // shared side no matter what the child wrote.
   {
     table: "flows",
-    cols: ["agent_id", "direction", "amount_usdg", "tx_hash", "block_number", "log_index", "source", "epoch", "at"],
+    cols: [
+      "agent_id",
+      "direction",
+      "amount_usdg",
+      "tx_hash",
+      "block_number",
+      "log_index",
+      "source",
+      "epoch",
+      "chain_id",
+      "at",
+    ],
   },
   // What the house actually accrued, per agent. Read straight off `agents` by
   // the scoreboard, but the per-accrual history is what makes a fee auditable.
@@ -302,8 +320,29 @@ export async function mirrorTenant(args: {
       // One transaction: the rows and the watermark that says they arrived.
       // Split them and a crash between the two duplicates the tape forever.
       await shared.tx(async (db) => {
+        // ON CONFLICT DO NOTHING, AND IT HAD TO LAND IN THE SAME CHANGE AS
+        // `flows.chain_id` — never after it.
+        //
+        // The watermark was this file's only exactly-once mechanism, which was
+        // safe precisely BECAUSE no unique constraint existed to violate: a
+        // re-copied row landed as a silent duplicate. That is how the canary's
+        // 10 USDG opening balance came to sit in Postgres three times.
+        //
+        // Populating chain_id makes `flows_chain_identity` bite, and the rebirth
+        // path above deliberately rewinds to id 0 after a redeploy — so the first
+        // re-copied flow would raise a unique violation, roll the whole batch
+        // back, and leave the watermark parked forever. `flows` would stop
+        // mirroring for that tenant while every other table kept moving: the
+        // exact silent stall documented forty lines up, which already cost this
+        // fleet its entire trade tape once.
+        //
+        // This does NOT weaken the watermark. A conflict can only occur on a row
+        // whose (chain_id, agent_id, tx_hash, log_index) is already present —
+        // the same log, the same account — which is by definition the row we
+        // already copied.
         const ins = db.prepare(
-          `INSERT INTO ${table} (${cols.join(", ")}) VALUES (${cols.map(() => "?").join(", ")})`,
+          `INSERT INTO ${table} (${cols.join(", ")}) VALUES (${cols.map(() => "?").join(", ")})
+           ON CONFLICT DO NOTHING`,
         );
         for (const r of rows) await ins.run(...cols.map((c) => r[c] ?? null));
         await db

--- a/worker/src/paper-boundary.test.ts
+++ b/worker/src/paper-boundary.test.ts
@@ -1,0 +1,384 @@
+/**
+ * THE SHAPES PRODUCTION ACTUALLY PRODUCED, pinned so they cannot come back.
+ *
+ * These are not invented cases. Every fixture below is a row shape read out of
+ * the hosted ledger during the diagnosis, and each one is a different way a
+ * simulated balance became a claim about an owner's money:
+ *
+ *   out 1000, repeated        a paper book reset and re-run
+ *   out 500, repeated         the same, at the other configured size
+ *   out 58.335 / 41.670 /     paper FILLS. `reconcileFlows` books a cash change
+ *      25.005 / 8.340         no ledger row explains — a rule written for a real
+ *                             account, where only the owner can do that
+ *
+ * and the three account shapes the repair has to tell apart:
+ *
+ *   a paper account with zero chain history  → contributed exactly nothing
+ *   a funded live account                    → contributed what the chain says
+ *   a funded-then-withdrawn account          → net zero, gross NOT zero
+ *
+ * The last one is the one a naive fix gets wrong: netting to zero and reporting
+ * "no contribution ever happened" is a different and false claim.
+ */
+import assert from "node:assert/strict";
+import { after, describe, it } from "node:test";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const HOME = mkdtempSync(path.join(os.tmpdir(), "merrymen-paper-"));
+process.env.MERRYMEN_HOME = HOME;
+
+const { admitCapitalFlow, tradingModeOf } = await import("./paper-boundary");
+const { initStore, addFlow, ensureAgent, setAgentMode, listFlows, getNetContributionsUsdg } = await import("./store");
+const { homePaths } = await import("./home");
+const { DatabaseSync } = await import("node:sqlite");
+const { planReconstruction } = await import("./accounting-reconstruction");
+const { classifyUsdgMovement, totalCapital } = await import("../../packages/core/src/index");
+const { legsFromReceipt } = await import("./chain-capital");
+
+const PAPER = "0x00000000000000000000000000000000000000a1";
+const LIVE = "0x00000000000000000000000000000000000000a2";
+const OWNER = "0x00000000000000000000000000000000000000ff";
+const USDG = "0x0000000000000000000000000000000000000001";
+
+function clearLedger(): void {
+  const db = new DatabaseSync(homePaths.db());
+  for (const t of ["agents", "equity", "flows", "trades", "fee_accruals"]) {
+    try {
+      db.exec(`DELETE FROM ${t}`);
+    } catch {
+      /* pre-migration copy */
+    }
+  }
+  db.close();
+}
+
+function grant(smartAccount: string) {
+  return {
+    smartAccount,
+    owner: OWNER,
+    sessionKeyAddress: "0x00000000000000000000000000000000000000fe",
+    chainId: 46630,
+    caps: { perTradeUsdg: 50, dailyUsdg: 500, expiryDays: 14, maxDrawdownPct: 10, maxOpsPerDay: 48 },
+    grantedAt: 1_700_000_000,
+    expiresAt: 1_800_000_000,
+  } as unknown as Parameters<typeof ensureAgent>[0];
+}
+
+after(() => {
+  try {
+    rmSync(HOME, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+// ── THE RULE ───────────────────────────────────────────────────────────────
+
+describe("the paper boundary", () => {
+  it("refuses every unevidenced flow from a paper agent", () => {
+    for (const source of ["inferred", "transfer-intent", "epoch-carry"] as const) {
+      const v = admitCapitalFlow({ mode: "paper", source });
+      assert.equal(v.admit, false, `${source} must not cross the boundary`);
+    }
+  });
+
+  it("still admits a REAL deposit into a paper agent's smart account", () => {
+    // A paper agent's address is a real address. Someone can really fund it, and
+    // that Transfer is real capital — refusing it would lose an owner's money in
+    // the other direction.
+    assert.equal(admitCapitalFlow({ mode: "paper", source: "chain-log", txHash: "0xdeadbeef" }).admit, true);
+  });
+
+  it("refuses a chain-log row that carries no transaction", () => {
+    // The source word claims a receipt; the missing hash says there isn't one.
+    const v = admitCapitalFlow({ mode: "paper", source: "chain-log" });
+    assert.equal(v.admit, false);
+    assert.match(v.admit === false ? v.why : "", /not a receipt/);
+  });
+
+  it("leaves live agents exactly as they were", () => {
+    for (const source of ["inferred", "transfer-intent", "epoch-carry", "chain-log"] as const) {
+      assert.equal(admitCapitalFlow({ mode: "live", source }).admit, true);
+    }
+  });
+
+  it("treats an unwritten mode as unknown, and unknown admits", () => {
+    // Refusing here would silently drop a LIVE agent's opening balance in the
+    // window before its first heartbeat. The narrow window is closed at the call
+    // site instead, where the answer is synchronous — see index.ts.
+    assert.equal(tradingModeOf(null), "unknown");
+    assert.equal(tradingModeOf(undefined), "unknown");
+    assert.equal(tradingModeOf("paper"), "paper");
+    assert.equal(tradingModeOf("live"), "live");
+    assert.equal(tradingModeOf("something else"), "unknown");
+    assert.equal(admitCapitalFlow({ mode: "unknown", source: "inferred" }).admit, true);
+  });
+});
+
+// ── THE EXACT ROWS, REPLAYED ───────────────────────────────────────────────
+
+describe("the corruption shapes found in production", () => {
+  /** Every figure below was read out of the hosted `flows` table. */
+  const PAPER_ROWS: { direction: "in" | "out"; amountUsdg: number; what: string }[] = [
+    { direction: "out", amountUsdg: 1000, what: "paper book reset" },
+    { direction: "out", amountUsdg: 1000, what: "paper book reset, again" },
+    { direction: "out", amountUsdg: 500, what: "paper book reset at the other size" },
+    { direction: "out", amountUsdg: 500, what: "paper book reset at the other size, again" },
+    { direction: "out", amountUsdg: 58.335, what: "a paper FILL, not a withdrawal" },
+    { direction: "out", amountUsdg: 41.67, what: "a paper FILL, not a withdrawal" },
+    { direction: "out", amountUsdg: 25.005, what: "a paper FILL, not a withdrawal" },
+    { direction: "out", amountUsdg: 8.34, what: "a paper FILL, not a withdrawal" },
+  ];
+
+  it("refuses all of them at the rule", () => {
+    for (const r of PAPER_ROWS) {
+      const v = admitCapitalFlow({ mode: "paper", source: "inferred" });
+      assert.equal(v.admit, false, `${r.direction} ${r.amountUsdg} (${r.what}) must be refused`);
+      assert.match(v.admit === false ? v.why : "", /SIMULATED/);
+    }
+  });
+
+  it("refuses all of them at the store, which is the boundary that matters", async () => {
+    initStore();
+    clearLedger();
+    await ensureAgent(grant(PAPER));
+    await setAgentMode(PAPER, "paper", 0, false);
+
+    for (const r of PAPER_ROWS) {
+      await addFlow({ agentId: PAPER, direction: r.direction, amountUsdg: r.amountUsdg, source: "inferred" });
+    }
+
+    const flows = await listFlows(PAPER, 100);
+    assert.equal(flows.length, 0, "not one simulated row reached the ledger");
+    assert.equal(await getNetContributionsUsdg(PAPER), null, "zero rows is UNKNOWN, not zero");
+  });
+
+  it("would have produced −3,133 USDG of phantom withdrawals without the rule", () => {
+    // What the ledger actually held. Stated as a number so the regression has a
+    // magnitude and not just a boolean: this is the shape behind the −59,000,
+    // −26,000 and −7,900 figures, at the size one paper agent reached.
+    const total = PAPER_ROWS.reduce((s, r) => s + (r.direction === "in" ? r.amountUsdg : -r.amountUsdg), 0);
+    assert.equal(Number(total.toFixed(3)), -3133.35);
+  });
+
+  it("a paper agent's real deposit still lands", async () => {
+    await addFlow({
+      agentId: PAPER,
+      direction: "in",
+      amountUsdg: 10,
+      source: "chain-log",
+      txHash: "0xfeed",
+      blockNumber: 1,
+      logIndex: 0,
+    });
+    assert.equal(await getNetContributionsUsdg(PAPER), 10);
+  });
+
+  it("a live agent is unaffected — the fix is not a blanket refusal", async () => {
+    await ensureAgent(grant(LIVE));
+    await setAgentMode(LIVE, "live", 0, false);
+    await addFlow({ agentId: LIVE, direction: "in", amountUsdg: 1000, source: "inferred" });
+    assert.equal(await getNetContributionsUsdg(LIVE), 1000);
+  });
+
+  it("an explicit mode beats the stored one, because the first tick has no stored one", async () => {
+    // `agents.mode` is written by the heartbeat. On an agent's very first tick it
+    // is NULL — and the first tick is exactly when an opening balance is booked.
+    clearLedger();
+    await ensureAgent(grant(PAPER)); // no setAgentMode: mode is NULL, as at first tick
+    await addFlow({ agentId: PAPER, direction: "in", amountUsdg: 3000, source: "inferred", mode: "paper" });
+    assert.equal(await getNetContributionsUsdg(PAPER), null, "the caller's answer is the authoritative one");
+  });
+});
+
+// ── THE THREE ACCOUNT SHAPES THE REPAIR MUST TELL APART ────────────────────
+
+describe("account shapes", () => {
+  const cap = (movements: { direction: "in" | "out"; amountRaw: string; kind: string }[]) => ({
+    account: "",
+    movements: movements.map((m, i) => ({
+      txHash: `0x${(i + 1).toString(16).padStart(64, "0")}`,
+      blockNumber: 100 + i,
+      logIndex: i,
+      direction: m.direction,
+      amountRaw: m.amountRaw,
+      counterparty: OWNER,
+      classification: {
+        kind: m.kind,
+        why: "fixture",
+        evidence: { counterparty: OWNER, direction: m.direction, txLegCount: 1, rule: "no-pair-external" },
+      },
+    })),
+    totals: totalCapital(
+      movements.map((m) => ({
+        amountRaw: m.amountRaw,
+        classification: {
+          kind: m.kind,
+          why: "fixture",
+          evidence: { counterparty: OWNER, direction: m.direction, txLegCount: 1, rule: "no-pair-external" },
+        },
+      })) as never,
+    ),
+    complete: true,
+    notes: [],
+  });
+
+  const planFor = (
+    account: string,
+    mode: string,
+    movements: Parameters<typeof cap>[0],
+    flows: Record<string, unknown>[],
+    onchainCash: number,
+  ) =>
+    planReconstruction({
+      agents: [{ smart_account: account, owner_address: OWNER, mode, epoch: 1 }],
+      flows,
+      equityByAccountEpoch: new Map([[`${account.toLowerCase()}#1`, onchainCash]]),
+      chain: new Map([[account.toLowerCase(), { ...cap(movements), account } as never]]),
+      onchainCash: new Map([[account.toLowerCase(), onchainCash]]),
+    })[0]!;
+
+  it("a paper account with zero chain history contributed exactly nothing", () => {
+    const p = planFor(
+      PAPER,
+      "paper",
+      [],
+      [
+        { id: 1, agent_id: PAPER, epoch: 1, direction: "out", amount_usdg: 1000, source: "inferred" },
+        { id: 2, agent_id: PAPER, epoch: 1, direction: "out", amount_usdg: 58.335, source: "inferred" },
+      ],
+      0,
+    );
+    assert.equal(p.isPaper, true);
+    assert.equal(p.insert.length, 0, "there is no chain evidence to insert");
+    assert.equal(p.quarantine.length, 2, "and the simulated rows come out");
+    assert.equal(p.contributionsAfterUsdg, 0);
+    assert.equal(p.blocked, null, "zero is the ANSWER here, not a refusal");
+    assert.equal(p.pnlPublishableAfter, false, "there is nothing to divide by");
+  });
+
+  it("a funded live account contributed what the chain says", () => {
+    const p = planFor(
+      LIVE,
+      "live",
+      [{ direction: "in", amountRaw: "10000000", kind: "capital-in" }],
+      [{ id: 1, agent_id: LIVE, epoch: 1, direction: "in", amount_usdg: 30, source: "inferred" }],
+      3.334,
+    );
+    assert.equal(p.isPaper, false);
+    assert.equal(p.insert.length, 1);
+    assert.equal(p.insert[0]!.amountUsdg, 10);
+    assert.equal(p.contributionsAfterUsdg, 10, "10, not the 30 the inferred rows claimed");
+    assert.equal(p.contributionsKnownAfter, true);
+    assert.equal(p.pnlPublishableAfter, true);
+  });
+
+  it("a funded-then-withdrawn account nets to zero WITHOUT losing its history", () => {
+    // The claim that must not be made here is "no contribution ever happened".
+    const p = planFor(
+      LIVE,
+      "live",
+      [
+        { direction: "in", amountRaw: "1010000000", kind: "capital-in" },
+        { direction: "out", amountRaw: "1010000000", kind: "capital-out" },
+      ],
+      [],
+      0,
+    );
+    assert.equal(p.chainGrossInUsdg, 1010, "gross in survives");
+    assert.equal(p.chainGrossOutUsdg, 1010, "gross out survives");
+    assert.equal(p.chainNetUsdg, 0);
+    assert.equal(p.insert.length, 2, "both legs are written, not one netted row");
+    assert.equal(p.contributionsAfterUsdg, 0);
+    assert.equal(p.pnlPublishableAfter, false, "net zero is not a denominator");
+  });
+});
+
+// ── THE PAPER FILL, AS THE CLASSIFIER SEES IT ──────────────────────────────
+
+describe("a paper-sized outflow that is really a trade", () => {
+  it("is a trade leg, not a withdrawal, when the receipt shows the other side", () => {
+    // 8.340 USDG out and TSLA in, one transaction. Address lists are irrelevant.
+    const legs = legsFromReceipt([
+      {
+        address: USDG,
+        topics: [
+          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          `0x000000000000000000000000${LIVE.slice(2)}`,
+          "0x000000000000000000000000f4acdaee1234567890123456789012345678abcd",
+        ],
+        data: "0x" + (8_340_000).toString(16),
+        blockNumber: "0x1",
+        transactionHash: "0xtrade",
+        logIndex: "0x0",
+      },
+      {
+        address: "0x00000000000000000000000000000000000000ee",
+        topics: [
+          "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          "0x000000000000000000000000f4acdaee1234567890123456789012345678abcd",
+          `0x000000000000000000000000${LIVE.slice(2)}`,
+        ],
+        data: "0x" + (22_000_000_000_000_000).toString(16),
+        blockNumber: "0x1",
+        transactionHash: "0xtrade",
+        logIndex: "0x1",
+      },
+    ]);
+
+    const v = classifyUsdgMovement({
+      account: LIVE,
+      usdg: legs[0]!,
+      txLegs: legs,
+      usdgToken: USDG,
+    });
+    assert.equal(v.kind, "trade-out");
+    assert.equal(v.evidence.rule, "paired-token-movement");
+    assert.equal(totalCapital([{ amountRaw: "8340000", classification: v }]).grossWithdrawalsRaw, "0");
+  });
+});
+
+// ── THE CALL SITE, PINNED ──────────────────────────────────────────────────
+
+describe("index.ts passes the mode it knows", () => {
+  it("does not leave the paper decision to the store's fallback read", () => {
+    // A source-level pin, and deliberately so: the fallback reads `agents.mode`,
+    // which is NULL on the tick that books an opening balance. If someone drops
+    // `mode` from this call the store still refuses paper agents that HAVE a
+    // recorded mode — so the regression would be invisible except on exactly the
+    // first tick of a fresh paper agent, which no integration test exercises and
+    // which is the only tick that matters.
+    const src = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+    const from = src.indexOf("const record = async (");
+    assert.ok(from > 0, "reconcileFlows still has a `record` closure");
+    const record = src.slice(from, src.indexOf("await adjustAgentHwm(agentId", from));
+    assert.match(record, /paperActive\(\)/, "the mode is decided from paperActive(), synchronously");
+    assert.match(record, /\bmode,/, "and passed into addFlow");
+    assert.match(record, /if \(mode === "paper" && !evidence\)/, "and the high-water mark is not moved either");
+  });
+});
+
+describe("both call sites obey the pairing rule", () => {
+  it("the transfer-intent site refuses to move the peak for a flow that did not land", () => {
+    // PR 2's whole claim is that the peak and the contribution move together.
+    // addFlow was made to REPORT whether the row landed, and there are exactly
+    // two production callers. Fixing one and leaving the other would leave the
+    // invariant true in the deposit direction and false in the withdrawal one —
+    // and this site is the more dangerous of the two to get wrong, because a
+    // peak lowered for a withdrawal the ledger has no row for leaves net
+    // contributions permanently too high with no retry path.
+    const src = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+    const from = src.indexOf('if (intent.kind === "transfer") {');
+    assert.ok(from > 0, "the transfer-intent flow site still exists");
+    const block = src.slice(from, src.indexOf("} catch (e) {", from));
+    assert.match(block, /const landed = await addFlow\(/, "it captures the answer");
+    assert.match(block, /if \(landed\) \{/, "and gates the high-water mark on it");
+    assert.match(block, /mode: "live"/, "and names the rail rather than inheriting a stale one");
+    // The two statements that must NOT run unconditionally.
+    const guarded = block.slice(block.indexOf("if (landed) {"));
+    assert.match(guarded, /adjustAgentHwm/, "the peak adjustment is inside the guard");
+    assert.match(guarded, /lastCashUsdg -= intent\.amountUsdg/, "so is the baseline decrement");
+  });
+});

--- a/worker/src/paper-boundary.ts
+++ b/worker/src/paper-boundary.ts
@@ -1,0 +1,83 @@
+/**
+ * PAPER MONEY MAY NOT WRITE REAL CAPITAL RECORDS. EVER.
+ *
+ * This is where the −59,000 / −26,000 / −7,900 USDG "contributions" came from,
+ * and the mechanism is worth stating exactly because it is not the redeploy bug
+ * wearing a different hat:
+ *
+ *   A paper agent's cash is SIMULATED. It moves when a simulated fill spends it.
+ *   `reconcileFlows` books an external flow whenever cash moved and no ledger row
+ *   explains it — a rule written for a real account, where the only thing that
+ *   can move cash without a fill is the owner. On a paper book the simulated
+ *   balance moves for simulated reasons, so the rule fired on trades: hence rows
+ *   of exactly 58.335, 41.670, 25.005 and 8.340 USDG sitting in `flows` as
+ *   though an owner had withdrawn them, and repeated round 1000s and 500s from
+ *   the paper book being reset and re-run.
+ *
+ * Those rows are indistinguishable from real capital AFTER the fact — same
+ * table, same columns, same `inferred` source a live agent also writes. The only
+ * place the distinction still exists is at the moment of writing, so that is
+ * where it has to be enforced, permanently, rather than cleaned up later.
+ *
+ * WHAT COUNTS AS ADMISSIBLE FOR A PAPER AGENT is narrower than "evidenced". A
+ * paper agent's SMART ACCOUNT is a real address that can really be funded, so a
+ * chain-log flow naming an actual Transfer is real capital and must be kept. But
+ * `epoch-carry` — the deterministic bridge that writes a closing equity forward
+ * as an opening balance — derives from the SIMULATED book, and carrying it would
+ * launder a paper equity into a real contribution figure across a boundary. It
+ * is checkable, which is why it is evidenced enough for a live agent; it is not
+ * a receipt, which is why it is not enough for a paper one.
+ *
+ * So: for a paper agent, only a chain-log flow with a transaction hash.
+ */
+import type { FlowSource } from "./store";
+
+/** What the agent is actually doing. `unknown` is a real answer, not a default. */
+export type TradingMode = "paper" | "live" | "unknown";
+
+export type FlowAdmission =
+  | { admit: true }
+  | {
+      admit: false;
+      /** The sentence written to the event log, so a refusal is never silent. */
+      why: string;
+    };
+
+/**
+ * May this flow be written? PURE.
+ *
+ * Separated from both call sites so the rule can be tested against the exact
+ * corrupt shapes production produced, rather than inferred from the behaviour of
+ * a tick loop that needs an RPC and a database to run.
+ */
+export function admitCapitalFlow(input: {
+  mode: TradingMode;
+  source: FlowSource;
+  txHash?: string | null;
+}): FlowAdmission {
+  if (input.mode !== "paper") return { admit: true };
+
+  if (input.source === "chain-log" && input.txHash) return { admit: true };
+
+  if (input.source === "chain-log") {
+    // A chain-log source with no transaction is a contradiction — the source
+    // means "read off a Transfer log" and the log is what carries the hash — so
+    // it is refused on the paper side rather than trusted for its label.
+    return {
+      admit: false,
+      why: "a chain-log flow with no transaction hash is not a receipt, and a paper book may not write one",
+    };
+  }
+
+  return {
+    admit: false,
+    why:
+      `this agent is trading on paper, so a '${input.source}' flow is derived from a SIMULATED balance — ` +
+      `it would enter the ledger indistinguishable from real contributed capital`,
+  };
+}
+
+/** Read a stored mode string without inventing one. */
+export function tradingModeOf(mode: string | null | undefined): TradingMode {
+  return mode === "paper" ? "paper" : mode === "live" ? "live" : "unknown";
+}

--- a/worker/src/store.ts
+++ b/worker/src/store.ts
@@ -13,6 +13,9 @@ import { wrapSqlite, makePgDb, type Db } from "./db";
 // The one definition of a flow's identity. Imported rather than restated so
 // the reader and the writer cannot disagree about what makes a flow unique.
 import { flowKey } from "./deposit-log";
+// The paper/live boundary. A rule rather than a convention, enforced at the one
+// function every flow writer passes through — see addFlow.
+import { admitCapitalFlow, tradingModeOf, type TradingMode } from "./paper-boundary";
 
 let driver: Db | null = null;
 
@@ -475,6 +478,38 @@ const SQLITE_ALTERS: string[] = [
     // Unix seconds of the assessment. A quality flag with no timestamp cannot be
     // told from a stale one, and stale quality is exactly what a redeploy leaves.
     "ALTER TABLE agents ADD COLUMN quality_at INTEGER",
+    // ── THE IDENTITY OF A CHAIN-DERIVED FLOW ─────────────────────────────
+    //
+    // A chain-log row's identity is the LOG that produced it, not the row: the
+    // same Transfer re-read by a second scan is the same deposit, and inserting
+    // it again doubles an owner's recorded capital. `flows` has no unique key at
+    // all — which is how the mirror's cursor rewind was able to re-copy a whole
+    // child ledger into it.
+    //
+    // The chain id is part of that identity because a tx hash is only unique
+    // WITHIN a chain, and this codebase runs mainnet 4663 and testnet 46630
+    // against the same schema.
+    //
+    // THE COLUMN AND THE NORMALISATION LAND FIRST, ALONE. The unique index that
+    // uses them arrives with the repair, deliberately one deploy later: an index
+    // built over rows that are still half-NULL and mixed-case would either fail
+    // to create — silently, since these DDLs are swallowed — or collapse rows
+    // that are not in fact the same log. By then every row here will have been
+    // written by the code below, which can produce neither shape.
+    "ALTER TABLE flows ADD COLUMN chain_id INTEGER",
+    // ── NORMALISE BEFORE CONSTRAINING, in this order and not the other ──────
+    //
+    // Rows written before the identity existed carry a NULL chain and whatever
+    // case the RPC happened to return the hash in. Both defeat the index — NULLs
+    // are distinct in a unique index on either engine, and 0xAB… is not 0xab… —
+    // so an old row and a new one naming the SAME log would sit side by side,
+    // both sourced 'chain-log', and the owner's deposit would be counted twice.
+    //
+    // The chain comes from the agent's own grant rather than from config,
+    // because that is the chain the transaction was actually on.
+    "UPDATE flows SET tx_hash = LOWER(tx_hash) WHERE tx_hash IS NOT NULL AND tx_hash <> LOWER(tx_hash)",
+    `UPDATE flows SET chain_id = (SELECT a.chain_id FROM agents a WHERE a.smart_account = flows.agent_id)
+       WHERE chain_id IS NULL AND tx_hash IS NOT NULL`,
     // HERE AND NOT IN SQLITE_SCHEMA, because `decision_id` is itself added by an
     // ALTER above — the base schema runs first, so an index on it there fails with
     // 'no such column' and takes every trade insert down with it.
@@ -927,6 +962,49 @@ export async function readJournal(agentId: string, epoch: number): Promise<Journ
   }
 }
 
+/**
+ * What the heartbeat last said this agent is doing — the BACKSTOP for the paper
+ * boundary, not its primary source.
+ *
+ * Null means the column has not been written yet, which is a genuinely different
+ * fact from "live" and is carried as such: `tradingModeOf` turns it into
+ * `unknown`, and an unknown mode admits the flow. That is deliberate. Refusing
+ * on unknown would silently drop a LIVE agent's opening balance during the
+ * window before its first heartbeat — trading one accounting bug for another —
+ * so the narrow window is closed at the call site instead, where the answer is
+ * known synchronously and never absent.
+ */
+async function modeOf(agentId: string): Promise<string | null> {
+  try {
+    const row = (await getDb().prepare("SELECT mode FROM agents WHERE smart_account = ?").get(agentId)) as
+      | { mode: string | null }
+      | undefined;
+    return row?.mode ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Which chain this agent's grant is on, for a flow that did not carry it.
+ *
+ * Read from `agents` rather than from config so it is the chain the GRANT was
+ * signed for, which is the chain any transaction touching this account is on.
+ * Null when the agent row is not there yet: a null chain_id is honest and merely
+ * leaves the identity index inert for that row, whereas guessing a chain would
+ * make two different chains' transactions collide under one identity.
+ */
+async function chainIdOf(agentId: string): Promise<number | null> {
+  try {
+    const row = (await getDb().prepare("SELECT chain_id FROM agents WHERE smart_account = ?").get(agentId)) as
+      | { chain_id: number | null }
+      | undefined;
+    return row?.chain_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
 /** The epoch this agent writes into now — 1 if it has none yet. */
 async function epochOf(agentId: string): Promise<number> {
   try {
@@ -1046,13 +1124,74 @@ export interface FlowRow {
   blockNumber?: number;
   /** Position within the block. Set only for 'chain-log' — see the migration. */
   logIndex?: number;
+  /**
+   * What the agent is actually doing, when the caller knows.
+   *
+   * PASS IT. The fallback below reads `agents.mode`, which is written by the
+   * heartbeat and may not be there yet on an agent's first tick — and a paper
+   * agent's first tick is exactly when the simulated opening balance would be
+   * booked as a real contribution. The caller in index.ts knows synchronously
+   * and unambiguously (`paperActive()`), so it says so.
+   */
+  mode?: TradingMode;
+  /**
+   * WHICH CHAIN the transaction is on — the first component of a flow's identity.
+   *
+   * A tx hash is unique only WITHIN a chain, and this codebase runs mainnet 4663
+   * and testnet 46630 against one schema. Without it every row this function
+   * wrote carried chain_id NULL, and NULLs are distinct in a unique index on
+   * both SQLite and Postgres — so the identity index the repair relies on could
+   * never fire on a row written here, and the repair (which DOES set it) would
+   * insert a second chain-log row for the same log rather than conflicting with
+   * it. Populating it here, one deploy ahead of the constraint, is what makes
+   * that constraint safe to add.
+   */
+  chainId?: number;
 }
 
-/** Record money crossing the account boundary, and mirror it into the journal. */
-export async function addFlow(flow: FlowRow): Promise<void> {
+/**
+ * Record money crossing the account boundary, and mirror it into the journal.
+ *
+ * RETURNS WHETHER THE ROW LANDED, and the caller must act on it. This used to
+ * return void with a try/catch that only logged, while `record()` in index.ts
+ * went straight on to `adjustAgentHwm`. Any transient failure of the insert
+ * therefore moved the high-water mark by the full amount with NO flow row to
+ * explain it, advanced the scan cursor past the block, and left no way to
+ * retry — the peak and the contribution silently split apart, which is the one
+ * pairing the whole anchor design exists to keep together.
+ *
+ * REFUSES SIMULATED CAPITAL. See paper-boundary.ts: a paper agent's cash moves
+ * for simulated reasons, and every rule that reads a cash change as an external
+ * flow was written for an account where it could only have been the owner. The
+ * check lives here as well as at the call site because this is the one function
+ * every writer must pass through, so a future call site cannot reintroduce the
+ * bug by forgetting.
+ */
+export async function addFlow(flow: FlowRow): Promise<boolean> {
+  const mode = flow.mode ?? tradingModeOf(await modeOf(flow.agentId));
+  const admission = admitCapitalFlow({ mode, source: flow.source, txHash: flow.txHash });
+  if (!admission.admit) {
+    // Loud, and on the agent's own event log rather than only stderr: a refused
+    // flow means a figure the owner can see did NOT move, and the reason has to
+    // be somewhere they can find it.
+    console.error(`[flows] refused ${flow.source} ${flow.direction} ${flow.amountUsdg} — ${admission.why}`);
+    await addEvent(flow.agentId, "warn", `capital flow not recorded — ${admission.why}`).catch(() => {});
+    // FALSE, because the caller must not move the high-water mark for money the
+    // ledger has no record of. A refusal is a decision, not an error, but the
+    // pairing rule is the same either way.
+    return false;
+  }
   try {
     const epoch = await epochOf(flow.agentId);
     const amount = Math.abs(flow.amountUsdg);
+    // LOWERCASE, ALWAYS. A hash is a number, but it reaches here as a string and
+    // an RPC may return it in either case — and a case difference defeats both
+    // the unique index and the repair's read-back, so the same log written by
+    // the scanner and by the backfill would sit in the table twice, both stamped
+    // 'chain-log'. Normalising at the single write point is the only place the
+    // two writers can be made to agree.
+    const txHash = flow.txHash ? flow.txHash.toLowerCase() : null;
+    const chainId = flow.chainId ?? (await chainIdOf(flow.agentId));
     await journaled(
       flow.agentId,
       epoch,
@@ -1063,28 +1202,32 @@ export async function addFlow(flow: FlowRow): Promise<void> {
         direction: flow.direction,
         logIndex: flow.logIndex ?? null,
         source: flow.source,
-        txHash: flow.txHash ?? null,
+        txHash,
       },
       async (db: Db) => {
         await db
           .prepare(
-            `INSERT INTO flows (agent_id, direction, amount_usdg, tx_hash, block_number, log_index, source, epoch)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+            `INSERT INTO flows (agent_id, direction, amount_usdg, tx_hash, block_number, log_index, source, epoch, chain_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT DO NOTHING`,
           )
           .run(
             flow.agentId,
             flow.direction,
             amount,
-            flow.txHash ?? null,
+            txHash,
             flow.blockNumber ?? null,
             flow.logIndex ?? null,
             flow.source,
             epoch,
+            chainId,
           );
       },
     );
+    return true;
   } catch (e) {
     console.error("[store] flow insert failed:", e);
+    return false;
   }
 }
 


### PR DESCRIPTION
**PR 2 of 3**, stacked on #PR1. These change **live accounting whether or not a repair ever runs**, which is why they are separated from the read-only preview. No schema constraint and no mutation path lands here.

### Paper money may not write real capital records

A paper agent's cash is simulated, and `reconcileFlows` books a cash change no ledger row explains — a rule written for an account where only the owner can do that. On a paper book the balance moves for simulated reasons, so the rule fired on **trades**: rows of exactly `58.335`, `41.670`, `25.005` and `8.340` USDG sitting in `flows` as withdrawals, plus repeated round 1000s and 500s from the book being reset and re-run. That is the shape behind the −59,000 / −26,000 / −7,900 figures.

Enforced twice on purpose:

- **At the call site**, where `paperActive()` is synchronous and never absent. The store's fallback reads `agents.mode`, which the heartbeat writes — and which is NULL on exactly the first tick, the one that books an opening balance.
- **In `addFlow`**, the one function every writer passes through, so a future call site cannot reintroduce it by forgetting.

A *real* deposit into a paper agent's smart account still lands: its address is a real address and someone can really fund it. Only a receipt qualifies — `epoch-carry` does not, because it derives from the simulated book.

Regression fixtures cover every shape found in production, plus the three account shapes the repair must tell apart: paper with zero chain history, funded live, and funded-then-withdrawn (net zero, gross **not** zero).

### The peak and the contribution move together or not at all

`addFlow` returned `void` and swallowed its own failures while the caller went straight on to `adjustAgentHwm`. Any transient failure of the insert moved the high-water mark by the full deposit with **no row to explain it**, advanced the scan cursor past the block, and left no way to retry — `knownFlowKeys` cannot contain a key for a row that was never written. The two swallows were independent, so the divergence ran both ways.

It now reports whether the row landed. The caller refuses to move the peak without it, and a failed write is treated exactly like a failed read: the cursor and the cash baseline stay where they were and the next tick retries.

### Flow identity, one deploy ahead of the constraint

`addFlow` never wrote `chain_id` and stored the hash in whatever case the RPC returned. Both defeat a unique index independently — NULLs are distinct in one on both engines, and `0xAB…` is not `0xab…` — so the scanner and the repair could each write their own row for the same log, both sourced `chain-log`. Normalised at the single write point, with a migration for existing rows. **The index itself comes with PR 3**, after this is deployed and the data is clean.

### The mirror

Carries `chain_id` **and** gains `ON CONFLICT DO NOTHING`, and those had to land together. The watermark was its only exactly-once mechanism, safe *because* no constraint existed to violate; the rebirth path rewinds to id 0 after a redeploy, so once the index exists the first re-copied flow would violate it, roll back the batch, and stop `flows` mirroring for that tenant forever while every other table kept moving — the silent stall that already cost this fleet its trade tape once. Pinned by a test that mirrors the same row twice against a destination that **has** the index, which is what makes PR 3 safe to land.

### The deposit scanner stays disabled

Its correctness blocker is fixed here — it decided contribution-vs-trade by **ledger membership**, so the canary's four router outflows would have been written as a 6.666 USDG withdrawal stamped `chain-log`, strictly worse than the inferred rows it replaces. Pinned with the canary's five real logs against an *empty* `tradeTxHashes`: the state the fleet was actually in.

Three lifecycle blockers still gate enabling it:
1. first arm opens at head rather than recovering relevant history;
2. the 200k-block lookback clamp runs once per process, so a failing scan's window grows without bound;
3. the cursor does not survive a child redeploy — it must live durably outside child SQLite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
