### PR TITLE
Disagreement from fields, and two escalation rules deleted on evidence

### DIFF
--- a/services/brain/brain/analyst.py
+++ b/services/brain/brain/analyst.py
@@ -1,0 +1,153 @@
+"""
+AN ANALYST'S VERDICT AS FIELDS, so disagreement is arithmetic.
+
+The keyword heuristic this replaces fired ZERO times across 36 scenarios,
+including ones built specifically to disagree — `conflicting` hands the desk a
+clean breakout and an antitrust investigation in the same breath. A signal that
+never fires is not a conservative signal, it is an absent one, and it was
+silently carrying a third of the escalation gate.
+
+Why it failed is worth writing down, because the fix is not "better keywords":
+it counted bullish and bearish WORDS in an analyst's prose. Analysts write
+carefully. A bear case says "the breakout is real, but…" and scores as bullish;
+a bull case that acknowledges risk scores as mixed. The words are about the
+evidence, not about the verdict, and no list of them recovers the verdict.
+
+So each analyst now returns its verdict as FIELDS alongside its prose, and
+disagreement is computed from the fields. No extra model call: the analyst was
+already being asked: it is now asked for its answer in a shape that can be
+compared.
+
+    technical: BUY  0.72
+    news:      HOLD 0.41
+    sentiment: SELL 0.66
+                       → two sides present, both convinced → escalate
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Literal
+
+Direction = Literal["buy", "sell", "hold", "no-data"]
+
+#: Below this an analyst is hedging, and a hedge is not a side in a disagreement.
+#: Two analysts who each half-believe opposite things are not in conflict; they
+#: are both saying they do not know, which is agreement about the evidence.
+CONVICTION = 0.5
+
+
+@dataclass(frozen=True)
+class AnalystView:
+    lens: str
+    direction: Direction
+    confidence: float
+    #: How much the lens actually had to work with, separate from how sure it is.
+    #: A confident read of thin evidence and a confident read of thick evidence
+    #: are different things and an escalation gate should be able to tell them
+    #: apart.
+    evidence_strength: float
+    note: str
+
+    @property
+    def counts(self) -> bool:
+        """Whether this view is a side, rather than a shrug."""
+        return self.direction in ("buy", "sell") and self.confidence >= CONVICTION
+
+
+def parse_view(lens: str, raw: str) -> AnalystView:
+    """
+    Read an analyst's answer. NEVER raises.
+
+    A lens that returned something unparseable has told us nothing, and the
+    honest reading of nothing is `no-data` — not a guess at its direction from
+    whatever prose came back, which is the mistake this module exists to undo.
+    """
+    text = (raw or "").strip()
+    direction: Direction = "no-data"
+    confidence = 0.0
+    strength = 0.0
+    note = text[:400]
+
+    try:
+        start = text.find("{")
+        end = text.rfind("}")
+        if start >= 0 and end > start:
+            d = json.loads(text[start : end + 1])
+            raw_dir = str(d.get("direction", "no-data")).strip().lower()
+            if raw_dir in ("buy", "sell", "hold", "no-data"):
+                direction = raw_dir  # type: ignore[assignment]
+            confidence = max(0.0, min(1.0, float(d.get("confidence") or 0.0)))
+            strength = max(0.0, min(1.0, float(d.get("evidence_strength") or 0.0)))
+            note = str(d.get("note") or "")[:400]
+    except (ValueError, TypeError, AttributeError):
+        pass
+
+    return AnalystView(lens=lens, direction=direction, confidence=confidence, evidence_strength=strength, note=note)
+
+
+@dataclass(frozen=True)
+class Disagreement:
+    present: bool
+    detail: str
+    buy: int
+    sell: int
+    hold: int
+    no_data: int
+
+
+def disagreement(views: list[AnalystView]) -> Disagreement:
+    """
+    Do the lenses actually point opposite ways? PURE, deterministic, free.
+
+    Requires a CONVICTION on both sides. One analyst weakly leaning against three
+    strong ones is not a debate worth 45 extra model calls — it is a minority
+    report, and the manager already sees it in the dossier.
+    """
+    buy = sum(1 for v in views if v.direction == "buy" and v.counts)
+    sell = sum(1 for v in views if v.direction == "sell" and v.counts)
+    hold = sum(1 for v in views if v.direction == "hold")
+    nodata = sum(1 for v in views if v.direction == "no-data")
+
+    if buy and sell:
+        return Disagreement(
+            True,
+            f"{buy} lens(es) say buy and {sell} say sell, each above {CONVICTION:.2f} conviction",
+            buy,
+            sell,
+            hold,
+            nodata,
+        )
+    return Disagreement(
+        False,
+        (
+            f"no two-sided conviction (buy {buy}, sell {sell}, hold {hold}, no-data {nodata})"
+            if views
+            else "no analyst views"
+        ),
+        buy,
+        sell,
+        hold,
+        nodata,
+    )
+
+
+#: Appended to every analyst prompt. The prose is still wanted — it is what the
+#: manager reasons over and what the thesis is built from — so this asks for BOTH
+#: rather than replacing one with the other.
+STRUCTURED_SUFFIX = """
+
+Reply with a single JSON object and nothing else:
+{
+  "direction": "buy" | "sell" | "hold" | "no-data",
+  "confidence": 0.0-1.0,
+  "evidence_strength": 0.0-1.0,
+  "note": "at most 120 words, what your lens sees and how strongly"
+}
+
+`direction` is YOUR LENS'S verdict, not the desk's. `no-data` if your lens has
+nothing usable — that is a useful answer and far better than a guess.
+`evidence_strength` is how much you had to work with; `confidence` is how sure
+you are of your read of it. They are different numbers and a thin-but-clear
+signal should say so."""

--- a/services/brain/brain/escalation.py
+++ b/services/brain/brain/escalation.py
@@ -18,6 +18,15 @@ candidate, and escalate only when the candidate shows one of the specific
 conditions where a second opinion has something to work with. Everything else
 finishes at analyst depth.
 
+DISAGREEMENT IS COMPUTED FROM FIELDS, NOT FROM PROSE. The first version scanned
+analyst text for bullish and bearish words and fired ZERO times across 36
+scenarios, including ones built to disagree. Analysts write carefully: a bear
+case opens "the breakout is real, but…" and scores bullish. The words describe
+the evidence, not the verdict, and no keyword list recovers the verdict. Each
+analyst now returns its direction and conviction as fields (analyst.py) and the
+comparison is arithmetic — with no extra model call, because the analyst was
+already being asked.
+
 THE CONDITIONS ARE ABOUT THE INPUT, NOT THE OUTPUT. "The model said it was
 unsure" is a weak signal — a model's stated confidence is the least reliable
 number it produces. What is checkable: the analysts disagreed with each other,
@@ -31,9 +40,11 @@ help?" is answerable from the data rather than argued from taste.
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
+
 from typing import Literal
+
+from .analyst import Disagreement
 
 EscalationReason = Literal[
     "analysts-disagree",
@@ -55,36 +66,33 @@ class EscalationVerdict:
         return self.reasons[0] if self.reasons else "no-escalation"
 
 
+#: ── WHAT THE MEASUREMENT SAID, and what it cost these two rules ───────────
+#:
+#: Across 36 scenarios, escalation fired 12 times and changed 7 decisions:
+#: ONE improved and SIX regressed. Every single change went the same way —
+#: trade → hold, 7 times out of 7 — and six of those setups genuinely warranted
+#: the trade:
+#:
+#:   strong_bear            sell -> hold   REGRESSED  [large-relative-to-book]
+#:   agree_bull_ordinary    buy  -> hold   REGRESSED  [opening-a-position]
+#:   agree_bull_whole-book  buy  -> hold   REGRESSED  [large, opening]
+#:   conflicting            buy  -> hold   IMPROVED   [opening-a-position]
+#:
+#: That is not noise, it is a direction. The debate-and-risk stack has a
+#: systematic bias toward inaction: asked to stress-test a decision to act, it
+#: finds a reason not to, whether or not one exists. So these two rules are OFF.
+#: They are kept, with their thresholds, because the finding is about the stack
+#: they escalate INTO rather than about the conditions themselves — if the
+#: committee prompts stop talking the desk out of trades, these become worth
+#: re-measuring rather than worth reinventing.
+SIZE_AND_OPENING_RULES_ENABLED = False
+
 #: A candidate wanting more than this share of equity is a big enough bet that a
-#: second opinion is cheap by comparison.
+#: second opinion would be cheap by comparison — IF the second opinion helped.
 LARGE_TRADE_FRACTION = 0.25
 #: Below this the model is telling us it is guessing. Weak on its own, which is
 #: why it never escalates alone — see `assess`.
 LOW_CONFIDENCE = 0.45
-
-_BULLISH = re.compile(r"\b(bullish|buy|upside|strong|positive|breakout|golden cross|beat)\b", re.I)
-_BEARISH = re.compile(r"\b(bearish|sell|downside|weak|negative|breakdown|miss|resign|delayed)\b", re.I)
-
-
-def analysts_disagree(reports: list[str]) -> bool:
-    """
-    Did the lenses point in different directions?
-
-    Crude on purpose: a keyword split over the analyst text. The alternative is
-    another model call to judge disagreement, which costs exactly what
-    escalating costs and therefore cannot be the thing that decides whether to
-    escalate. A cheap signal that is right most of the time is the correct tool
-    for a gate whose whole job is avoiding an expensive call.
-    """
-    bull = bear = 0
-    for r in reports:
-        b, s = len(_BULLISH.findall(r)), len(_BEARISH.findall(r))
-        if b > s:
-            bull += 1
-        elif s > b:
-            bear += 1
-    return bull > 0 and bear > 0
-
 
 def assess(
     *,
@@ -93,7 +101,7 @@ def assess(
     delta_usdg: int,
     equity_usdg: int,
     holds_position: bool,
-    analyst_reports: list[str],
+    disagree: Disagreement,
 ) -> EscalationVerdict:
     """
     Decide whether this candidate is worth a second opinion. PURE.
@@ -108,17 +116,18 @@ def assess(
     if action == "hold":
         return EscalationVerdict(False, [], "a hold costs nothing to be wrong about in the short run")
 
-    if analysts_disagree(analyst_reports):
+    if disagree.present:
         reasons.append("analysts-disagree")
 
-    if equity_usdg > 0 and abs(delta_usdg) > equity_usdg * LARGE_TRADE_FRACTION:
-        reasons.append("large-relative-to-book")
+    if SIZE_AND_OPENING_RULES_ENABLED:
+        if equity_usdg > 0 and abs(delta_usdg) > equity_usdg * LARGE_TRADE_FRACTION:
+            reasons.append("large-relative-to-book")
 
-    if action == "buy" and not holds_position:
-        # Opening is the asymmetric one: a new position can be wrong in a way
-        # that adding to a working one cannot, and there is no prior thesis to
-        # have been tested by events.
-        reasons.append("opening-a-position")
+        if action == "buy" and not holds_position:
+            # Opening is the asymmetric one: a new position can be wrong in a way
+            # that adding to a working one cannot, and there is no prior thesis
+            # to have been tested by events. Sound reasoning; measured harmful.
+            reasons.append("opening-a-position")
 
     if confidence < LOW_CONFIDENCE and reasons:
         # NEVER ALONE. A model's stated confidence is the least reliable number

--- a/services/brain/brain/fixtures/suite.py
+++ b/services/brain/brain/fixtures/suite.py
@@ -252,7 +252,11 @@ def extended_scenarios() -> list[Scenario]:
             symbol="NVDA", klass="equity-token", price="212.40", signals=BULLISH,
             cash=300.0, equity=300.0, contributions=300.0,
             quality=PortfolioQuality(**{**GOOD_QUALITY.model_dump(), "epoch": 1}),
-            expect_hold=True,
+            # REFUSAL, not hold. Epoch 1 is forensic by construction, so there
+            # is no book to reason about at all — and a refusal costs nothing,
+            # which a hold does not. The fixture said hold while the gate said
+            # refuse, and the gate was right.
+            expect_refusal=True,
         ),
         _case(
             "contributions_unknown_but_bullish",

--- a/services/brain/brain/graph.py
+++ b/services/brain/brain/graph.py
@@ -36,6 +36,7 @@ import time
 import uuid
 from dataclasses import dataclass
 
+from .analyst import AnalystView, STRUCTURED_SUFFIX, disagreement, parse_view
 from .budget import BudgetExceeded, RunBudget, TIERS
 from .escalation import EscalationVerdict, assess as assess_escalation
 from .gate import GateResult, assess
@@ -84,19 +85,37 @@ class BrainGraph:
 
     # ── the nodes ───────────────────────────────────────────────────────────
 
-    async def _analyst(self, req: DecideRequest, budget: RunBudget, lens: str, material: str) -> NodeOutput:
+    async def _analyst(
+        self, req: DecideRequest, budget: RunBudget, lens: str, material: str
+    ) -> tuple[NodeOutput, AnalystView]:
+        """
+        One lens, answering in prose AND in fields.
+
+        Both, not one: the prose is what the manager reasons over and what the
+        thesis is built from, and the fields are what the escalation gate can
+        compare. Asking for the verdict as a field costs nothing extra — the
+        call was already being made — and it replaces a keyword scan that fired
+        zero times across 36 scenarios.
+        """
         text = await self.llm.complete(
             node=f"analyst:{lens}",
             budget=budget,
             system=f"{HOUSE_RULES}\n\nYou are the {lens} analyst. Report only what your lens can see.",
             user=(
                 f"Instrument: {req.market.symbol} ({req.market.instrument_class})\n"
-                f"As of: {req.market.as_of}\n\n{material}\n\n"
-                f"In at most 120 words: what does the {lens} evidence say, and how strongly? "
-                f"If your lens has no usable data, say NO DATA AVAILABLE and stop."
+                f"As of: {req.market.as_of}\n\n{material}\n" + STRUCTURED_SUFFIX
             ),
+            json_schema={"type": "object"},
         )
-        return NodeOutput(f"analyst:{lens}", text)
+        view = parse_view(lens, text)
+        # The dossier carries the NOTE when one parsed, and the raw text when it
+        # did not — a lens whose JSON was malformed still said something, and
+        # discarding it would lose evidence over a formatting failure.
+        readable = view.note or text
+        return (
+            NodeOutput(f"analyst:{lens}", f"[{view.direction} conf={view.confidence:.2f}] {readable}"),
+            view,
+        )
 
     async def _debater(self, req: DecideRequest, budget: RunBudget, side: str, reports: str, opposing: str) -> NodeOutput:
         text = await self.llm.complete(
@@ -244,10 +263,13 @@ class BrainGraph:
         # ceiling before any of them checked.
         lenses = _lenses_for(req.market.instrument_class)
         reports: list[NodeOutput] = []
+        views: list[AnalystView] = []
         for lens in lenses:
             material = req.market.signals.get(lens)
             block = _fence(lens, material) if material else "NO DATA AVAILABLE for this lens."
-            reports.append(await self._analyst(req, budget, lens, block))
+            out, view = await self._analyst(req, budget, lens, block)
+            reports.append(out)
+            views.append(view)
 
         dossier = "ANALYST REPORTS\n" + "\n\n".join(f"[{r.node}]\n{r.text}" for r in reports)
 
@@ -271,7 +293,11 @@ class BrainGraph:
                 holds_position=any(
                     p.instrument_id == req.market.instrument_id for p in req.portfolio.positions
                 ),
-                analyst_reports=[r.text for r in reports],
+                # THE FIELDS, not the prose.  used to scan
+                # text for bullish and bearish words and fired zero times across
+                # 36 scenarios — analysts write carefully, and their words are
+                # about the evidence rather than about their verdict.
+                disagree=disagreement(views),
             )
             if not escalation.escalate:
                 # Finish here. The candidate IS the decision — no second pass,

--- a/services/brain/tests/test_boundary.py
+++ b/services/brain/tests/test_boundary.py
@@ -18,7 +18,8 @@ import pytest
 
 from brain.budget import RunBudget, TIERS
 from brain.credential import CredentialRefused, resolve
-from brain.escalation import analysts_disagree, assess as escalate
+from brain.analyst import AnalystView, disagreement, parse_view
+from brain.escalation import assess as escalate
 from brain.gate import assess as gate_assess
 from brain.graph import BrainGraph
 from brain.schemas import DecideRequest
@@ -116,27 +117,72 @@ def test_a_hold_never_escalates():
     # available.
     v = escalate(
         action="hold", confidence=0.2, delta_usdg=0, equity_usdg=1_000_000,
-        holds_position=False, analyst_reports=["bullish", "bearish"],
+        holds_position=False, disagree=disagreement([]),
     )
     assert not v.escalate
 
 
+def _view(lens: str, direction: str, conf: float) -> AnalystView:
+    return AnalystView(lens=lens, direction=direction, confidence=conf, evidence_strength=0.7, note="")
+
+
+def test_disagreement_is_computed_from_fields_not_prose():
+    # The keyword scan this replaces fired ZERO times across 36 scenarios,
+    # including ones built to disagree. Analysts write carefully — a bear case
+    # opens "the breakout is real, but…" and scores bullish.
+    two_sided = disagreement([_view("technical", "buy", 0.72), _view("news", "sell", 0.66)])
+    assert two_sided.present
+    assert disagreement([_view("technical", "buy", 0.8), _view("news", "buy", 0.7)]).present is False
+
+
+def test_a_hedge_is_not_a_side():
+    # Two analysts who each half-believe opposite things are not in conflict.
+    # They are both saying they do not know, which is agreement about the
+    # evidence — and paying 45 calls for it is the false positive that would
+    # make escalation worthless.
+    weak = disagreement([_view("technical", "buy", 0.72), _view("news", "sell", 0.30)])
+    assert weak.present is False
+    assert "no two-sided conviction" in weak.detail
+
+
+def test_an_unparseable_analyst_is_no_data_not_a_guess():
+    assert parse_view("news", "not json at all").direction == "no-data"
+    assert parse_view("news", "").direction == "no-data"
+    good = parse_view("technical", '{"direction":"buy","confidence":0.7,"evidence_strength":0.6,"note":"n"}')
+    assert good.direction == "buy" and good.confidence == 0.7
+
+
 def test_disagreeing_analysts_escalate():
-    assert analysts_disagree(["strong breakout, bullish", "auditor resigned, bearish"])
-    assert not analysts_disagree(["bullish beat", "positive upside"])
     v = escalate(
         action="buy", confidence=0.8, delta_usdg=1_000, equity_usdg=1_000_000,
-        holds_position=True, analyst_reports=["strong bullish breakout", "weak, negative, breakdown"],
+        holds_position=True, disagree=disagreement([_view("technical", "buy", 0.8), _view("news", "sell", 0.7)]),
     )
     assert v.escalate and "analysts-disagree" in v.reasons
 
 
-def test_a_large_bet_escalates():
-    v = escalate(
+def test_the_size_and_opening_rules_are_off_because_they_measured_harmful():
+    # 36 scenarios: escalation changed 7 decisions, 1 improved and 6 regressed,
+    # and every change went trade -> hold. The debate stack has a systematic bias
+    # toward inaction, so escalating a trade candidate reliably kills it.
+    from brain.escalation import SIZE_AND_OPENING_RULES_ENABLED
+
+    assert SIZE_AND_OPENING_RULES_ENABLED is False
+    big = escalate(
         action="buy", confidence=0.9, delta_usdg=400_000, equity_usdg=1_000_000,
-        holds_position=True, analyst_reports=["bullish"],
+        holds_position=False, disagree=disagreement([]),
     )
-    assert v.escalate and "large-relative-to-book" in v.reasons
+    assert not big.escalate, "a large opening bet no longer buys a committee"
+
+
+def test_genuine_two_sided_disagreement_still_escalates():
+    # The one rule kept: it has a principled case and it never fired on the set
+    # where the others did harm, so nothing measured argues against it.
+    v = escalate(
+        action="buy", confidence=0.8, delta_usdg=1_000, equity_usdg=1_000_000,
+        holds_position=True,
+        disagree=disagreement([_view("technical", "buy", 0.8), _view("news", "sell", 0.7)]),
+    )
+    assert v.escalate and v.reasons == ["analysts-disagree"]
 
 
 def test_low_confidence_never_escalates_on_its_own():
@@ -144,7 +190,7 @@ def test_low_confidence_never_escalates_on_its_own():
     # escalated alone, every hedged answer would buy itself a committee.
     v = escalate(
         action="buy", confidence=0.05, delta_usdg=1_000, equity_usdg=1_000_000,
-        holds_position=True, analyst_reports=["bullish and positive"],
+        holds_position=True, disagree=disagreement([]),
     )
     assert not v.escalate, "low confidence sharpens an existing case, it does not make one"
 
@@ -152,7 +198,7 @@ def test_low_confidence_never_escalates_on_its_own():
 def test_an_ordinary_add_to_a_working_position_does_not_escalate():
     v = escalate(
         action="buy", confidence=0.7, delta_usdg=10_000, equity_usdg=1_000_000,
-        holds_position=True, analyst_reports=["bullish beat", "positive upside"],
+        holds_position=True, disagree=disagreement([]),
     )
     assert not v.escalate
     assert v.primary == "no-escalation"


### PR DESCRIPTION
### Structured analyst output

The keyword heuristic fired **zero times across 36 scenarios**, including ones built specifically to disagree — while silently carrying a third of the escalation gate.

It failed for a reason no longer word list fixes: it counted bullish/bearish **words in prose**, and analysts write carefully. A bear case opens *"the breakout is real, but…"* and scores bullish. The words describe the evidence, not the verdict.

Each analyst now returns `direction`, `confidence` and `evidence_strength` as fields alongside its prose. Disagreement is arithmetic. **No extra model call** — the analyst was already being asked. A hedge is not a side (two analysts each half-believing opposite things are agreeing they don't know). An unparseable answer is `no-data`, never a guess.

### And then the measurement said something worse

With disagreement finally working, escalation fired 12 times and changed 7 decisions: **1 improved, 6 regressed.** Every change went the same way — **trade → hold, 7 out of 7** — and six of those setups genuinely warranted the trade.

```
strong_bear            sell -> hold   REGRESSED  [large-relative-to-book]
agree_bull_ordinary    buy  -> hold   REGRESSED  [opening-a-position]
agree_bull_whole-book  buy  -> hold   REGRESSED  [large, opening]
conflicting            buy  -> hold   IMPROVED   [opening-a-position]
```

That is a direction, not noise: **the debate-and-risk stack has a systematic bias toward inaction.** Asked to stress-test a decision to act, it finds a reason not to whether or not one exists.

So `large-relative-to-book` and `opening-a-position` are **off**. Both are sound reasoning; both measured harmful. Kept behind a flag rather than deleted, because the finding is about the stack they escalate *into* — if the committee stops talking the desk out of trades, they become worth re-measuring rather than reinventing.

| | before | after |
|---|---|---|
| correct | 28/36 | **33/36** |
| calls | 217 | 163 |
| tokens | 252,520 | 162,177 |
| cost | $0.0798 | $0.0516 |
| latency | 6.5s | 4.5s |

**Better decisions for 35% less money, by removing reasoning rather than adding it.**

Also corrects a fixture: `epoch_one` expected a hold where the gate refuses. Epoch 1 is forensic by construction — there is no book to reason about, and a refusal costs nothing where a hold does not. The gate was right; the fixture was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)