### PR TITLE
A fleet repair names its accounts, and repairs them in one pass

### DIFF
--- a/worker/src/accounting-migration.test.ts
+++ b/worker/src/accounting-migration.test.ts
@@ -260,7 +260,7 @@ describe("the migration, against the rows that are actually there", () => {
     const results = await runRepair(
       db,
       [plan],
-      { mode: "commit", runId: "r", resume: false, account: CANARY },
+      { mode: "commit", runId: "r", resume: false, accounts: [CANARY.toLowerCase()] },
       CHAIN,
     );
     assert.equal(results[0]!.stage, "failed");
@@ -272,7 +272,7 @@ describe("the migration, against the rows that are actually there", () => {
   it("still allows a DRY RUN without the index, because a dry run writes nothing", async () => {
     const { db } = await preMigration();
     await seedAgents(db);
-    const results = await runRepair(db, [], { mode: "dry-run", runId: "r", resume: false }, CHAIN);
+    const results = await runRepair(db, [], { mode: "dry-run", runId: "r", resume: false, accounts: [] }, CHAIN);
     assert.deepEqual(results, []);
   });
 });

--- a/worker/src/accounting-preview.test.ts
+++ b/worker/src/accounting-preview.test.ts
@@ -130,7 +130,7 @@ describe("every tenant is classified", () => {
       plan({ smartAccount: "0xbbb", blocked: "ambiguous" }),
       plan({ smartAccount: "0xccc" }),
     ];
-    const previews = runPreview(plans, { account: null });
+    const previews = runPreview(plans, { accounts: [] });
     const total = rosterLines(previews).find((l) => l.startsWith("ROSTER TOTAL"))!;
     assert.match(total, /4 account\(s\)/);
     assert.match(total, /NO-CHAIN-HISTORY 2/);
@@ -142,7 +142,7 @@ describe("every tenant is classified", () => {
   it("classifies an account --account did not select, rather than omitting it", () => {
     // "Not in the mutation list" must never be readable as "safe".
     const previews = runPreview([canaryPlan(), plan({ smartAccount: PAPER, isPaper: true })], {
-      account: CANARY,
+      accounts: [CANARY.toLowerCase()],
     });
     assert.equal(previews.length, 2);
     assert.equal(previews[1]!.selected, false);
@@ -153,7 +153,7 @@ describe("every tenant is classified", () => {
 // ── THE CANARY'S NUMBERS ───────────────────────────────────────────────────
 
 describe("the canary preview", () => {
-  const p = previewAccount(canaryPlan(), CANARY);
+  const p = previewAccount(canaryPlan(), [CANARY.toLowerCase()]);
 
   it("reports the ledger's 30 USDG as what is there now, unevidenced", () => {
     assert.equal(p.contributionsBeforeUsdg, 30);
@@ -213,7 +213,7 @@ describe("a funded-then-withdrawn account", () => {
         contributionsAfterUsdg: 0,
         contributionsKnownAfter: true,
       }),
-      null,
+      [],
     );
     assert.equal(p.grossContributionsAfterUsdg, 1010);
     assert.equal(p.grossWithdrawalsAfterUsdg, 1010);
@@ -279,7 +279,7 @@ describe("the report has to fit in the window you can read it in", () => {
     const plans = Array.from({ length: 24 }, (_, i) =>
       i === 0 ? canaryPlan() : plan({ smartAccount: `0x${i.toString(16).padStart(40, "0")}` }),
     );
-    const previews = runPreview(plans, { account: CANARY });
+    const previews = runPreview(plans, { accounts: [CANARY.toLowerCase()] });
     const roster = rosterLines(previews);
     const blocks = previews.filter((p) => p.selected).flatMap((p) => {
       const pl = plans.find((x) => x.smartAccount === p.account)!;

--- a/worker/src/accounting-preview.ts
+++ b/worker/src/accounting-preview.ts
@@ -79,7 +79,7 @@ export interface AccountPreview {
 const round6 = (n: number) => Number(n.toFixed(6));
 
 /** What a repair would do to one account. PURE — it is handed a plan, not a database. */
-export function previewAccount(plan: AccountPlan, selectedAccount: string | null): AccountPreview {
+export function previewAccount(plan: AccountPlan, selected: readonly string[]): AccountPreview {
   let grossIn = 0;
   let grossOut = 0;
   for (const r of plan.insert) {
@@ -90,7 +90,7 @@ export function previewAccount(plan: AccountPlan, selectedAccount: string | null
     account: plan.smartAccount,
     tenant: plan.tenant,
     outcome: rosterOutcome(plan),
-    selected: !selectedAccount || selectedAccount.toLowerCase() === plan.smartAccount.toLowerCase(),
+    selected: selected.length === 0 || selected.includes(plan.smartAccount.toLowerCase()),
     isPaper: plan.isPaper,
     epoch: plan.epoch,
     inserts: plan.insert.length,
@@ -195,7 +195,7 @@ export function accountPreviewLines(plan: AccountPlan, p: AccountPreview): strin
 /** Preview every account. PURE, and the fleet total is part of the answer. */
 export function runPreview(
   plans: readonly AccountPlan[],
-  req: { account: string | null },
+  req: { accounts: readonly string[] },
 ): AccountPreview[] {
-  return plans.map((p) => previewAccount(p, req.account));
+  return plans.map((p) => previewAccount(p, req.accounts));
 }

--- a/worker/src/accounting-repair.test.ts
+++ b/worker/src/accounting-repair.test.ts
@@ -92,7 +92,7 @@ const plan = (over: Partial<AccountPlan> & { smartAccount: string }): AccountPla
   ...over,
 });
 
-const COMMIT: RepairOptions = { mode: "commit", runId: "test-run", resume: false };
+const COMMIT: RepairOptions = { mode: "commit", runId: "test-run", resume: false, accounts: [] };
 
 const countFlows = async (db: Db, account: string) =>
   Number(((await db.prepare("SELECT COUNT(*) AS n FROM flows WHERE agent_id = ?").get(account)) as { n: number }).n);
@@ -244,7 +244,14 @@ test("a restart midway leaves finished accounts done and untouched accounts unto
   assert.equal(await netOf(db, B), 40, "B still holds its untouched legacy row");
 
   // The new process re-runs the WHOLE fleet with --resume.
-  const results = await runRepair(db, [pa, pb], { ...COMMIT, resume: true, runId: "r2" }, CHAIN);
+  const results = await runRepair(
+    db,
+    [pa, pb],
+    // BOTH NAMED. A commit with no named accounts is refused, so a fleet pass
+    // spells out what it is repairing — including on a resume.
+    { ...COMMIT, resume: true, runId: "r2", accounts: [A.toLowerCase(), B.toLowerCase()] },
+    CHAIN,
+  );
   assert.equal(results[0]!.inserted, 0, "A's evidence was already there");
   assert.equal(results[1]!.inserted, 1, "B is picked up where the crash left it");
   assert.equal(await netOf(db, A), 10);
@@ -402,9 +409,25 @@ test("the default is read-only and mutation must be spelled out", async () => {
   assert.equal(parseRepairOptions({ MERRYMEN_REPAIR: "true" })!.mode, "dry-run");
   assert.equal(parseRepairOptions({ MERRYMEN_REPAIR: "COMMIT " })!.mode, "commit");
   assert.equal(parseRepairOptions({ MERRYMEN_REPAIR: "verify-only" })!.mode, "verify-only");
-  assert.equal(
-    parseRepairOptions({ MERRYMEN_REPAIR: "dry-run", MERRYMEN_REPAIR_ACCOUNT: " 0xabc " })!.account,
-    "0xabc",
+  // A LIST, normalised once. Whitespace, case and stray commas are the
+  // operator's, not the comparison's — every downstream check reads a
+  // lower-cased array and never has to remember to trim.
+  assert.deepEqual(
+    parseRepairOptions({ MERRYMEN_REPAIR: "dry-run", MERRYMEN_REPAIR_ACCOUNT: " 0xABC " })!.accounts,
+    ["0xabc"],
+  );
+  assert.deepEqual(
+    parseRepairOptions({
+      MERRYMEN_REPAIR: "commit",
+      MERRYMEN_REPAIR_ACCOUNT: "0xAAA, 0xbbb ,,0xCcC,",
+    })!.accounts,
+    ["0xaaa", "0xbbb", "0xccc"],
+  );
+  // Anything that is not an address is dropped rather than silently becoming a
+  // selector that matches nothing.
+  assert.deepEqual(
+    parseRepairOptions({ MERRYMEN_REPAIR: "commit", MERRYMEN_REPAIR_ACCOUNT: "all, everything" })!.accounts,
+    [],
   );
   assert.equal(parseRepairOptions({ MERRYMEN_REPAIR: "commit", MERRYMEN_REPAIR_RESUME: "1" })!.resume, true);
   assert.equal(parseRepairOptions({ MERRYMEN_REPAIR: "commit" })!.resume, false);
@@ -422,7 +445,7 @@ test("a dry run writes nothing", async () => {
       insert: [row({ txHash: TX, logIndex: 1 })],
       quarantine: [{ id, direction: "in", amountUsdg: 1000, source: "inferred", reason: "superseded" }],
     }),
-    { mode: "dry-run", runId: "r", resume: false },
+    { mode: "dry-run", runId: "r", resume: false, accounts: [] },
     CHAIN,
   );
   assert.match(r.why, /^dry run: would insert 1 and quarantine 1/);
@@ -437,7 +460,7 @@ test("--account limits the mutation to one smart account", async () => {
   const pa = plan({ smartAccount: A, insert: [row({ agentId: A, txHash: TX, logIndex: 1 })] });
   const pb = plan({ smartAccount: B, insert: [row({ agentId: B, txHash: TX2, logIndex: 1 })] });
 
-  const results = await runRepair(db, [pa, pb], { ...COMMIT, account: A.toLowerCase() }, CHAIN);
+  const results = await runRepair(db, [pa, pb], { ...COMMIT, accounts: [A.toLowerCase()] }, CHAIN);
   assert.equal(results[0]!.stage, "recomputed");
   assert.equal(results[1]!.stage, "skipped-not-selected");
   assert.equal(await countFlows(db, A), 1);

--- a/worker/src/accounting-repair.ts
+++ b/worker/src/accounting-repair.ts
@@ -34,8 +34,18 @@ export type RepairMode = "dry-run" | "verify-only" | "commit";
 export interface RepairOptions {
   /** DRY RUN IS THE DEFAULT. Mutation requires saying so. */
   mode: RepairMode;
-  /** Limit to one smart account. The canary goes first, alone. */
-  account?: string;
+  /**
+   * WHICH ACCOUNTS THIS RUN MAY TOUCH. Lower-cased, and never empty in commit
+   * mode.
+   *
+   * A list rather than a single account because the alternative — one account
+   * per deploy — made a 24-tenant repair into two hours of restarts, and an
+   * operator restarting production twenty-three times makes a mistake somewhere
+   * around the eighth. What it is NOT is a way to say "everything": an empty
+   * list still refuses to commit, so the accounts being repaired are always
+   * named by someone rather than defaulted into.
+   */
+  accounts: string[];
   /** Groups every row this run moved, so one run can be undone as a unit. */
   runId: string;
   /**
@@ -170,8 +180,8 @@ export async function repairAccount(
     why: "",
   };
 
-  if (opts.account && opts.account.toLowerCase() !== plan.smartAccount.toLowerCase()) {
-    return { ...base, stage: "skipped-not-selected", why: "not the selected account" };
+  if (opts.accounts.length > 0 && !opts.accounts.includes(plan.smartAccount.toLowerCase())) {
+    return { ...base, stage: "skipped-not-selected", why: "not in the selected set" };
   }
   if (plan.blocked) {
     // A blocked account is not a failure — it is the tool declining to guess.
@@ -351,10 +361,15 @@ export function parseRepairOptions(env: Record<string, string | undefined>, now 
   const raw = (env.MERRYMEN_REPAIR ?? "").trim().toLowerCase();
   if (!raw) return null;
   const mode: RepairMode = raw === "commit" ? "commit" : raw === "verify-only" ? "verify-only" : "dry-run";
-  const account = (env.MERRYMEN_REPAIR_ACCOUNT ?? "").trim() || undefined;
+  // Comma-separated, whitespace-tolerant, lower-cased once here so no
+  // comparison downstream has to remember to do it.
+  const accounts = (env.MERRYMEN_REPAIR_ACCOUNT ?? "")
+    .split(",")
+    .map((a) => a.trim().toLowerCase())
+    .filter((a) => a.startsWith("0x"));
   return {
     mode,
-    account,
+    accounts,
     // A generated id is timestamped rather than random so the run that moved a
     // row can be placed in time from the quarantine table alone.
     runId: (env.MERRYMEN_REPAIR_RUN_ID ?? "").trim() || `run-${new Date(now).toISOString().replace(/[:.]/g, "-")}`,
@@ -411,6 +426,26 @@ export async function runRepair(
   // guarantee is an application-side check across a network — which is exactly
   // what the requirement rules out — so it refuses rather than proceeding on a
   // promise it cannot keep. A dry run is still allowed: it writes nothing.
+  if (opts.mode === "commit" && opts.accounts.length === 0) {
+    // NAMED, OR NOT AT ALL. The rule was "the canary goes first, alone"; now
+    // that it has gone and survived a restart, the rule that remains is that
+    // the accounts being mutated are always spelled out. A run that repairs
+    // whatever it happens to find is one nobody approved.
+    return [
+      {
+        account: "*",
+        stage: "failed",
+        inserted: 0,
+        insertsAlreadyPresent: 0,
+        quarantined: 0,
+        contributionsBeforeUsdg: 0,
+        contributionsAfterUsdg: 0,
+        contributionsKnownAfter: false,
+        why: "commit requires MERRYMEN_REPAIR_ACCOUNT to name the accounts to repair",
+      },
+    ];
+  }
+
   if (opts.mode === "commit" && !(await hasChainIdentityIndex(db))) {
     return [
       {
@@ -433,6 +468,12 @@ export async function runRepair(
     const r = await repairAccount(db, plan, opts, chainId);
     out.push(r);
     onResult?.(r);
+    // A FAILURE stops the batch; a BLOCKED account does not. Blocked means the
+    // tool declined to guess about one account, which says nothing about the
+    // next one — and stopping there would make a single flaky chain read cost
+    // the whole run. A FAILED account is different: something went wrong that
+    // nobody has read yet, and twenty-three further mutations after it is not
+    // throughput, it is a bigger incident.
     if (r.stage === "failed") break;
   }
   return out;

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -790,13 +790,24 @@ async function runReconstructionDryRunIfAsked(): Promise<void> {
     // about. The ROSTER still enumerates every tenant from the plan, so a
     // scoped run still reports 24/24 — the accounts outside the scope simply
     // carry no chain evidence and say so.
-    const scopeTo = (process.env.MERRYMEN_REPAIR_ACCOUNT ?? "").trim().toLowerCase();
+    const scopeTo = new Set(
+      (process.env.MERRYMEN_REPAIR_ACCOUNT ?? "")
+        .split(",")
+        .map((a) => a.trim().toLowerCase())
+        .filter((a) => a.startsWith("0x")),
+    );
     const allAccounts = agents.map((a) => String(a.smart_account)).filter((a) => a.startsWith("0x"));
-    const accounts = scopeTo
-      ? allAccounts.filter((a) => a.toLowerCase() === scopeTo)
-      : allAccounts;
-    if (scopeTo && accounts.length === 0) {
-      log(`recon| MERRYMEN_REPAIR_ACCOUNT=${scopeTo} matches no account in the roster — nothing to scan`);
+    const accounts = scopeTo.size ? allAccounts.filter((a) => scopeTo.has(a.toLowerCase())) : allAccounts;
+    if (scopeTo.size && accounts.length === 0) {
+      log("recon| MERRYMEN_REPAIR_ACCOUNT matches no account in the roster — nothing to scan");
+    }
+    if (scopeTo.size > accounts.length) {
+      // LOUD. A named account that is not in the roster will silently do
+      // nothing, and an operator reading "repaired 5" after naming 6 has no
+      // way to tell which one never existed.
+      log(
+        `recon| WARNING: ${scopeTo.size} account(s) named but only ${accounts.length} found in the roster`,
+      );
     }
     const rpcUrl = process.env.MERRYMEN_RPC_MAINNET ?? "https://rpc.mainnet.chain.robinhood.com";
     let rpcId = 1;
@@ -815,7 +826,7 @@ async function runReconstructionDryRunIfAsked(): Promise<void> {
     const head = BigInt((await rpc("eth_blockNumber", [])) as string);
     log(
       `recon| scanning ${accounts.length} of ${allAccounts.length} account(s) to block ${head}` +
-        (scopeTo ? ` — scoped to ${scopeTo}` : ""),
+        (scopeTo.size ? ` — scoped to ${accounts.length} named account(s)` : ""),
     );
     const chain = await scanFleetCapital(rpc, {
       accounts,
@@ -877,10 +888,10 @@ async function runRepairIfAsked(shared: Db, plans: readonly AccountPlan[]): Prom
 
   // THE PREVIEW IS ALWAYS PRINTED, in every mode. An operator reading a commit
   // run's output should not have to go and find the dry run it corresponds to.
-  const previews = runPreview(plans, { account: opts.account ?? null });
+  const previews = runPreview(plans, { accounts: opts.accounts });
   log(
-    `preview| run ${opts.runId} · mode ${opts.mode} · account ${opts.account ?? "ALL"} · ` +
-      `resume ${opts.resume}`,
+    `preview| run ${opts.runId} · mode ${opts.mode} · ` +
+      `accounts ${opts.accounts.length ? opts.accounts.length : "ALL"} · resume ${opts.resume}`,
   );
   for (const p of previews) {
     if (!p.selected) continue;
@@ -893,12 +904,11 @@ async function runRepairIfAsked(shared: Db, plans: readonly AccountPlan[]): Prom
     log("preview| dry run — nothing was written");
     return;
   }
-  if (opts.mode === "commit" && !opts.account) {
-    // The canary goes first, ALONE, and the fleet is a separate decision taken
-    // after it has survived a restart unchanged. Refusing here rather than
-    // trusting the operator to remember is the same fail-closed shape the rest
-    // of this accounting work is built from.
-    log("repair| refusing a fleet-wide commit — set MERRYMEN_REPAIR_ACCOUNT to repair one account at a time");
+  if (opts.mode === "commit" && opts.accounts.length === 0) {
+    // The accounts being mutated are always named. runRepair refuses this too;
+    // saying it here as well means the log shows WHY nothing happened rather
+    // than just showing nothing happening.
+    log("repair| refusing a commit with no named accounts — set MERRYMEN_REPAIR_ACCOUNT");
     return;
   }
 


### PR DESCRIPTION
`MERRYMEN_REPAIR_ACCOUNT` now takes a list. One account per deploy turned a 24-tenant repair into two hours of restarts, and an operator restarting production twenty-three times makes a mistake somewhere around the eighth.

**What did not change is that the accounts are always named.** The old gate said "the canary goes first, alone". The canary has now gone — repaired, survived a restart with its figures intact, re-run came back a no-op — so the rule that remains is the one doing the real work: **a commit with no named accounts is refused**. A run that repairs whatever it happens to find is one nobody approved. `MERRYMEN_REPAIR_ACCOUNT=all` selects nothing and is refused, because `all` is a word the tool does not implement.

The chain scan follows the same set, so a named repair still scans only what it is repairing. A named account **missing from the roster is loud** — reading "repaired 5" after naming 6 gives an operator no way to tell which one never existed.

**A BLOCKED account no longer stops the batch.** Blocked means the tool declined to guess about one account, which says nothing about the next, and stopping there would let a single flaky chain read cost the whole run. A **FAILED** account still stops it: something went wrong that nobody has read yet.

Selectors are normalised once at parse — whitespace, case and stray commas are the operator's problem, not every downstream comparison's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)