### PR TITLE
Read the credential file the way Windows actually writes it

### DIFF
--- a/services/brain/brain/credential.py
+++ b/services/brain/brain/credential.py
@@ -70,7 +70,14 @@ def _dotenv() -> dict[str, str]:
     path = Path(__file__).resolve().parent.parent / ".env"
     out: dict[str, str] = {}
     try:
-        for line in path.read_text(encoding="utf-8").splitlines():
+        # utf-8-SIG, not utf-8. PowerShell's Set-Content and > both write a
+        # UTF-8 BOM by default, and with plain utf-8 that BOM becomes part of
+        # the FIRST KEY — so the file parses, contains what looks like the right
+        # line, and yields nothing. A credential file that silently reads as
+        # empty is the worst possible failure here: it looks like "no key set"
+        # and sends someone back to the fleet key. utf-8-sig strips a BOM when
+        # present and is identical to utf-8 when not.
+        for line in path.read_text(encoding="utf-8-sig").splitlines():
             line = line.strip()
             if not line or line.startswith("#") or "=" not in line:
                 continue


### PR DESCRIPTION
PowerShell's `Set-Content` and `>` both write a UTF-8 BOM by default. Read as plain `utf-8`, that BOM becomes part of the **first key** — so `services/brain/.env` parses cleanly, visibly contains the right line, and yields nothing.

That is the worst available failure for this file: it looks exactly like *"no key configured"*, which is the state that sends someone back to the fleet's shared key — the one thing `credential.py` exists to prevent. A credential loader that silently reads as empty is worse than one that throws.

`utf-8-sig` strips a BOM when present and is byte-identical to `utf-8` when not, so the file works however it was created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)