### PR TITLE
An account nobody looked at is not an account with a problem

### DIFF
--- a/worker/src/accounting-preview.test.ts
+++ b/worker/src/accounting-preview.test.ts
@@ -139,14 +139,16 @@ describe("every tenant is classified", () => {
     assert.equal(previews.length, plans.length, "no account is dropped from the roster");
   });
 
-  it("classifies an account --account did not select, rather than omitting it", () => {
-    // "Not in the mutation list" must never be readable as "safe".
+  it("keeps an account --account did not select on the roster, rather than omitting it", () => {
+    // "Not in the mutation list" must never be readable as "safe" — but it must
+    // not be readable as "broken" either. An unselected account is NOT-EXAMINED:
+    // present, counted, and honest about the fact that nobody looked at it.
     const previews = runPreview([canaryPlan(), plan({ smartAccount: PAPER, isPaper: true })], {
       accounts: [CANARY.toLowerCase()],
     });
     assert.equal(previews.length, 2);
     assert.equal(previews[1]!.selected, false);
-    assert.equal(previews[1]!.outcome, "NO-CHAIN-HISTORY");
+    assert.equal(previews[1]!.outcome, "NOT-EXAMINED");
   });
 });
 
@@ -288,5 +290,57 @@ describe("the report has to fit in the window you can read it in", () => {
     assert.equal(roster.length, 25, "one line per tenant, plus the total");
     assert.equal(previews.filter((p) => p.selected).length, 1, "only the named account gets a block");
     assert.ok(roster.length + blocks.length < 100, `report is ${roster.length + blocks.length} lines, well inside 503`);
+  });
+});
+
+describe("an account nobody looked at is not an account with a problem", () => {
+  it("reports NOT-EXAMINED rather than BLOCKED-AMBIGUOUS", () => {
+    // A scoped repair scans only what it repairs, so every other account has no
+    // chain result and the planner marks it blocked. Reporting that as BLOCKED
+    // reads as "this account is in trouble" when the truth is "nobody asked".
+    const outside = plan({
+      smartAccount: PAPER,
+      blocked: "no chain scan result for this account",
+      existingTotalUsdg: 10,
+      contributionsKnownBefore: true,
+      contributionsAfterUsdg: 0,
+      contributionsKnownAfter: false,
+    });
+    const p = previewAccount(outside, [CANARY.toLowerCase()]);
+    assert.equal(p.selected, false);
+    assert.equal(p.outcome, "NOT-EXAMINED");
+    assert.equal(p.blocked, null, "it is not blocked, it is unread");
+  });
+
+  it("does not invent an 'after' from a scan that never ran", () => {
+    // The line that made this urgent: the already-repaired canary appeared as
+    // `contributions 10.000000 -> 0.000000 · known false -> false`, derived
+    // entirely from evidence nobody gathered. An operator reading that would
+    // conclude the repair had undone itself.
+    const repaired = plan({
+      smartAccount: CANARY,
+      blocked: "no chain scan result for this account",
+      existingTotalUsdg: 10,
+      contributionsKnownBefore: true,
+      contributionsAfterUsdg: 0,
+      contributionsKnownAfter: false,
+    });
+    const p = previewAccount(repaired, ["0xsomeoneelse"]);
+    assert.equal(p.contributionsAfterUsdg, 10, "unchanged, because nothing was examined");
+    assert.equal(p.contributionsKnownAfter, true, "and its known-state is not downgraded either");
+  });
+
+  it("still counts every tenant, which was always the point", () => {
+    const plans = [
+      canaryPlan(),
+      plan({ smartAccount: PAPER, blocked: "no chain scan result for this account" }),
+      plan({ smartAccount: "0xccc", blocked: "no chain scan result for this account" }),
+    ];
+    const previews = runPreview(plans, { accounts: [CANARY.toLowerCase()] });
+    const total = rosterLines(previews).find((l) => l.startsWith("ROSTER TOTAL"))!;
+    assert.match(total, /3 account\(s\)/);
+    assert.match(total, /EVIDENCE-BACKED-REPAIR 1/);
+    assert.match(total, /NOT-EXAMINED 2/);
+    assert.match(total, /BLOCKED-AMBIGUOUS 0/, "not looked at is not blocked");
   });
 });

--- a/worker/src/accounting-preview.ts
+++ b/worker/src/accounting-preview.ts
@@ -25,7 +25,26 @@ import type { AccountPlan } from "./accounting-reconstruction";
  * one — the report is meant to be read as "all 24 are accounted for", which it
  * cannot be if an account can fall through.
  */
-export type RosterOutcome = "NO-CHAIN-HISTORY" | "EVIDENCE-BACKED-REPAIR" | "BLOCKED-AMBIGUOUS";
+export type RosterOutcome =
+  | "NO-CHAIN-HISTORY"
+  | "EVIDENCE-BACKED-REPAIR"
+  | "BLOCKED-AMBIGUOUS"
+  /**
+   * NOT LOOKED AT THIS RUN — which is not the same as "has a problem".
+   *
+   * A scoped repair scans only the accounts it is repairing, so every other
+   * account has no chain result and the planner marks it blocked. Reporting
+   * that as BLOCKED-AMBIGUOUS was wrong in the way that matters: it reads as
+   * "this account is in trouble" when the truth is "nobody asked about it", and
+   * it dragged the already-repaired canary into the blocked column with a
+   * `contributions 10.000000 -> 0.000000` line derived from evidence that was
+   * never gathered. An operator reading that would think the repair had undone
+   * itself.
+   *
+   * The roster still enumerates all 24 — the point was never that every account
+   * is examined every run, it was that none disappears.
+   */
+  | "NOT-EXAMINED";
 
 
 /**
@@ -41,8 +60,12 @@ export function previewRequested(env: Record<string, string | undefined>): boole
 }
 
 /** Which of the three outcomes this account falls into. Total over every plan. */
-export function rosterOutcome(plan: AccountPlan): RosterOutcome {
-  // BLOCKED FIRST. An account the classifier could not resolve must not be
+export function rosterOutcome(plan: AccountPlan, examined = true): RosterOutcome {
+  // NOT EXAMINED FIRST. An account outside a scoped run's selection was never
+  // scanned, so every verdict below would be an opinion about evidence nobody
+  // collected.
+  if (!examined) return "NOT-EXAMINED";
+  // BLOCKED NEXT. An account the classifier could not resolve must not be
   // reported as a repair merely because it also has rows to insert.
   if (plan.blocked !== null) return "BLOCKED-AMBIGUOUS";
   if (plan.insert.length > 0) return "EVIDENCE-BACKED-REPAIR";
@@ -86,22 +109,29 @@ export function previewAccount(plan: AccountPlan, selected: readonly string[]): 
     if (r.direction === "in") grossIn += r.amountUsdg;
     else grossOut += r.amountUsdg;
   }
+  const isSelected = selected.length === 0 || selected.includes(plan.smartAccount.toLowerCase());
+  const outcome = rosterOutcome(plan, isSelected);
+  // AN UNEXAMINED ACCOUNT REPORTS NO "AFTER". Every after-figure is computed
+  // from chain evidence, and for an account nobody scanned there is none — so
+  // the honest answer is the figure it already has, not a zero derived from an
+  // empty scan.
+  const unexamined = outcome === "NOT-EXAMINED";
   return {
     account: plan.smartAccount,
     tenant: plan.tenant,
-    outcome: rosterOutcome(plan),
-    selected: selected.length === 0 || selected.includes(plan.smartAccount.toLowerCase()),
+    outcome,
+    selected: isSelected,
     isPaper: plan.isPaper,
     epoch: plan.epoch,
     inserts: plan.insert.length,
     quarantines: plan.quarantine.length,
     contributionsBeforeUsdg: round6(plan.existingTotalUsdg),
-    contributionsAfterUsdg: round6(plan.contributionsAfterUsdg),
+    contributionsAfterUsdg: round6(unexamined ? plan.existingTotalUsdg : plan.contributionsAfterUsdg),
     contributionsKnownBefore: plan.contributionsKnownBefore,
-    contributionsKnownAfter: plan.contributionsKnownAfter,
+    contributionsKnownAfter: unexamined ? plan.contributionsKnownBefore : plan.contributionsKnownAfter,
     grossContributionsAfterUsdg: round6(grossIn),
     grossWithdrawalsAfterUsdg: round6(grossOut),
-    blocked: plan.blocked,
+    blocked: unexamined ? null : plan.blocked,
   };
 }
 
@@ -118,6 +148,7 @@ export function rosterLines(previews: readonly AccountPreview[]): string[] {
     "NO-CHAIN-HISTORY": 0,
     "EVIDENCE-BACKED-REPAIR": 0,
     "BLOCKED-AMBIGUOUS": 0,
+    "NOT-EXAMINED": 0,
   };
   for (const p of previews) {
     tally[p.outcome] += 1;
@@ -133,7 +164,8 @@ export function rosterLines(previews: readonly AccountPreview[]): string[] {
     `ROSTER TOTAL ${previews.length} account(s) — ` +
       `NO-CHAIN-HISTORY ${tally["NO-CHAIN-HISTORY"]} · ` +
       `EVIDENCE-BACKED-REPAIR ${tally["EVIDENCE-BACKED-REPAIR"]} · ` +
-      `BLOCKED-AMBIGUOUS ${tally["BLOCKED-AMBIGUOUS"]}`,
+      `BLOCKED-AMBIGUOUS ${tally["BLOCKED-AMBIGUOUS"]} · ` +
+      `NOT-EXAMINED ${tally["NOT-EXAMINED"]}`,
   );
   return L;
 }


### PR DESCRIPTION
Scoping the chain scan to the accounts being repaired (#75 — the fix that made the canary repair possible) quietly broke the roster it is read alongside.

Every account **outside the scope** has no chain result, so the planner marks it blocked, and the report called that `BLOCKED-AMBIGUOUS`. The first fleet dry run showed how bad the confusion gets — the **already-repaired canary** appeared as:

```
0x3E34E58e … BLOCKED-AMBIGUOUS · contributions 10.000000 -> 0.000000 · known false -> false
```

derived entirely from evidence that was never gathered. An operator reading that would conclude the repair had undone itself. **It had not** — a blocked account is not mutated, so nothing was ever at risk — but a report that says the opposite of the truth is its own defect.

`NOT-EXAMINED` is now a fourth outcome, **checked first**, because every verdict below it is an opinion about evidence nobody collected. An unexamined account reports no "after" either: its after-figures are its current ones, not zeros from an empty scan, and its known-state is not downgraded.

The roster still enumerates all 24 and the tally still adds up. The point was never that every account is examined every run — it was that none disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)