### PR TITLE
The worker call site: a Merryman thinks, and nothing happens

### DIFF
--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -59,6 +59,22 @@ export interface MerrymenSettings {
    */
   browserUrl?: string;
   browserToken?: string;
+  /**
+   * HOW A MERRYMAN THINKS — one shared Brain service, reached over Railway
+   * private networking, same shape as the browser and the bundler.
+   *
+   * HOUSE-OWNED on both counts: the URL is an address our egress connects to,
+   * and the token is a credential for a service whose inference bill the house
+   * pays. Unlike llmApiKey there is no version of this a tenant brings — a
+   * tenant who could set either would be repointing our egress or spending our
+   * model budget.
+   *
+   * ABSENT MEANS BRAIN DOES NOT RUN. Not "falls back to the local strategist":
+   * a missing Brain is a missing Brain, and quietly substituting a different
+   * reasoner would make the feed claim a thesis came from something it did not.
+   */
+  brainUrl?: string;
+  brainToken?: string;
   /** Rialto integrator key — enables the full quote→swap leg. */
   rialtoApiKey?: string;
   /** Header name the Rialto API expects the key in (their docs say). */
@@ -416,6 +432,15 @@ export const HOUSE_KEY_FIELDS = [
   "telegramTranscribeBase",
   "browserUrl",
   "browserToken",
+  // BRAIN IS THE HOUSE'S, on both counts the split above draws.
+  //
+  // The URL is an address OUR egress connects to on the private network, so it
+  // is the SSRF half. The token is a credential the HOUSE issued for a service
+  // the house pays the inference bill for — a tenant who could set either would
+  // be pointing our egress somewhere of their choosing, or spending our model
+  // budget. Unlike llmApiKey, there is no version of this a tenant brings.
+  "brainUrl",
+  "brainToken",
 ] as const;
 
 /**

--- a/worker/src/brain-disconnected.test.ts
+++ b/worker/src/brain-disconnected.test.ts
@@ -1,0 +1,74 @@
+/**
+ * EXECUTION IS DISCONNECTED BY ABSENCE, and this is what checks it.
+ *
+ * The shadow path's guarantee is not a flag someone can flip — it is that these
+ * modules do not import or call the execution machinery at all. Connecting
+ * execution later has to ADD an import, which shows up in a diff and needs a
+ * reason given.
+ *
+ * COMMENTS ARE STRIPPED FIRST. The modules describe what they will not do, in
+ * prose, using the names of the things they will not do — and the first version
+ * of this check failed on its own documentation. What is under review is code.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+
+const SHADOW_MODULES = ["brain-shadow", "brain-client", "brain-trigger", "brain-enabled"];
+
+const FORBIDDEN_IMPORTS = ["./proposals", "./policy", "./executor", "./simulate", "./wall", "./intents"];
+const FORBIDDEN_CALLS = [
+  "proposalsToIntents",
+  "checkPolicy",
+  "simulateSwap",
+  "sendUserOp",
+  "buildCalldata",
+  "executeIntent",
+];
+
+/** Source with comments removed, so prose about execution is not read as execution. */
+function codeOnly(mod: string): string {
+  const raw = readFileSync(new URL("./" + mod + ".ts", import.meta.url), "utf8");
+  return raw.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/[^\n]*/g, " ");
+}
+
+describe("the shadow path cannot reach execution", () => {
+  for (const mod of SHADOW_MODULES) {
+    it(mod + " imports nothing that can move money", () => {
+      const code = codeOnly(mod);
+      const modules = [...code.matchAll(/from\s+"([^"]+)"/g)].map((m) => m[1]!);
+      for (const bad of FORBIDDEN_IMPORTS) {
+        const hit = modules.find((m) => m === bad || m.endsWith(bad.slice(1)));
+        assert.equal(hit, undefined, mod + " imports " + bad + " — the shadow path must not reach execution");
+      }
+    });
+
+    it(mod + " calls no execution function", () => {
+      const code = codeOnly(mod);
+      for (const fn of FORBIDDEN_CALLS) {
+        assert.doesNotMatch(code, new RegExp("\\b" + fn + "\\s*\\("), mod + " calls " + fn);
+      }
+    });
+  }
+
+  it("the tick guards the shadow path and defaults to nobody", () => {
+    const raw = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+    assert.match(
+      raw,
+      /if \(shadowBrainEnabledFor\(agentId\) && cfg\.brainUrl && cfg\.brainToken/,
+      "three guards: the agent is named AND the house configured a Brain",
+    );
+  });
+
+  it("the tick does nothing with the outcome but log it", () => {
+    // The decision is persisted inside runShadow and dropped here. If a future
+    // edit routes `outcome` onward, this is the line that notices.
+    const raw = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+    const from = raw.indexOf("const outcome = await runShadow(");
+    assert.ok(from > 0, "the tick still calls runShadow");
+    const block = raw.slice(from, from + 700).replace(/\/\/[^\n]*/g, " ");
+    for (const fn of FORBIDDEN_CALLS) {
+      assert.doesNotMatch(block, new RegExp("\\b" + fn + "\\b"), "the outcome reaches " + fn);
+    }
+  });
+});

--- a/worker/src/brain-enabled.test.ts
+++ b/worker/src/brain-enabled.test.ts
@@ -1,0 +1,51 @@
+/**
+ * OFF IS THE DEFAULT, and it has to survive a missing variable.
+ *
+ * The failure direction for a feature that spends money is silence. This fleet's
+ * one real incident was an unwatched background feature emptying a shared
+ * allowance, and the thing that would have prevented it is exactly this: an
+ * absent setting meaning nobody, rather than everybody.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { shadowBrainEnabledFor } from "./brain-enabled";
+
+const A = "0x3E34E58e39DC6614e047dFD3BAD5B7DEA45DCd62";
+const B = "0x1102b20c835ff07DCA4eDC15F0B4C7d805bbB22F";
+const env = (v?: string) => ({ MERRYMEN_BRAIN_SHADOW: v }) as NodeJS.ProcessEnv;
+
+describe("who may think", () => {
+  it("nobody, when the variable is absent or blank", () => {
+    assert.equal(shadowBrainEnabledFor(A, {} as NodeJS.ProcessEnv), false);
+    assert.equal(shadowBrainEnabledFor(A, env("")), false);
+    assert.equal(shadowBrainEnabledFor(A, env("   ")), false);
+  });
+
+  it("matches on a prefix, the way the reconcile shadow already does", () => {
+    assert.equal(shadowBrainEnabledFor(A, env("0x3E34E58e")), true);
+    assert.equal(shadowBrainEnabledFor(B, env("0x3E34E58e")), false);
+  });
+
+  it("is case-insensitive, because an operator pastes what the dashboard shows", () => {
+    assert.equal(shadowBrainEnabledFor(A, env("0x3e34e58e")), true);
+    assert.equal(shadowBrainEnabledFor(A.toLowerCase(), env("0x3E34E58E")), true);
+  });
+
+  it("takes a list, so a cohort is one edit", () => {
+    assert.equal(shadowBrainEnabledFor(A, env("0x1102b20c, 0x3E34E58e")), true);
+    assert.equal(shadowBrainEnabledFor(B, env("0x1102b20c, 0x3E34E58e")), true);
+    assert.equal(shadowBrainEnabledFor("0xdead", env("0x1102b20c, 0x3E34E58e")), false);
+  });
+
+  it("accepts `all`, but only when written out", () => {
+    assert.equal(shadowBrainEnabledFor(A, env("all")), true);
+    // Not a wildcard, not a truthy value — the literal word or nothing.
+    assert.equal(shadowBrainEnabledFor(A, env("*")), false);
+    assert.equal(shadowBrainEnabledFor(A, env("true")), false);
+    assert.equal(shadowBrainEnabledFor(A, env("1")), false);
+  });
+
+  it("an empty agent id never matches, whatever the list says", () => {
+    assert.equal(shadowBrainEnabledFor("", env("all")), false);
+  });
+});

--- a/worker/src/brain-enabled.ts
+++ b/worker/src/brain-enabled.ts
@@ -1,0 +1,28 @@
+/**
+ * WHICH AGENTS MAY THINK — an allowlist, not a boolean.
+ *
+ * Shadow Brain starts at ONE agent. Not because the code cannot handle more,
+ * but because nobody has watched it spend anything in production yet, and this
+ * fleet's one real incident was an unwatched background feature emptying a
+ * shared allowance. An allowlist makes expanding a deliberate act with a name
+ * attached; a boolean makes it a typo.
+ *
+ * Prefix matching, comma separated, `all` accepted — the exact shape
+ * `MERRYMEN_RECONCILE_SHADOW` already uses, so an operator who has enabled one
+ * shadow feature already knows how to enable this one. Reusing a convention is
+ * worth more than a marginally better one nobody remembers.
+ *
+ * EMPTY MEANS OFF. A missing variable is not "everyone" — the failure direction
+ * for a feature that spends money has to be silence.
+ */
+export function shadowBrainEnabledFor(id: string, env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = (env.MERRYMEN_BRAIN_SHADOW ?? "").trim();
+  if (!raw) return false;
+  const want = id.trim().toLowerCase();
+  if (!want) return false;
+  return raw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)
+    .some((p) => p === "all" || want.startsWith(p));
+}

--- a/worker/src/brain-shadow.ts
+++ b/worker/src/brain-shadow.ts
@@ -1,0 +1,357 @@
+/**
+ * THE SHADOW PATH: a Merryman thinks, and nothing happens.
+ *
+ * worker state → buildPortfolioSnapshot() → trigger → Brain → persist.
+ *
+ * EXECUTION IS DISCONNECTED BY ABSENCE, not by a flag. This module does not
+ * import proposalsToIntents, checkPolicy, simulate or the executor, and nothing
+ * it returns is shaped like an intent. A future version that connects execution
+ * has to ADD an import, which is a reviewable act; a flag would be one edit by
+ * someone who did not read this comment.
+ *
+ * THE SNAPSHOT IS BUILT BY CORE. `buildPortfolioSnapshot` is the only place
+ * equity and P&L are computed, and this file passes it inputs rather than
+ * arithmetic. Every figure Brain sees can be traced to one snapshot id.
+ *
+ * TRIGGER STATE IS DURABLE, and that is deliberate rather than tidy. The
+ * accounting work spent weeks on a bug whose whole shape was "a redeploy makes
+ * the child forget, so it books the same thing again" — and an AI budget has
+ * exactly the same failure available to it. A child that forgot its cooldowns
+ * would re-fire every reason on every deploy.
+ */
+import {
+  buildPortfolioSnapshot,
+  type PortfolioQuality,
+  type PortfolioSnapshot,
+  type SnapshotPosition,
+} from "../../packages/core/src/index";
+import { decide, type BrainConfig, type BrainDecision, type BrainResult } from "./brain-client";
+import {
+  afterFiring,
+  DEFAULT_TRIGGERS,
+  EMPTY_TRIGGER_STATE,
+  shouldWake,
+  type TriggerInputs,
+  type TriggerState,
+  type TriggerVerdict,
+} from "./brain-trigger";
+import { addDecision, addEvent, loadTriggerState, newDecisionId, saveTriggerState } from "./store";
+
+/**
+ * How long after a COLD start the first run may happen.
+ *
+ * A child's sqlite is wiped by every redeploy, so a cold start is common and
+ * says nothing about whether Brain ran recently. Two choices were available and
+ * both are wrong on their own: treat cold as "never ran" and every deploy fires
+ * every reason for every agent; treat it as "just ran" and a fresh agent waits
+ * four hours to think for the first time.
+ *
+ * So a cold start seeds the cooldowns as though Brain ran
+ * `scheduledIntervalSec - COLD_START_DELAY_SEC` ago: the first run comes a
+ * couple of minutes in, and a redeploy costs AT MOST one run per enabled agent
+ * rather than one per reason per agent.
+ */
+const COLD_START_DELAY_SEC = 120;
+
+export interface ShadowInputs {
+  agentId: string;
+  now: number;
+  epoch: number;
+  /** Micro-USDG, straight off the tick. */
+  cashUsdg: number;
+  vaultUsdg: number;
+  quarantinedUsdg: number;
+  positions: SnapshotPosition[];
+  netContributionsUsdg: number | null;
+  grossContributionsUsdg: number | null;
+  grossWithdrawalsUsdg: number | null;
+  gasUsdg: number | null;
+  quality: PortfolioQuality;
+  /** The instrument this run is about, and what the lenses can see. */
+  market: {
+    instrumentId: string;
+    symbol: string;
+    instrumentClass: "equity-token" | "crypto-native" | "memecoin" | "stablecoin";
+    priceUsd: string | null;
+    signals: Record<string, string>;
+  };
+  persona?: string;
+  memory?: string[];
+  /** Set when a person asked. Bypasses the movement thresholds, not the budget. */
+  userRequested?: boolean;
+  /** A stable identity for the newest material news item, or null. */
+  newsKey?: string | null;
+}
+
+export type ShadowOutcome =
+  | { ran: false; why: string; trigger: TriggerVerdict }
+  | { ran: true; trigger: TriggerVerdict; snapshot: PortfolioSnapshot; result: BrainResult };
+
+/**
+ * A snapshot id that IS the state it describes.
+ *
+ * Content-addressed rather than random, so two runs over identical inputs carry
+ * the same id and a decision can be traced to exactly what Brain saw — a random
+ * id would only say WHEN, which is the question nobody asks afterwards.
+ */
+export function snapshotId(agentId: string, asOf: number, parts: (string | number | null)[]): string {
+  let h = 0x811c9dc5;
+  for (const ch of `${agentId}|${asOf}|${parts.join("|")}`) {
+    h ^= ch.charCodeAt(0);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return `snap_${asOf}_${h.toString(16).padStart(8, "0")}`;
+}
+
+/** Assemble the canonical snapshot. NOTHING is computed here — core does it. */
+export function buildShadowSnapshot(i: ShadowInputs): PortfolioSnapshot {
+  return buildPortfolioSnapshot({
+    snapshotId: snapshotId(i.agentId, i.now, [
+      i.cashUsdg,
+      i.vaultUsdg,
+      i.quarantinedUsdg,
+      i.netContributionsUsdg,
+      i.epoch,
+      i.positions.map((p) => `${p.symbol}:${p.valueUsdg}`).join(","),
+    ]),
+    agentId: i.agentId,
+    asOf: i.now,
+    epoch: i.epoch,
+    cashUsdg: i.cashUsdg,
+    vaultUsdg: i.vaultUsdg,
+    quarantinedUsdg: i.quarantinedUsdg,
+    netContributionsUsdg: i.netContributionsUsdg,
+    grossContributionsUsdg: i.grossContributionsUsdg,
+    grossWithdrawalsUsdg: i.grossWithdrawalsUsdg,
+    gasUsdg: i.gasUsdg,
+    positions: i.positions,
+    quality: i.quality,
+  });
+}
+
+/**
+ * Run one shadow decision, if anything is worth thinking about.
+ *
+ * Returns without calling Brain when the trigger says nothing changed — which
+ * is the common case and the whole reason the trigger exists.
+ */
+export async function runShadow(
+  cfg: BrainConfig | null,
+  i: ShadowInputs,
+  log: (m: string) => void,
+): Promise<ShadowOutcome> {
+  const idle: TriggerVerdict = { fire: false, reason: null, detail: "brain not configured", candidates: [] };
+  if (!cfg || !cfg.url || !cfg.token) {
+    // ABSENT MEANS ABSENT. Not "fall back to the local strategist" — a feed that
+    // attributed a thesis to Brain when a different reasoner wrote it would be
+    // lying about provenance, and provenance is the product.
+    return { ran: false, why: "brainUrl/brainToken not configured", trigger: idle };
+  }
+
+  const snapshot = buildShadowSnapshot(i);
+
+  // The stored blob is validated rather than cast: a row written by an older
+  // build, or a half-written one, must degrade to a cold start rather than
+  // producing a TriggerState with undefined baselines that compare as "no move".
+  const stored = readTriggerState(await loadTriggerState(i.agentId));
+  const state: TriggerState = stored ?? coldStart(i.now);
+  if (!stored) {
+    log(
+      `[brain] cold start — cooldowns seeded so the first run lands in ~${COLD_START_DELAY_SEC}s ` +
+        `and a redeploy costs at most one run`,
+    );
+  }
+
+  const triggerInput: TriggerInputs = {
+    now: i.now,
+    priceUsd: i.market.priceUsd === null ? null : Number(i.market.priceUsd),
+    equityUsdg: snapshot.equityUsdg,
+    newsKey: i.newsKey ?? null,
+    userRequested: i.userRequested ?? false,
+  };
+
+  const trigger = shouldWake(state, triggerInput);
+  if (!trigger.fire) {
+    // Persist anyway when this is the first sighting, so a cold start's seeded
+    // cooldowns survive the next restart rather than being re-seeded forever.
+    if (!stored) await saveTriggerState(i.agentId, state);
+    return { ran: false, why: trigger.detail, trigger };
+  }
+
+  // THE STATE IS SAVED BEFORE THE CALL, not after.
+  //
+  // A crash between the call and the save would otherwise leave the cooldown
+  // unset, and the next tick would ask again — paying twice for one situation.
+  // Saving first means a crash costs one wasted run at most, and the failure
+  // direction is "thought once and lost it" rather than "thinks forever".
+  await saveTriggerState(i.agentId, afterFiring(state, trigger.reason!, triggerInput));
+
+  const runId = `brain_${i.agentId.slice(2, 10)}_${i.now}`;
+  const triggerId = `${trigger.reason}_${i.now}`;
+  log(
+    `[brain] waking — ${trigger.detail} · snapshot ${snapshot.snapshotId} · ` +
+      `quality epoch=${snapshot.quality.epoch} contributionsKnown=${snapshot.quality.contributionsKnown} ` +
+      `pnlPublishable=${snapshot.pnl.publishable}`,
+  );
+
+  const result = await decide(cfg, {
+    runId,
+    agentId: i.agentId,
+    triggerId,
+    snapshot,
+    market: {
+      snapshot_id: snapshot.snapshotId,
+      as_of: i.now,
+      instrument_id: i.market.instrumentId,
+      symbol: i.market.symbol,
+      instrument_class: i.market.instrumentClass,
+      price_usd: i.market.priceUsd,
+      signals: i.market.signals,
+    },
+    persona: i.persona,
+    memory: i.memory,
+    tier: "research",
+  });
+
+  await persist(i.agentId, runId, triggerId, trigger, snapshot, result, log);
+  return { ran: true, trigger, snapshot, result };
+}
+
+/** Parse a stored blob, or say it is unusable. A partial state is not a state. */
+function readTriggerState(raw: Record<string, unknown> | null): TriggerState | null {
+  if (!raw || typeof raw !== "object") return null;
+  const fired = raw.lastFiredAt;
+  if (!fired || typeof fired !== "object") return null;
+  const num = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+  return {
+    lastFiredAt: fired as TriggerState["lastFiredAt"],
+    lastPriceUsd: num(raw.lastPriceUsd),
+    lastEquityUsdg: num(raw.lastEquityUsdg),
+    lastNewsKey: typeof raw.lastNewsKey === "string" ? raw.lastNewsKey : null,
+  };
+}
+
+function coldStart(now: number): TriggerState {
+  const seeded = now - DEFAULT_TRIGGERS.scheduledIntervalSec + COLD_START_DELAY_SEC;
+  return {
+    ...EMPTY_TRIGGER_STATE,
+    lastFiredAt: {
+      "scheduled-review": seeded,
+      "price-move": seeded,
+      "portfolio-change": seeded,
+      "news-event": seeded,
+      "user-request": seeded,
+    },
+  };
+}
+
+/**
+ * Write the decision into the SAME substrate every other decision uses.
+ *
+ * Not a shadow table. When execution is eventually connected, a trade links to
+ * this row by `decision_id` exactly as a strategist trade already does — and the
+ * social thesis is read from it rather than generated separately. One decision,
+ * two readings; that is the product invariant.
+ */
+async function persist(
+  agentId: string,
+  runId: string,
+  triggerId: string,
+  trigger: TriggerVerdict,
+  snapshot: PortfolioSnapshot,
+  result: BrainResult,
+  log: (m: string) => void,
+): Promise<void> {
+  if (!result.ok) {
+    // A REFUSAL IS A RESULT, and it is recorded. The runs that produced nothing
+    // are exactly the ones an unmeasured system loses track of, and they are
+    // where the interesting failures live.
+    const detail = result.kind === "refused" ? `${result.reason}: ${result.detail}` : result.detail;
+    log(`[brain] no decision — ${result.kind} · ${detail}`);
+    await addEvent(agentId, result.kind === "refused" ? "warn" : "err", `brain ${result.kind}: ${detail}`).catch(
+      () => {},
+    );
+    await addDecision({
+      id: newDecisionId(),
+      agent_id: agentId,
+      source: "brain-shadow",
+      strategy: "brain",
+      // undefined, not null: DecisionRow leaves these out entirely for a run
+      // that produced no decision, which is a different row shape from one that
+      // decided and happened to have no size.
+      reason: `no decision (${result.kind}): ${detail}`,
+      dropped_rule: `brain-${result.kind}`,
+      signals_json: JSON.stringify({
+        brain_run_id: runId,
+        snapshot_id: snapshot.snapshotId,
+        trigger_id: triggerId,
+        trigger_reason: trigger.reason,
+        quality: snapshot.quality,
+        cost: result.kind === "refused" ? result.cost : null,
+      }),
+    }).catch(() => {});
+    return;
+  }
+
+  const d: BrainDecision = result.decision;
+  log(
+    `[brain] ${d.action.toUpperCase()} ${d.symbol} conf=${d.confidence.toFixed(2)} ` +
+      `delta=${d.suggested_delta_usdg} · depth=${d.depth_used}` +
+      (d.escalation_reasons.length ? ` (escalated: ${d.escalation_reasons.join(", ")})` : "") +
+      ` · ${d.cost.model_calls} calls ${d.cost.tokens_in + d.cost.tokens_out} tok ` +
+      `$${d.cost.usd.toFixed(4)} ${result.seconds.toFixed(1)}s · decision ${d.decision_id}`,
+  );
+
+  await addDecision({
+    id: d.decision_id,
+    agent_id: agentId,
+    // SHADOW IS NAMED IN THE SOURCE, so nothing downstream can mistake a
+    // thought for an instruction. When execution connects, this becomes
+    // "brain" and the change is visible in one place.
+    source: "brain-shadow",
+    strategy: "brain",
+    provider: d.models[0]?.provider,
+    model: d.models[0]?.model,
+    symbol: d.symbol,
+    action: d.action,
+    size_usdg: d.suggested_delta_usdg / 1e6,
+    // The model's own words — the thesis, which the feed publishes verbatim.
+    reason: d.thesis,
+    // NOT DROPPED. A shadow decision was not rejected by anything — it simply
+    // has nowhere to go yet, and marking it dropped would make the tape read as
+    // though policy had refused it.
+    dropped_rule: undefined,
+    signals_json: JSON.stringify({
+      brain_run_id: runId,
+      decision_id: d.decision_id,
+      snapshot_id: snapshot.snapshotId,
+      trigger_id: triggerId,
+      trigger_reason: trigger.reason,
+      trigger_detail: trigger.detail,
+      instrument_id: d.instrument_id,
+      confidence: d.confidence,
+      suggested_delta_usdg: d.suggested_delta_usdg,
+      target_position_usdg: d.target_position_usdg,
+      evidence: d.evidence,
+      risks: d.risks,
+      invalidation: d.invalidation,
+      bull_case: d.bull_case,
+      bear_case: d.bear_case,
+      time_horizon: d.time_horizon,
+      tier: d.tier,
+      depth_used: d.depth_used,
+      escalation_reasons: d.escalation_reasons,
+      candidate_action: d.candidate_action,
+      cost: d.cost,
+      models: d.models,
+      latency_seconds: result.seconds,
+      quality: snapshot.quality,
+      pnl_publishable: snapshot.pnl.publishable,
+      // EXPLICIT, so a reader of the tape never has to infer it. Until
+      // execution is connected this is always zero, and a future non-zero is a
+      // change someone made on purpose.
+      executor_calls: 0,
+      execution_connected: false,
+    }),
+  }).catch((e) => log(`[brain] decision write failed: ${e instanceof Error ? e.message : String(e)}`));
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -91,6 +91,8 @@ import { takeTick } from "./strategies/types";
 import { grantHasDeadRateLimit } from "./session-account";
 import { claimCommandFile, writeCommandResult } from "./command-files";
 import { bookGaps, composeEquityUsdg } from "./equity";
+import { runShadow, type ShadowInputs } from "./brain-shadow";
+import { shadowBrainEnabledFor } from "./brain-enabled";
 import { priceGas, wethPriceToken } from "./gas-price";
 import { createPaperOrderExecutor, type OrderExecutor } from "./executor-order";
 import { readHolderStatus } from "./circle";
@@ -227,6 +229,7 @@ import {
   setAgentName,
   setAgentXHandle,
   getGasPaidUsdg,
+  getNetContributionsUsdg,
   setAgentEpoch,
   setAgentHwm,
   setAgentQuality,
@@ -5221,6 +5224,97 @@ async function main() {
         valueUsdg: usdgNum(p.valueUsdg),
       })),
     );
+
+    // ── SHADOW BRAIN ─────────────────────────────────────────────────────
+    //
+    // A Merryman thinks. NOTHING HAPPENS. There is no path from here to
+    // proposalsToIntents, checkPolicy, simulate or the executor — brain-shadow
+    // does not import them, so connecting execution later is an ADDED import
+    // somebody has to review rather than a flag somebody can flip.
+    //
+    // Guarded three ways, each of which alone would be enough to keep it off:
+    // the house must have configured a Brain, the agent must be named in
+    // MERRYMEN_BRAIN_SHADOW, and the trigger must say something changed. The
+    // allowlist is what keeps this at ONE agent while we learn what it costs.
+    //
+    // Everything after the guard is best-effort. A Brain that is slow, refuses,
+    // or is unreachable must not delay or fail a tick — it produces no thought
+    // this time, and the trigger will wake it again.
+    if (shadowBrainEnabledFor(agentId) && cfg.brainUrl && cfg.brainToken && !bookIncomplete) {
+      try {
+        const epochNow = await getAgentEpoch(agentId);
+        const netContrib = await getNetContributionsUsdg(agentId);
+        const gasNow = await getGasPaidUsdg(agentId, epochNow);
+        // THE BIGGEST HOLDING IS WHAT THIS RUN IS ABOUT. One instrument per run
+        // keeps the question answerable and the bill bounded; a Brain asked
+        // about a whole book at once produces a paragraph, not a decision.
+        const focus = [...positions].sort((a, b) => Number(b.valueUsdg - a.valueUsdg))[0];
+        if (focus) {
+          const inputs: ShadowInputs = {
+            agentId,
+            now: Math.floor(Date.now() / 1000),
+            epoch: epochNow,
+            cashUsdg: Number(balances.cashUsdg),
+            vaultUsdg: Number(balances.vaultUsdg),
+            quarantinedUsdg: Number(quarantine.totalCostUsdg),
+            positions: positions.map((pp) => ({
+              instrumentId: `merrymen:${pp.symbol.toLowerCase()}`,
+              symbol: pp.symbol,
+              qtyRaw: String(pp.rawBalance),
+              valueUsdg: Number(pp.valueUsdg),
+              costBasisUsdg: null,
+              priceSource: pp.priceSource === "pool" ? "pool" : "chainlink",
+              quarantined: false,
+            })),
+            // NULL SURVIVES AS NULL all the way to Brain, which refuses on it.
+            netContributionsUsdg: netContrib === null ? null : Math.round(netContrib * 1e6),
+            grossContributionsUsdg: null,
+            grossWithdrawalsUsdg: null,
+            gasUsdg: gasNow.unpricedTrades > 0 ? null : Math.round(gasNow.usdg * 1e6),
+            quality: {
+              auditPassed: false,
+              epoch: epochNow,
+              contributionsKnown: accounting.contributionsKnown,
+              equityComplete: !bookIncomplete,
+              gasAccounting: undefined,
+              gasBasis: gasNow.unpricedTrades > 0 ? "gross" : gasNow.usdg > 0 ? "net" : "unknown",
+              positionHistoryAvailable: false,
+              quarantinedAssetsPresent: quarantine.totalCostUsdg > 0n,
+              assessedAt: Math.floor(Date.now() / 1000),
+            } as never,
+            market: {
+              instrumentId: `merrymen:${focus.symbol.toLowerCase()}`,
+              symbol: focus.symbol,
+              instrumentClass: "equity-token",
+              priceUsd: (Number(focus.price8) / 1e8).toFixed(4),
+              // WHAT THE WORKER CAN HONESTLY SEE, and nothing more. A lens with
+              // no data is OMITTED rather than filled with a plausible sentence
+              // — Brain answers NO DATA AVAILABLE for what is missing, which is
+              // the truthful input and the one the fixtures were built against.
+              signals: {
+                technical:
+                  `Price ${(Number(focus.price8) / 1e8).toFixed(4)} USD from ${focus.priceSource}` +
+                  `${focus.priceStale ? " (STALE)" : ""}. Position value ` +
+                  `${usdgNum(focus.valueUsdg).toFixed(6)} USDG of a ${usdgNum(equityUsdg).toFixed(6)} USDG book.`,
+              },
+            },
+            persona: cfg.agentName ? `You are ${cfg.agentName}, a Merryman.` : "",
+            memory: [],
+          };
+          const outcome = await runShadow(
+            { url: cfg.brainUrl, token: cfg.brainToken, timeoutMs: 90_000 },
+            inputs,
+            (m) => console.log(`[${short}] ${m}`),
+          );
+          if (!outcome.ran) console.log(`[${short}] [brain] asleep — ${outcome.why}`);
+        }
+      } catch (e) {
+        // NEVER TAKES A TICK DOWN. Shadow thinking is the least important thing
+        // happening in this loop, and the agent's accounting and risk controls
+        // must not depend on a research service being reachable.
+        console.log(`[${short}] [brain] skipped (${e instanceof Error ? e.message : String(e)})`);
+      }
+    }
 
     // On-chain breaker check — the contract is the authority once deployed;
     // this read stops the worker from wasting ops the chain would refuse.

--- a/worker/src/settings.ts
+++ b/worker/src/settings.ts
@@ -83,6 +83,9 @@ export interface ResolvedConfig {
   deskMaxSteps: number;
   browserUrl: string | undefined;
   browserToken: string | undefined;
+  /** The shared Brain service. Absent = shadow Brain does not run, ever. */
+  brainUrl: string | undefined;
+  brainToken: string | undefined;
   scoutEnabled: boolean;
   /** Max USDG of COST that may sit in unpriceable positions at once. */
   scoutBudgetUsdg: number;
@@ -303,6 +306,8 @@ export function mergeSettings(
     deskMaxSteps: num(file.deskMaxSteps, env.MERRYMEN_DESK_MAX_STEPS, d.deskMaxSteps, 1, 12),
     browserUrl: str(file.browserUrl, env.MERRYMEN_BROWSER_URL),
     browserToken: str(file.browserToken, env.MERRYMEN_BROWSER_TOKEN),
+    brainUrl: str(file.brainUrl, env.MERRYMEN_BRAIN_URL),
+    brainToken: str(file.brainToken, env.MERRYMEN_BRAIN_TOKEN),
     scoutEnabled: bool(file.scoutEnabled, env.MERRYMEN_SCOUT_ENABLED, d.scoutEnabled),
     scoutBudgetUsdg: num(file.scoutBudgetUsdg, env.MERRYMEN_SCOUT_BUDGET_USDG, d.scoutBudgetUsdg, 0, 1_000_000),
     scoutPerTokenUsdg: num(file.scoutPerTokenUsdg, env.MERRYMEN_SCOUT_PER_TOKEN_USDG, d.scoutPerTokenUsdg, 0, 1_000_000),

--- a/worker/src/store.ts
+++ b/worker/src/store.ts
@@ -558,6 +558,20 @@ const SQLITE_ALTERS: string[] = [
        PRIMARY KEY (run_id, original_id)
      )`,
     "CREATE INDEX IF NOT EXISTS flows_quarantine_agent ON flows_quarantine (agent_id)",
+    // ── WHAT BRAIN ALREADY THOUGHT ABOUT, so a restart cannot forget ──────
+    //
+    // The accounting work spent weeks on one bug shape: a redeploy wipes the
+    // child ledger, the child forgets, and it books the same thing again. An AI
+    // budget has exactly that failure available to it — a child that forgot its
+    // cooldowns would re-fire every trigger reason on every deploy.
+    //
+    // One row per agent. Baselines live here too, because a cooldown with no
+    // baseline still lets the next tick read an old price move as a new one.
+    `CREATE TABLE IF NOT EXISTS brain_trigger_state (
+       agent_id TEXT PRIMARY KEY,
+       state_json TEXT NOT NULL,
+       updated_at INTEGER NOT NULL
+     )`,
     // HERE AND NOT IN SQLITE_SCHEMA, because `decision_id` is itself added by an
     // ALTER above — the base schema runs first, so an index on it there fails with
     // 'no such column' and takes every trade insert down with it.
@@ -2918,5 +2932,45 @@ export async function curveFor(
     return { curve: row.curve, quoteToken: row.quote_token, graduationThresholdRaw: threshold };
   } catch {
     return null;
+  }
+}
+
+/**
+ * WHAT BRAIN ALREADY THOUGHT ABOUT — durable, so a restart cannot forget.
+ *
+ * The accounting work spent weeks on one bug shape: a redeploy wipes the child
+ * ledger, the child forgets, and it books the same thing again. An AI budget has
+ * exactly that failure available to it, and it is worse in one respect — a
+ * forgotten contribution is a wrong number, a forgotten cooldown is a bill.
+ *
+ * Best-effort on both sides: a trigger-state read or write that fails must never
+ * take a tick down. A failed READ degrades to a cold start, which the caller
+ * seeds conservatively; a failed WRITE costs at most one extra run.
+ */
+export async function loadTriggerState(agentId: string): Promise<Record<string, unknown> | null> {
+  try {
+    const row = (await getDb()
+      .prepare("SELECT state_json FROM brain_trigger_state WHERE agent_id = ?")
+      .get(agentId)) as { state_json: string } | undefined;
+    if (!row?.state_json) return null;
+    return JSON.parse(row.state_json) as Record<string, unknown>;
+  } catch {
+    // A cold start is the safe reading of "I cannot tell": the caller seeds
+    // cooldowns as though Brain just ran, so an unreadable row delays thinking
+    // rather than repeating it.
+    return null;
+  }
+}
+
+export async function saveTriggerState(agentId: string, state: unknown): Promise<void> {
+  try {
+    await getDb()
+      .prepare(
+        `INSERT INTO brain_trigger_state (agent_id, state_json, updated_at) VALUES (?, ?, ?)
+         ON CONFLICT(agent_id) DO UPDATE SET state_json = excluded.state_json, updated_at = excluded.updated_at`,
+      )
+      .run(agentId, JSON.stringify(state), Math.floor(Date.now() / 1000));
+  } catch (e) {
+    console.error("[brain] trigger state write failed:", e);
   }
 }


### PR DESCRIPTION
`worker state → buildPortfolioSnapshot() → deterministic trigger → Brain → persisted decision.` Execution is not connected, and *how* it is not connected is the point.

### Disconnected by absence, not by a flag

`brain-shadow`, `brain-client`, `brain-trigger` and `brain-enabled` import none of proposals/policy/simulate/wall/executor and call none of their functions. Connecting execution has to **add an import** — a line in a diff that needs a reason — rather than flip a boolean. `brain-disconnected.test.ts` enforces it every run, with comments stripped first (the first version failed on its own documentation).

### Three guards, each sufficient alone

House configured `brainUrl`+`brainToken` · agent named in `MERRYMEN_BRAIN_SHADOW` · trigger says something changed.

**The allowlist defaults to nobody.** A missing variable is not "everyone" — the failure direction for a feature that spends money has to be silence. That is the control that would have stopped the 2026-08-31 incident.

### Core owns the numbers

The call site passes inputs to `buildPortfolioSnapshot` and does no arithmetic. `null` contributions survive as null to Brain, which refuses on them. The snapshot id is **content-addressed**, so a decision traces to exactly what Brain saw — a random id records only *when*, which is not what anyone asks afterwards.

### Trigger state is durable

The accounting work spent weeks on one bug shape: a redeploy wipes the child, it forgets, it does the thing again. An AI budget has that failure available to it — a forgotten contribution is a wrong number, a forgotten cooldown is a bill.

Cold start seeds cooldowns so the first run lands ~2 minutes in and **a redeploy costs at most one run per enabled agent**, not one per reason per agent. State is saved *before* the call, so a crash costs one wasted run rather than an unset cooldown that re-asks every tick.

2210/2210 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)