### PR TITLE
One report, sized to the window it has to be read in

### DIFF
--- a/worker/src/accounting-preview.test.ts
+++ b/worker/src/accounting-preview.test.ts
@@ -11,6 +11,7 @@ import { describe, it } from "node:test";
 import { readFileSync } from "node:fs";
 import {
   accountPreviewLines,
+  previewRequested,
   parsePreviewRequest,
   previewAccount,
   rosterLines,
@@ -297,5 +298,39 @@ describe("the run id is a real timestamp in production", () => {
     const call = src.match(/parsePreviewRequest\([^)]*\)/);
     assert.ok(call, "the orchestrator still calls parsePreviewRequest");
     assert.match(call[0], /Date\.now\(\)/, "and hands it a clock");
+  });
+});
+
+describe("the report has to fit in the window you can read it in", () => {
+  it("knows a preview was asked for before deciding how much else to print", () => {
+    // `railway logs` is a 503-line snapshot, not a stream, and the ledger mirror
+    // alone writes ~200 lines a minute. The per-account dump was ~12 lines each —
+    // 288 for a 24-tenant fleet — and the preview then added its own on top, so
+    // the combined burst pushed itself out of the window and neither could be
+    // read. This is what lets the caller print one report instead of two.
+    assert.equal(previewRequested({}), false);
+    assert.equal(previewRequested({ MERRYMEN_REPAIR: "" }), false);
+    assert.equal(previewRequested({ MERRYMEN_REPAIR: "   " }), false);
+    assert.equal(previewRequested({ MERRYMEN_REPAIR: "dry-run" }), true);
+    // A REFUSED request still counts as asked, so the refusal is not buried
+    // under three hundred lines of something nobody wanted.
+    assert.equal(previewRequested({ MERRYMEN_REPAIR: "commit" }), true);
+  });
+
+  it("bounds the fleet report to one line per tenant plus one block", () => {
+    // The roster is the fleet answer; the four-part block is the account answer.
+    // 24 tenants scoped to one account is 24 + 1 + ~20 lines, which fits.
+    const plans = Array.from({ length: 24 }, (_, i) =>
+      i === 0 ? canaryPlan() : plan({ smartAccount: `0x${i.toString(16).padStart(40, "0")}` }),
+    );
+    const previews = runPreview(plans, { account: CANARY });
+    const roster = rosterLines(previews);
+    const blocks = previews.filter((p) => p.selected).flatMap((p) => {
+      const pl = plans.find((x) => x.smartAccount === p.account)!;
+      return accountPreviewLines(pl, p);
+    });
+    assert.equal(roster.length, 25, "one line per tenant, plus the total");
+    assert.equal(previews.filter((p) => p.selected).length, 1, "only the named account gets a block");
+    assert.ok(roster.length + blocks.length < 100, `report is ${roster.length + blocks.length} lines, well inside 503`);
   });
 });

--- a/worker/src/accounting-preview.ts
+++ b/worker/src/accounting-preview.ts
@@ -74,6 +74,18 @@ export function parsePreviewRequest(
   };
 }
 
+/**
+ * Was a preview asked for at all?
+ *
+ * Separate from parsing it, because the caller needs the answer BEFORE it
+ * decides how much else to print — and a refused request still counts as asked,
+ * so the refusal is not buried under three hundred lines of something nobody
+ * wanted.
+ */
+export function previewRequested(env: Record<string, string | undefined>): boolean {
+  return (env.MERRYMEN_REPAIR ?? "").trim() !== "";
+}
+
 /** Which of the three outcomes this account falls into. Total over every plan. */
 export function rosterOutcome(plan: AccountPlan): RosterOutcome {
   // BLOCKED FIRST. An account the classifier could not resolve must not be

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -52,7 +52,7 @@ import { deriveBootstrapAccounting } from "./bootstrap-source";
 import { diagnoseAccounting, diagnosisLines } from "./accounting-diagnosis";
 import { planReconstruction, reconstructionLines } from "./accounting-reconstruction";
 import type { AccountPlan } from "./accounting-reconstruction";
-import { accountPreviewLines, parsePreviewRequest, rosterLines, runPreview } from "./accounting-preview";
+import { accountPreviewLines, parsePreviewRequest, previewRequested, rosterLines, runPreview } from "./accounting-preview";
 import { scanFleetCapital } from "./chain-capital";
 import { getFollowStore, MAX_FOLLOWS } from "./follow-store";
 import { MIRROR_STATE_DDL, mirrorTenant, openChildLedger } from "./ledger-mirror";
@@ -813,8 +813,23 @@ async function runReconstructionDryRunIfAsked(): Promise<void> {
     }
 
     const plans = planReconstruction({ agents, flows, equityByAccountEpoch, chain, onchainCash, tenantByAccount });
-    for (const line of reconstructionLines(plans)) log(`recon| ${line}`);
 
+    // ONE REPORT, NOT TWO — AND IT HAS TO FIT IN THE WINDOW YOU CAN READ IT IN.
+    //
+    // `railway logs` is a 503-line snapshot rather than a stream (measured: it
+    // returns 503 lines and does not grow), and the ledger mirror alone writes
+    // ~200 lines a minute. The old dump was ~12 lines per account unconditionally
+    // — 288 for this fleet — and the preview then added its own on top, so the
+    // combined burst pushed itself out of the window and nobody could read
+    // either. A report that cannot be retrieved is not a report.
+    //
+    // So when a preview is asked for, IT is the report: one roster line per
+    // tenant plus the four-part block for the account under examination. The
+    // older per-account dump stays for a bare reconstruction with no preview,
+    // which is the only caller that still wants it.
+    if (!previewRequested(process.env)) {
+      for (const line of reconstructionLines(plans)) log(`recon| ${line}`);
+    }
     runPreviewIfAsked(plans);
   } catch (e) {
     log(`reconstruction dry run failed — ${e instanceof Error ? e.message : String(e)}`);


### PR DESCRIPTION
Follow-up to #70 and #73. The fleet dry run produced the right answer and nobody could read it.

`railway logs` is a **503-line snapshot, not a stream** — measured: it returns 503 lines and does not grow. The ledger mirror alone writes ~200 lines a minute. The reconstruction printed ~12 lines per account *unconditionally* (288 for a 24-tenant fleet) and the preview then added its own on top, so the combined burst pushed itself out of the window and neither report could be retrieved. Sampling at 4-second intervals recovered 45 of ~600 lines.

When a preview is asked for, **it** is the report: one roster line per tenant plus the four-part block for the account under examination — 24 + 1 + ~20 lines, well inside the window. The older per-account dump stays for a bare reconstruction with no preview, which is the only caller that still wants it.

`previewRequested` is deliberately separate from parsing the request: the caller needs the answer *before* it decides how much else to print, and a **refused** request still counts as asked — otherwise the refusal is buried under three hundred lines of something nobody wanted.

Still read-only: no schema, no mutation, no write path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)