### PR TITLE
The node was refusing the rate, not the range

### DIFF
--- a/worker/src/chain-capital.test.ts
+++ b/worker/src/chain-capital.test.ts
@@ -1,0 +1,172 @@
+/**
+ * THE TWO WAYS A NODE SAYS NO, AND WHY THEY WANT OPPOSITE ANSWERS.
+ *
+ * The first version of this sweep retried every failure four times at the same
+ * size, 700ms apart, on the reasoning that "a rate limit is not a hint about the
+ * question". That reasoning is right and it is half the story. Run against the
+ * live chain it failed all 110 of its windows with 429 Too Many Requests — while
+ * the identical query for a single account across the WHOLE 54.7M-block history
+ * succeeded in 1.6 seconds. The node was refusing the RATE, not the range, and
+ * windowing was what created the rate.
+ *
+ * So the sweep now starts with the whole range and narrows only when the node
+ * says the answer was too big, which is the one refusal that splitting can fix.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { classifyRpcError, scanFleetCapital, TRANSFER_TOPIC, type RpcCall } from "./chain-capital";
+
+const USDG = "0x5fc5360d0400a0fd4f2af552add042d716f1d168";
+const ACCT = "0x3e34e58e1e1b52a6cbe2bd7c6e0c1b1e1e1e1e1e";
+const OWNER = "0x00000000000000000000000000000000000000ff";
+const pad32 = (a: string) => "0x" + a.toLowerCase().replace(/^0x/, "").padStart(64, "0");
+
+const transferLog = (a: { from: string; to: string; amount: bigint; tx: string; block: number; idx: number }) => ({
+  address: USDG,
+  topics: [TRANSFER_TOPIC, pad32(a.from), pad32(a.to)],
+  data: "0x" + a.amount.toString(16),
+  blockNumber: "0x" + a.block.toString(16),
+  transactionHash: a.tx,
+  logIndex: "0x" + a.idx.toString(16),
+});
+
+const DEPOSIT = transferLog({ from: OWNER, to: ACCT, amount: 10_000_000n, tx: "0xfund", block: 4_100_000, idx: 0 });
+
+describe("what the node's refusal means", () => {
+  it("tells a result-cap apart from a rate limit apart from neither", () => {
+    assert.equal(classifyRpcError(new Error("-32000: logs matched by query exceeds limit of 10000")), "too-many-results");
+    assert.equal(classifyRpcError(new Error("query returned more than 10000 results")), "too-many-results");
+    assert.equal(classifyRpcError(new Error("429: Too Many Requests")), "rate-limited");
+    assert.equal(classifyRpcError(new Error("rate limit exceeded")), "rate-limited");
+    assert.equal(classifyRpcError(new Error("connection reset")), "unknown");
+    assert.equal(classifyRpcError("not an Error at all"), "unknown");
+  });
+});
+
+describe("the fleet sweep", () => {
+  /**
+   * Counts the getLogs calls, so "how many did it make" is testable — and
+   * HONOURS THE TOPIC FILTER, which a fake that ignores it cannot.
+   *
+   * The first version of this fake returned the same deposit to both the
+   * outbound and the inbound sweep, which doubled the account's contributed
+   * capital. That is the real bug this module exists to prevent, reached by a
+   * test double rather than by the code: a fake that does not filter is not a
+   * model of the node, it is a model of a node that does not work.
+   */
+  const spy = (handler: (from: bigint, to: bigint, call: number) => RawResult) => {
+    const ranges: [bigint, bigint][] = [];
+    let call = 0;
+    const rpc: RpcCall = async (method, params) => {
+      if (method === "eth_getTransactionReceipt") return { logs: [DEPOSIT] };
+      const p = params[0] as { fromBlock: string; toBlock: string; topics: (string | string[] | null)[] };
+      const from = BigInt(p.fromBlock);
+      const to = BigInt(p.toBlock);
+      ranges.push([from, to]);
+      const r = handler(from, to, call++);
+      if (r instanceof Error) throw r;
+      return (r as { topics: string[] }[]).filter((log) =>
+        p.topics.every((want, i) => {
+          if (want === null || want === undefined) return true;
+          const list = Array.isArray(want) ? want : [want];
+          return list.some((w) => w.toLowerCase() === String(log.topics[i]).toLowerCase());
+        }),
+      );
+    };
+    return { rpc, ranges, calls: () => ranges.length };
+  };
+  type RawResult = Error | unknown[];
+
+  it("asks for the whole history in one call per direction, not 110", async () => {
+    // The measured behaviour that made the windowed version fail: the node
+    // filters server-side on the topic OR-list, so the whole range is cheap.
+    const s = spy((from, to) => (from === 0n ? [DEPOSIT] : []));
+    const out = await scanFleetCapital(s.rpc, {
+      accounts: [ACCT],
+      usdgToken: USDG,
+      fromBlock: 0n,
+      toBlock: 54_700_000n,
+    });
+    assert.equal(s.calls(), 2, "one sweep for outbound, one for inbound");
+    assert.deepEqual(s.ranges[0], [0n, 54_700_000n], "and each covers everything");
+    const cap = out.get(ACCT)!;
+    assert.equal(cap.complete, true);
+    assert.equal(cap.totals.grossContributionsRaw, "10000000");
+  });
+
+  it("SPLITS when the node says the answer was too big", async () => {
+    // The one refusal that a smaller question can fix.
+    const s = spy((from, to) =>
+      to - from > 20_000_000n
+        ? new Error("-32000: logs matched by query exceeds limit of 10000")
+        : from === 0n
+          ? [DEPOSIT]
+          : [],
+    );
+    const out = await scanFleetCapital(s.rpc, {
+      accounts: [ACCT],
+      usdgToken: USDG,
+      fromBlock: 0n,
+      toBlock: 54_700_000n,
+    });
+    assert.ok(s.calls() > 2, "it narrowed rather than giving up");
+    assert.equal(out.get(ACCT)!.complete, true, "and the coverage is still complete");
+    assert.equal(out.get(ACCT)!.totals.grossContributionsRaw, "10000000");
+  });
+
+  it("WAITS OUT a rate limit at the same size, because splitting makes it worse", async () => {
+    // Splitting here would turn one refused call into two refused calls.
+    let seen = 0;
+    const s = spy((from, to, call) => {
+      if (call < 2) {
+        seen += 1;
+        return new Error("429: Too Many Requests");
+      }
+      return from === 0n ? [DEPOSIT] : [];
+    });
+    const out = await scanFleetCapital(s.rpc, {
+      accounts: [ACCT],
+      usdgToken: USDG,
+      fromBlock: 0n,
+      toBlock: 1_000n,
+    });
+    assert.equal(seen, 2, "it retried");
+    for (const [from, to] of s.ranges) {
+      assert.deepEqual([from, to], [0n, 1_000n], "…at the SAME range every time, never split");
+    }
+    assert.equal(out.get(ACCT)!.complete, true);
+  });
+
+  it("reports coverage short rather than an empty history when it truly cannot read", async () => {
+    // The distinction that matters most: a window nobody could read must not
+    // look like a window with no deposits in it. `complete: false` is what stops
+    // the planner writing a contribution history with holes in it.
+    const s = spy(() => new Error("429: Too Many Requests"));
+    const out = await scanFleetCapital(s.rpc, {
+      accounts: [ACCT],
+      usdgToken: USDG,
+      fromBlock: 0n,
+      toBlock: 1_000n,
+    });
+    const cap = out.get(ACCT)!;
+    assert.equal(cap.complete, false, "an unread window is not an empty one");
+    assert.equal(cap.movements.length, 0);
+  });
+
+  it("never pads the topic filter with a trailing null", async () => {
+    // Transfer has three topics. A fourth position matches nothing, so a padded
+    // filter reports an empty history for a funded account — confirmed against
+    // the live node while diagnosing the failed sweep.
+    const shapes: unknown[][] = [];
+    const rpc: RpcCall = async (method, params) => {
+      if (method === "eth_getTransactionReceipt") return { logs: [DEPOSIT] };
+      shapes.push((params[0] as { topics: unknown[] }).topics);
+      return [];
+    };
+    await scanFleetCapital(rpc, { accounts: [ACCT], usdgToken: USDG, fromBlock: 0n, toBlock: 10n });
+    assert.equal(shapes.length, 2);
+    assert.equal(shapes[0]!.length, 2, "outbound filters on topic1 and stops");
+    assert.equal(shapes[1]!.length, 3, "inbound filters on topic2 and stops");
+    for (const t of shapes) assert.notEqual(t[t.length - 1], null, "no trailing null");
+  });
+});

--- a/worker/src/chain-capital.ts
+++ b/worker/src/chain-capital.ts
@@ -41,6 +41,37 @@ export interface RawChainLog {
 /** The JSON-RPC seam, injected so this is testable without a node. */
 export type RpcCall = (method: string, params: unknown[]) => Promise<unknown>;
 
+/**
+ * WHY A WINDOW WAS REFUSED, WHICH DECIDES WHAT TO DO ABOUT IT.
+ *
+ * The first version of this sweep retried every failure four times at the same
+ * size, on the reasoning that "a rate limit is not a hint about the question".
+ * That reasoning is sound and it is also only half the story: there are TWO
+ * failures here and they want opposite responses.
+ *
+ *   too-many-results  the node found more logs than it will return. The window
+ *                     IS the question, and the answer is to ask a smaller one.
+ *                     Retrying the same range cannot ever succeed.
+ *   rate-limited      the node will not answer right now. The window is fine;
+ *                     splitting it makes MORE calls and makes things worse.
+ *                     Wait longer and ask again.
+ *
+ * Run against the live chain the fleet sweep failed every one of its 110
+ * windows with 429 Too Many Requests, while the identical query for a single
+ * account over the WHOLE history succeeded in 1.6s — the endpoint was never
+ * refusing the range, it was refusing the rate, and four retries 700ms apart
+ * (against a node 24 children are also using) never outlasted it.
+ */
+export type SweepRefusal = "too-many-results" | "rate-limited" | "unknown";
+
+export function classifyRpcError(e: unknown): SweepRefusal {
+  const m = (e instanceof Error ? e.message : String(e)).toLowerCase();
+  if (m.includes("exceeds limit") || m.includes("too many results") || m.includes("query returned more than"))
+    return "too-many-results";
+  if (m.includes("429") || m.includes("too many requests") || m.includes("rate limit")) return "rate-limited";
+  return "unknown";
+}
+
 /** One classified USDG movement, with everything a durable row needs. */
 export interface CapitalMovement {
   txHash: string;
@@ -61,6 +92,18 @@ export interface AccountCapital {
   complete: boolean;
   notes: string[];
 }
+
+/** How many times to wait out a rate limit before calling the window unread. */
+const RATE_LIMIT_ATTEMPTS = 6;
+/** First backoff, doubling each attempt: 1s, 2s, 4s, 8s, 16s — 31s in total. */
+const RATE_LIMIT_BASE_MS = 1_000;
+/** Courtesy pause between top-level ranges, so the fleet's children still get served. */
+const INTER_RANGE_MS = 250;
+/**
+ * How far a too-large range may be halved. 54.7M blocks reaches a single block
+ * in 26 splits; this stops a pathological node turning one query into thousands.
+ */
+const MAX_SPLIT_DEPTH = 24;
 
 const pad32 = (a: string) => "0x" + a.toLowerCase().replace(/^0x/, "").padStart(64, "0");
 const addrOfTopic = (t: string) => "0x" + t.slice(-40);
@@ -104,7 +147,11 @@ export async function scanFleetCapital(
     log?: (m: string) => void;
   },
 ): Promise<Map<string, AccountCapital>> {
-  const span = args.maxSpan ?? 1_000_000n;
+  // NO DEFAULT WINDOWING. The node filters server-side on the topic OR-list, so
+  // the whole history in one call is both correct and cheaper than slicing it —
+  // and the slicing is what earned the rate limits. A caller may still cap the
+  // opening bid; the sweep narrows from there on the node's say-so.
+  const span = args.maxSpan ?? args.toBlock - args.fromBlock + 1n;
   const wanted = new Map(args.accounts.map((a) => [pad32(a), a]));
   const topicList = [...wanted.keys()];
   const usdg = args.usdgToken.toLowerCase();
@@ -116,37 +163,95 @@ export async function scanFleetCapital(
 
   const hits: RawChainLog[] = [];
   let short = false;
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  /**
+   * Read one block range, and let the node tell us how to ask.
+   *
+   * ONE CALL FOR THE WHOLE HISTORY IS THE OPENING BID, not 55 windowed ones.
+   * Topic OR-lists work on this endpoint and filter server-side, so a fleet-wide
+   * query over all of history returns a handful of logs — measured: 6 logs, 1.6s
+   * for one account across 54.7M blocks. Windowing up front turned that into 110
+   * calls against a node 24 children are already using, which is what earned the
+   * 429s. So it starts wide and narrows ONLY when the node says the answer was
+   * too big, which is the one refusal that splitting can fix.
+   */
+  const sweep = async (
+    from: bigint,
+    to: bigint,
+    pos: number,
+    dir: string,
+    depth: number,
+  ): Promise<void> => {
+    const topics: (string | string[] | null)[] = [TRANSFER_TOPIC, null, null];
+    topics[pos] = topicList;
+
+    for (let attempt = 0; attempt < RATE_LIMIT_ATTEMPTS; attempt++) {
+      try {
+        const logs = (await rpc("eth_getLogs", [
+          {
+            address: args.usdgToken,
+            fromBlock: "0x" + from.toString(16),
+            toBlock: "0x" + to.toString(16),
+            // TRIMMED, never padded. A trailing null adds a FOURTH topic
+            // position, and Transfer has three — so the filter matches nothing
+            // and the sweep reports an empty history for a funded account.
+            // Confirmed against the live node while diagnosing this.
+            topics: topics.slice(0, pos + 1),
+          },
+        ])) as RawChainLog[];
+        for (const l of logs) hits.push(l);
+        return;
+      } catch (e) {
+        const why = classifyRpcError(e);
+
+        if (why === "too-many-results") {
+          if (from >= to || depth >= MAX_SPLIT_DEPTH) {
+            short = true;
+            args.log?.(
+              `range ${from}-${to} (${dir}) holds more logs than the node will return and cannot be split ` +
+                `further — coverage is short`,
+            );
+            return;
+          }
+          const mid = from + (to - from) / 2n;
+          args.log?.(`range ${from}-${to} (${dir}) too large — splitting at ${mid}`);
+          await sweep(from, mid, pos, dir, depth + 1);
+          await sweep(mid + 1n, to, pos, dir, depth + 1);
+          return;
+        }
+
+        if (attempt === RATE_LIMIT_ATTEMPTS - 1) {
+          short = true;
+          args.log?.(
+            `range ${from}-${to} (${dir}) UNREAD after ${RATE_LIMIT_ATTEMPTS} attempts (${why}) — coverage is short`,
+          );
+          return;
+        }
+        // EXPONENTIAL, IN SECONDS. The old backoff topped out at 2.1s, which
+        // against this endpoint is not a wait at all — it is four requests in
+        // quick succession dressed as patience.
+        const wait = RATE_LIMIT_BASE_MS * 2 ** attempt;
+        args.log?.(`range ${from}-${to} (${dir}) ${why} — waiting ${wait}ms before asking again`);
+        await sleep(wait);
+      }
+    }
+  };
 
   for (const [pos, dir] of [
     [1, "out"],
     [2, "in"],
   ] as const) {
+    // `maxSpan` is now a CEILING rather than a stride: it caps the opening bid
+    // for a caller who knows their node is stricter, and is otherwise ignored
+    // because the node's own refusal is a better guide than a guess.
     for (let from = args.fromBlock; from <= args.toBlock; from += span) {
       const to = from + span - 1n > args.toBlock ? args.toBlock : from + span - 1n;
-      const topics: (string | string[] | null)[] = [TRANSFER_TOPIC, null, null];
-      topics[pos] = topicList;
-      let ok = false;
-      for (let attempt = 0; attempt < 4 && !ok; attempt++) {
-        try {
-          const logs = (await rpc("eth_getLogs", [
-            {
-              address: args.usdgToken,
-              fromBlock: "0x" + from.toString(16),
-              toBlock: "0x" + to.toString(16),
-              topics: topics.slice(0, pos + 1),
-            },
-          ])) as RawChainLog[];
-          for (const l of logs) hits.push(l);
-          ok = true;
-        } catch (e) {
-          if (attempt === 3) {
-            short = true;
-            args.log?.(`window ${from}-${to} (${dir}) UNREAD after 4 attempts — coverage is short`);
-          } else {
-            await new Promise((r) => setTimeout(r, 700 * (attempt + 1)));
-          }
-        }
-      }
+      await sweep(from, to, pos, dir, 0);
+      // A courtesy pause between top-level ranges. The fleet's 24 children share
+      // this endpoint, and a reconstruction that rate-limits them is a
+      // reconstruction that breaks the thing it is measuring.
+      if (to < args.toBlock) await sleep(INTER_RANGE_MS);
     }
   }
 


### PR DESCRIPTION
Follow-up to #70, needed before the production dry run can produce anything.

The fleet reconstruction failed **every one of its 110 windows** in production with `UNREAD after 4 attempts — coverage is short`, which would have marked every account `BLOCKED` and made the preview useless.

Probing the live endpoint showed the assumption was backwards:

```
1M blocks, OR-list of 5 accounts   OK    0 logs   782ms
1M blocks, ONE account             OK    0 logs   352ms
FULL history, ONE account          OK    6 logs  1649ms
FULL history, OR-list of 5         FAIL  429: Too Many Requests
```

Topic OR-lists work and filter server-side. The whole 54.7M-block history for an account is one cheap call. What the node would not take was 110 calls in quick succession from a service whose 24 children are already using it — **the windowing was what created the rate limit**.

### Two refusals, opposite answers

The old loop retried everything four times at the same size, 700ms apart, reasoning that "a rate limit is not a hint about the question". That is correct, and it is half the story:

| refusal | what it means | what to do |
|---|---|---|
| `too-many-results` | the window **is** the question | ask a smaller one — retrying cannot ever work |
| `rate-limited` | the window is fine | wait longer; splitting makes **more** calls and makes it worse |

`classifyRpcError` separates them. The sweep now opens with the whole range and narrows **only** on a result-cap refusal; a rate limit is waited out at the same range with exponential backoff — 1s doubling to 16s, 31s total, against an old ceiling of 2.1s that was four requests dressed as patience. A courtesy pause between top-level ranges keeps the fleet's children served.

`maxSpan` becomes a ceiling on the opening bid rather than a stride, defaulting to the whole range: the node's own refusal is a better guide than a guess about it.

### Also pinned

The topic filter is **trimmed, never padded**. `Transfer` has three topics, so a trailing null adds a fourth position that matches nothing — reporting an empty history for a funded account. Confirmed against the live node while diagnosing this.

And the test double now honours the topic filter, which the first version of it did not. That omission returned the same deposit to both the outbound and the inbound sweep, doubling the account's contributed capital — the exact bug this module exists to prevent, reached through a fake rather than the code. A fake that does not filter is not a model of the node.

Still read-only: no schema, no mutation, no write path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)