### PR TITLE
The canonical portfolio snapshot — one type, one builder, four consumers

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,3 +13,8 @@ export * from "./safe-url";
 export * from "./robinhood-oauth";
 export * from "./flow-evidence";
 export * from "./capital-classify";
+
+// THE CANONICAL PORTFOLIO SNAPSHOT. One type, one builder, four consumers —
+// worker, web, social and Brain. Exported from core precisely so none of them
+// can grow its own NAV or P&L implementation.
+export * from "./portfolio-snapshot";

--- a/packages/core/src/portfolio-snapshot.test.ts
+++ b/packages/core/src/portfolio-snapshot.test.ts
@@ -1,0 +1,214 @@
+/**
+ * THE NUMBERS THAT REACHED A REAL OWNER'S SCREEN, pinned so they cannot again.
+ *
+ * Each case here is a figure this system actually published: +999.48 on a book
+ * that was down 0.52, a fabricated -100%, a -66.7% derived from netting trade
+ * legs as withdrawals. The gate that stops them is now in ONE place, and these
+ * are the inputs that used to get past the five that disagreed.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildPortfolioSnapshot,
+  computePnl,
+  microToString,
+  pnlPercent,
+  toMicro,
+  type PortfolioQuality,
+  type SnapshotPosition,
+} from "./portfolio-snapshot";
+
+const GOOD: PortfolioQuality = {
+  auditPassed: true,
+  epoch: 2,
+  contributionsKnown: true,
+  equityComplete: true,
+  gasBasis: "net",
+  positionHistoryAvailable: true,
+  quarantinedAssetsPresent: false,
+  assessedAt: 1_788_000_000,
+};
+
+const pos = (over: Partial<SnapshotPosition> = {}): SnapshotPosition => ({
+  instrumentId: "merrymen:tsla",
+  symbol: "TSLA",
+  qtyRaw: "4420417000000000",
+  valueUsdg: toMicro(6.55),
+  costBasisUsdg: toMicro(6.666),
+  priceSource: "chainlink",
+  quarantined: false,
+  ...over,
+});
+
+const build = (over: Partial<Parameters<typeof buildPortfolioSnapshot>[0]> = {}) =>
+  buildPortfolioSnapshot({
+    snapshotId: "snap_1",
+    agentId: "0xagent",
+    asOf: 1_788_000_000,
+    epoch: 2,
+    cashUsdg: toMicro(3.334),
+    netContributionsUsdg: toMicro(10),
+    gasUsdg: toMicro(0.01),
+    positions: [pos()],
+    quality: GOOD,
+    ...over,
+  });
+
+describe("money never becomes a float across the boundary", () => {
+  it("round-trips through integer micro-USDG", () => {
+    assert.equal(toMicro(3.334), 3_334_000);
+    assert.equal(microToString(3_334_000), "3.334000");
+    assert.equal(microToString(10_000_000), "10.000000");
+    assert.equal(microToString(-59_000_000_000), "-59000.000000");
+    assert.equal(microToString(1), "0.000001");
+  });
+
+  it("does not lose the sixth decimal the way a float would", () => {
+    // 0.1 + 0.2 territory. The ledger stores REAL and the chain speaks base
+    // units; this is the seam where the difference used to disappear.
+    const m = toMicro(1.666500) * 4;
+    assert.equal(m, 6_666_000);
+    assert.equal(microToString(m), "6.666000");
+  });
+});
+
+describe("the equity identity is computed in one place", () => {
+  it("is cash + vault + positions + quarantined", () => {
+    const s = build({
+      cashUsdg: toMicro(3.334),
+      vaultUsdg: toMicro(1),
+      quarantinedUsdg: toMicro(2),
+      positions: [pos({ valueUsdg: toMicro(6.55) })],
+    });
+    assert.equal(s.equityUsdg, toMicro(3.334) + toMicro(1) + toMicro(6.55) + toMicro(2));
+    assert.equal(microToString(s.equityUsdg), "12.884000");
+  });
+
+  it("does not double-count a quarantined position", () => {
+    // Quarantined holdings are carried at cost in `quarantinedUsdg`, so counting
+    // their market value again in `positionsUsdg` would inflate the book by an
+    // asset that cannot be sold.
+    const s = build({
+      quarantinedUsdg: toMicro(5),
+      positions: [pos({ valueUsdg: toMicro(6.55) }), pos({ symbol: "DEAD", valueUsdg: toMicro(99), quarantined: true })],
+    });
+    assert.equal(s.positionsUsdg, toMicro(6.55));
+    assert.equal(s.equityUsdg, toMicro(3.334) + toMicro(6.55) + toMicro(5));
+  });
+});
+
+describe("P&L refuses rather than fabricating", () => {
+  it("publishes when the book supports it", () => {
+    const s = build();
+    assert.equal(s.pnl.publishable, true);
+    // 9.884 equity − 10 contributed − 0.01 gas
+    assert.equal(microToString(s.pnl.usdgSinceContribution!), "-0.126000");
+    assert.equal(s.pnl.gasBasis, "net");
+  });
+
+  it("REFUSES when contributions are unknown — the +999.48 case", () => {
+    // A ledger written before flow tracking knows nothing about what was put in.
+    // Equity minus zero is the bankroll, and it was once published as profit on
+    // a book that was actually down 0.52.
+    const s = build({ netContributionsUsdg: null, cashUsdg: toMicro(999.48), positions: [] });
+    assert.equal(s.pnl.publishable, false);
+    assert.equal(s.pnl.unavailable, "contributions-unknown");
+    assert.equal(s.pnl.usdgSinceContribution, null);
+    assert.equal(pnlPercent(s), null);
+  });
+
+  it("REFUSES when the flag says unknown even if a figure is present", () => {
+    // Both halves have to agree. A number with `contributionsKnown: false`
+    // behind it is exactly the inferred row this system spent a repair removing.
+    const s = build({ quality: { ...GOOD, contributionsKnown: false } });
+    assert.equal(s.pnl.unavailable, "contributions-unknown");
+  });
+
+  it("REFUSES on zero contributed capital rather than dividing by it", () => {
+    // The repaired paper books land here: known, and known to be zero. That is
+    // knowledge, but it is not a denominator — this is the -100% case.
+    const s = build({ netContributionsUsdg: 0 });
+    assert.equal(s.pnl.unavailable, "no-capital-contributed");
+    assert.equal(pnlPercent(s), null);
+  });
+
+  it("REFUSES in epoch 1, which is forensic by construction", () => {
+    const s = build({ quality: { ...GOOD, epoch: 1 } });
+    assert.equal(s.pnl.unavailable, "epoch-unauditable");
+  });
+
+  it("REFUSES on a gappy equity series", () => {
+    const s = build({ quality: { ...GOOD, equityComplete: false } });
+    assert.equal(s.pnl.unavailable, "equity-incomplete");
+  });
+
+  it("reports the reasons in the order they actually bite", () => {
+    // Unknown contributions and epoch 1 together must report UNKNOWN, not
+    // EPOCH: they send whoever reads it to different places, and the
+    // denominator is the more fundamental problem.
+    const s = build({ netContributionsUsdg: null, quality: { ...GOOD, epoch: 1, contributionsKnown: false } });
+    assert.equal(s.pnl.unavailable, "contributions-unknown");
+  });
+});
+
+describe("gross-of-gas never masquerades as net", () => {
+  it("marks the basis gross when gas could not be priced", () => {
+    const s = build({ gasUsdg: null });
+    assert.equal(s.pnl.publishable, true);
+    assert.equal(s.pnl.gasBasis, "gross", "the qualifier travels with the figure");
+    // Unsubtracted, because it is unknown — not silently treated as zero cost.
+    assert.equal(microToString(s.pnl.usdgSinceContribution!), "-0.116000");
+  });
+
+  it("carries the qualifier even on a healthy book", () => {
+    const s = build({ quality: { ...GOOD, gasBasis: "gross" } });
+    assert.equal(s.pnl.gasBasis, "gross");
+  });
+});
+
+describe("the canary, after its repair", () => {
+  it("reads 10 USDG contributed and a publishable P&L", () => {
+    // The real post-repair figures: 3.334 cash, 6.55 in TSLA, 10.000000
+    // contributed and evidenced. Before the repair this account carried three
+    // inferred rows totalling 30 and contributionsKnown was false.
+    const s = build({
+      cashUsdg: toMicro(3.334),
+      positions: [pos({ valueUsdg: toMicro(6.55) })],
+      netContributionsUsdg: toMicro(10),
+      grossContributionsUsdg: toMicro(10),
+      grossWithdrawalsUsdg: 0,
+      gasUsdg: null,
+    });
+    assert.equal(microToString(s.equityUsdg), "9.884000");
+    assert.equal(microToString(s.netContributionsUsdg!), "10.000000");
+    assert.equal(s.pnl.publishable, true);
+    assert.equal(microToString(s.pnl.usdgSinceContribution!), "-0.116000");
+    assert.ok(Math.abs(pnlPercent(s)! - -1.16) < 0.001);
+    // And never the pre-repair figure derived from netting trade legs.
+    assert.notEqual(microToString(s.netContributionsUsdg!), "3.334000");
+  });
+
+  it("keeps gross apart from net, because net zero is not 'never funded'", () => {
+    const s = build({
+      netContributionsUsdg: 0,
+      grossContributionsUsdg: toMicro(1010),
+      grossWithdrawalsUsdg: toMicro(1010),
+    });
+    assert.equal(microToString(s.grossContributionsUsdg!), "1010.000000");
+    assert.equal(s.netContributionsUsdg, 0);
+    assert.equal(s.pnl.unavailable, "no-capital-contributed");
+  });
+});
+
+describe("computePnl is the only gate", () => {
+  it("is pure and agrees with the snapshot that uses it", () => {
+    const s = build();
+    const direct = computePnl({
+      equityUsdg: s.equityUsdg,
+      netContributionsUsdg: s.netContributionsUsdg,
+      gasUsdg: s.gasUsdg,
+      quality: s.quality,
+    });
+    assert.deepEqual(direct, s.pnl, "one implementation, not two that drift");
+  });
+});

--- a/packages/core/src/portfolio-snapshot.ts
+++ b/packages/core/src/portfolio-snapshot.ts
@@ -1,0 +1,261 @@
+/**
+ * THE ONE DESCRIPTION OF WHAT AN AGENT OWNS AND HOW IT IS DOING.
+ *
+ * It lives in core rather than in the worker, the web tier or Brain, because
+ * three copies of "what is this book worth" is how you get three answers. The
+ * worker computes equity from balances, the web recomputed it from mirrored
+ * rows, and Brain would have been the third — and each would have been right
+ * about slightly different things. The whole accounting effort behind this file
+ * exists because numbers that disagree are worse than numbers that are missing.
+ *
+ * SO: one type, one builder, four consumers — worker, web, social, Brain.
+ *
+ * MONEY IS INTEGER MICRO-USDG throughout. Not a preference: the ledger stores
+ * decimal REAL, the chain speaks base units, and JavaScript's number silently
+ * loses the difference. A snapshot that crosses a service boundary as a float is
+ * a snapshot whose last decimal place depends on who parsed it.
+ *
+ * THE THREE THINGS THIS TYPE REFUSES TO DO:
+ *
+ *   1. It will not present UNKNOWN as ZERO. `netContributionsUsdg` is null when
+ *      nothing is on record, and every consumer must handle that arm — equity
+ *      minus zero is the owner's own bankroll presented as profit, which is the
+ *      original bug this whole system was rebuilt around.
+ *   2. It will not publish a P&L it cannot back. `pnl.publishable` is computed
+ *      HERE, once, from the quality object, rather than left to five different
+ *      gates in the web tier that historically disagreed.
+ *   3. It will not let gross-of-gas masquerade as net. The basis travels with
+ *      the figure.
+ */
+
+/** Integer micro-USDG (1e-6 USDG). The only money type that crosses a boundary. */
+export type MicroUsdg = number;
+
+export const USDG_SCALE = 1_000_000;
+
+/** Decimal USDG to micro-USDG, rounded once, at the edge. */
+export const toMicro = (usdg: number): MicroUsdg => Math.round(usdg * USDG_SCALE);
+/** Micro-USDG to a decimal STRING. Never back to a float for display. */
+export const microToString = (m: MicroUsdg): string => {
+  const neg = m < 0;
+  const a = Math.abs(Math.trunc(m));
+  return `${neg ? "-" : ""}${Math.floor(a / USDG_SCALE)}.${String(a % USDG_SCALE).padStart(6, "0")}`;
+};
+
+/**
+ * HOW MUCH OF THIS SNAPSHOT CAN BE TRUSTED, as machine-readable facts.
+ *
+ * Every field is a claim a consumer may need to refuse on. Prose in a `why`
+ * string is for humans; these are for code, and the difference is that code
+ * cannot be persuaded.
+ */
+export interface PortfolioQuality {
+  /** The ledger recomputed from fills/flows/marks and matched. */
+  auditPassed: boolean;
+  /** Accounting epoch. Epoch 1 predates auditable flows and is forensic only. */
+  epoch: number;
+  /** Contributed capital rests on receipts, not on inference. */
+  contributionsKnown: boolean;
+  /** The equity series has no gaps in the window this snapshot covers. */
+  equityComplete: boolean;
+  /**
+   * Whether trading costs are subtracted. `gross` means small edges are
+   * overstated by exactly the gas, and saying so is the difference between a
+   * qualified figure and a wrong one.
+   */
+  gasBasis: "gross" | "net" | "unknown";
+  positionHistoryAvailable: boolean;
+  /** Some holdings are carried at cost rather than at market. */
+  quarantinedAssetsPresent: boolean;
+  /** Unix seconds. A quality flag with no timestamp cannot be told from a stale one. */
+  assessedAt: number | null;
+}
+
+export interface SnapshotPosition {
+  /** Merrymen's canonical id. NEVER an address — see thesis-policy and Brain. */
+  instrumentId: string;
+  symbol: string;
+  /** Base units as a decimal string; token decimals vary (USDG 6, most others 18). */
+  qtyRaw: string;
+  valueUsdg: MicroUsdg;
+  costBasisUsdg: MicroUsdg | null;
+  /** Where the price came from. A feed and a pool TWAP are not equal evidence. */
+  priceSource: "chainlink" | "pool" | "paper" | "unknown";
+  /** Carried at cost because it could not be sold or priced. */
+  quarantined: boolean;
+}
+
+/**
+ * WHY A P&L IS OR IS NOT PUBLISHABLE, decided once.
+ *
+ * The web tier had five separate gates for this and they disagreed, which is how
+ * a `-100%` reached a real owner's screen. A closed union with a distinct arm
+ * per reason means a consumer renders the reason rather than inventing one.
+ */
+export type PnlUnavailable =
+  | "contributions-unknown"
+  | "no-capital-contributed"
+  | "equity-incomplete"
+  | "epoch-unauditable";
+
+export interface SnapshotPnl {
+  /** equity − contributions − gas, in micro-USDG. Null when not publishable. */
+  usdgSinceContribution: MicroUsdg | null;
+  publishable: boolean;
+  /** Set exactly when `publishable` is false. */
+  unavailable: PnlUnavailable | null;
+  /** Carried WITH the figure so it cannot be quoted without its qualifier. */
+  gasBasis: PortfolioQuality["gasBasis"];
+}
+
+export interface PortfolioSnapshot {
+  schemaVersion: "1.0.0";
+  snapshotId: string;
+  agentId: string;
+  /** Unix seconds the underlying reads were taken. */
+  asOf: number;
+  epoch: number;
+
+  cashUsdg: MicroUsdg;
+  vaultUsdg: MicroUsdg;
+  positionsUsdg: MicroUsdg;
+  quarantinedUsdg: MicroUsdg;
+  /** cash + vault + positions + quarantined. Computed, never read back. */
+  equityUsdg: MicroUsdg;
+
+  /**
+   * NULL MEANS UNKNOWN, and unknown is not zero.
+   *
+   * A ledger written before flow tracking knows nothing about what was put in,
+   * and treating that as "nothing was put in" republishes the original bug.
+   */
+  netContributionsUsdg: MicroUsdg | null;
+  grossContributionsUsdg: MicroUsdg | null;
+  grossWithdrawalsUsdg: MicroUsdg | null;
+
+  /** Gas actually paid, priced. Null when it could not be priced at burn time. */
+  gasUsdg: MicroUsdg | null;
+
+  positions: SnapshotPosition[];
+  quality: PortfolioQuality;
+  pnl: SnapshotPnl;
+}
+
+export interface SnapshotInputs {
+  agentId: string;
+  asOf: number;
+  epoch: number;
+  cashUsdg: MicroUsdg;
+  vaultUsdg?: MicroUsdg;
+  quarantinedUsdg?: MicroUsdg;
+  netContributionsUsdg: MicroUsdg | null;
+  grossContributionsUsdg?: MicroUsdg | null;
+  grossWithdrawalsUsdg?: MicroUsdg | null;
+  gasUsdg: MicroUsdg | null;
+  positions: SnapshotPosition[];
+  quality: PortfolioQuality;
+  /** Injected so the builder stays pure and two callers cannot disagree on ids. */
+  snapshotId: string;
+}
+
+/**
+ * Build the snapshot. PURE, and the ONLY place equity and P&L are computed.
+ *
+ * `buildPortfolioSnapshot` is what stops "web NAV", "worker NAV" and "Brain NAV"
+ * from becoming three implementations. A consumer that wants a number calls
+ * this; a consumer that computes its own is a bug.
+ */
+export function buildPortfolioSnapshot(input: SnapshotInputs): PortfolioSnapshot {
+  const vault = input.vaultUsdg ?? 0;
+  const quarantined = input.quarantinedUsdg ?? 0;
+  const positionsUsdg = input.positions
+    .filter((p) => !p.quarantined)
+    .reduce((sum, p) => sum + p.valueUsdg, 0);
+
+  // THE EQUITY IDENTITY, in one place. cash + vault + positions + quarantined.
+  // Quarantined holdings are carried at cost and are still the owner's, so
+  // leaving them out understates the book by exactly what cannot be sold.
+  const equityUsdg = input.cashUsdg + vault + positionsUsdg + quarantined;
+
+  const pnl = computePnl({
+    equityUsdg,
+    netContributionsUsdg: input.netContributionsUsdg,
+    gasUsdg: input.gasUsdg,
+    quality: input.quality,
+  });
+
+  return {
+    schemaVersion: "1.0.0",
+    snapshotId: input.snapshotId,
+    agentId: input.agentId,
+    asOf: input.asOf,
+    epoch: input.epoch,
+    cashUsdg: input.cashUsdg,
+    vaultUsdg: vault,
+    positionsUsdg,
+    quarantinedUsdg: quarantined,
+    equityUsdg,
+    netContributionsUsdg: input.netContributionsUsdg,
+    grossContributionsUsdg: input.grossContributionsUsdg ?? null,
+    grossWithdrawalsUsdg: input.grossWithdrawalsUsdg ?? null,
+    gasUsdg: input.gasUsdg,
+    positions: input.positions,
+    quality: input.quality,
+    pnl,
+  };
+}
+
+/**
+ * ONE GATE, and it is checked in the order the reasons actually bite.
+ *
+ * The web tier had five gates for this question and they disagreed with each
+ * other, which is how a fabricated `-100%` reached an owner's screen. Order
+ * matters: an unknown denominator is a different fact from a zero one, and
+ * reporting the wrong reason sends whoever reads it to the wrong place.
+ */
+export function computePnl(args: {
+  equityUsdg: MicroUsdg;
+  netContributionsUsdg: MicroUsdg | null;
+  gasUsdg: MicroUsdg | null;
+  quality: PortfolioQuality;
+}): SnapshotPnl {
+  const basis = args.quality.gasBasis;
+
+  if (args.netContributionsUsdg === null || !args.quality.contributionsKnown) {
+    return { usdgSinceContribution: null, publishable: false, unavailable: "contributions-unknown", gasBasis: basis };
+  }
+  if (args.quality.epoch < 2) {
+    // Epoch 1 predates auditable flows by construction. Its rows are kept for
+    // forensics and must never be presented as measured.
+    return { usdgSinceContribution: null, publishable: false, unavailable: "epoch-unauditable", gasBasis: basis };
+  }
+  if (args.netContributionsUsdg <= 0) {
+    // KNOWN, and zero. That is knowledge — no real capital is at stake — but it
+    // is not a denominator, so no percentage rests on it.
+    return { usdgSinceContribution: null, publishable: false, unavailable: "no-capital-contributed", gasBasis: basis };
+  }
+  if (!args.quality.equityComplete) {
+    return { usdgSinceContribution: null, publishable: false, unavailable: "equity-incomplete", gasBasis: basis };
+  }
+
+  // GAS IS SUBTRACTED WHEN IT IS KNOWN, and the basis says so when it is not.
+  // Silently omitting it would overstate every small edge by exactly the gas.
+  const gas = args.gasUsdg ?? 0;
+  return {
+    usdgSinceContribution: args.equityUsdg - args.netContributionsUsdg - gas,
+    publishable: true,
+    unavailable: null,
+    gasBasis: args.gasUsdg === null ? "gross" : basis,
+  };
+}
+
+/**
+ * The percentage, or null. Separated from the figure because a percentage needs
+ * a denominator and the figure does not — and every place that has published a
+ * wrong number here published a percentage.
+ */
+export function pnlPercent(snap: PortfolioSnapshot): number | null {
+  if (!snap.pnl.publishable || snap.pnl.usdgSinceContribution === null) return null;
+  if (!snap.netContributionsUsdg || snap.netContributionsUsdg <= 0) return null;
+  return (snap.pnl.usdgSinceContribution / snap.netContributionsUsdg) * 100;
+}


### PR DESCRIPTION
The last Phase 1 item. It lives in `packages/core` rather than in the worker, the web tier or Brain, because **three copies of "what is this book worth" is how you get three answers**. The worker computed equity from balances, the web recomputed it from mirrored rows, and Brain would have been the third — each right about slightly different things.

`buildPortfolioSnapshot` is the only place equity is computed; `computePnl` the only place P&L is decided. A consumer that computes its own is a bug.

### Money is integer micro-USDG

The ledger stores decimal `REAL`, the chain speaks base units, and JavaScript's `number` silently loses the difference. A snapshot that crosses a service boundary as a float is one whose last decimal place depends on who parsed it. `microToString` renders; nothing converts back.

### Three things the type refuses to do — each a figure that reached a real owner's screen

- **It will not present UNKNOWN as ZERO.** `netContributionsUsdg` is `null` when nothing is on record. Equity minus zero is the owner's own bankroll published as profit — the `+999.48` on a book that was down `0.52`.
- **It will not publish a P&L it cannot back.** The web tier had *five* gates for this and they disagreed, which is how a fabricated `-100%` shipped. There is now one, reporting its reason as a closed union so a consumer renders the reason rather than inventing one. Order matters: unknown contributions *and* epoch 1 together report `contributions-unknown`, because the denominator is the more fundamental problem and the two send a reader to different places.
- **It will not let gross-of-gas masquerade as net.** The basis travels with the figure, and gas that could not be priced marks the figure `gross` rather than being silently treated as zero cost.

### The equity identity, in one place

`cash + vault + positions + quarantined`. Quarantined holdings are carried at cost and are still the owner's, so omitting them understates the book by exactly what cannot be sold — and counting their market value *again* in positions would inflate it by the same asset twice. Both directions are pinned.

Tested against the canary's real post-repair figures (3.334 cash, 6.55 TSLA, 10.000000 contributed, P&L publishable at `-0.116000`) and against the number it must never produce again — the `3.334` that direction-only netting gave when it counted four router legs as withdrawals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)