### PR TITLE
brain: the review cadence is configurable, and refuses to become expensive

### DIFF
--- a/worker/src/brain-trigger.test.ts
+++ b/worker/src/brain-trigger.test.ts
@@ -14,6 +14,7 @@ import {
   afterFiring,
   DEFAULT_TRIGGERS,
   EMPTY_TRIGGER_STATE,
+  scheduledInterval,
   shouldWake,
   type TriggerInputs,
   type TriggerState,
@@ -147,5 +148,42 @@ describe("the baseline moves on every fire", () => {
     assert.equal(after.lastPriceUsd, 130, "the new price is the new baseline");
     const again = shouldWake(after, input({ now: T0 + 60, priceUsd: 130, newsKey: "n1" }));
     assert.equal(again.fire, false, "the same 30% move must not fire a second time");
+  });
+});
+
+describe("the review cadence is configurable, within bounds", () => {
+  // Shadow evaluation wants a tighter cadence than production: ten real
+  // decisions four hours apart takes a day and a half, and the point of shadow
+  // mode is learning what the thing does before it matters.
+  const FOUR_HOURS = 4 * 3600;
+  const read = (v?: string) =>
+    scheduledInterval(v === undefined ? {} : { MERRYMEN_BRAIN_INTERVAL_SEC: v });
+
+  it("takes a shorter cadence when one is set", () => {
+    assert.equal(read("900"), 900);
+    assert.equal(read(" 600 "), 600, "whitespace from a Railway variable is not a parse failure");
+    assert.equal(read("60"), 60, "the floor itself is allowed");
+    assert.equal(read("120.9"), 120, "fractional seconds are meaningless against a 240s tick");
+  });
+
+  it("falls back to four hours on anything under a minute, or any nonsense", () => {
+    // A scheduled review firing faster than the 240s tick cannot mean anything.
+    // And the failure direction for a SPEND CONTROL is the expensive default,
+    // never the cheap one: a typo must not become 360 runs a day.
+    for (const bad of ["0", "-1", "30", "59", "", "   ", "soon", "NaN", "Infinity", "1e400", undefined]) {
+      assert.equal(read(bad), FOUR_HOURS, `${JSON.stringify(bad)} must not shorten the cadence`);
+    }
+  });
+
+  it("ships four hours with nothing configured", () => {
+    assert.equal(DEFAULT_TRIGGERS.scheduledIntervalSec >= 60, true);
+  });
+
+  it("keeps the scheduled cooldown below the interval it spaces out", () => {
+    // A cooldown longer than the interval silences the very review it is meant
+    // to space — which is how a configurable cadence quietly becomes no cadence.
+    const cd = DEFAULT_TRIGGERS.cooldownSec["scheduled-review"] ?? 0;
+    assert.ok(cd < DEFAULT_TRIGGERS.scheduledIntervalSec, `cooldown ${cd} must be under the interval`);
+    assert.ok(cd >= 30, "but not so small that a restart loop can spin on it");
   });
 });

--- a/worker/src/brain-trigger.ts
+++ b/worker/src/brain-trigger.ts
@@ -54,17 +54,37 @@ export interface TriggerConfig {
   cooldownSec: Partial<Record<TriggerReason, number>>;
 }
 
+/**
+ * How long Brain may sleep with nothing happening, in seconds.
+ *
+ * FOUR HOURS BY DEFAULT — long enough that a quiet market costs six runs a day
+ * rather than 360, short enough that an agent is never silent for a session.
+ *
+ * Configurable because SHADOW EVALUATION wants a tighter cadence than
+ * production does: gathering ten real decisions at four hours apart takes a day
+ * and a half, and the whole point of shadow mode is learning what the thing
+ * does before it matters. Bounded on both sides — under a minute is refused,
+ * because a scheduled review firing faster than the tick cannot mean anything,
+ * and the per-reason cooldowns and the per-run budget still apply underneath.
+ */
+export function scheduledInterval(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = Number((env.MERRYMEN_BRAIN_INTERVAL_SEC ?? "").trim());
+  if (!Number.isFinite(raw) || raw < 60) return 4 * 3600;
+  return Math.floor(raw);
+}
+
 export const DEFAULT_TRIGGERS: TriggerConfig = {
-  // Four hours. Long enough that a quiet market costs six runs a day rather
-  // than 360; short enough that an agent is never silent for a session.
-  scheduledIntervalSec: 4 * 3600,
+  scheduledIntervalSec: scheduledInterval(),
   priceMovePct: 0.03,
   equityMovePct: 0.05,
   cooldownSec: {
     "price-move": 1800,
     "portfolio-change": 1800,
     "news-event": 900,
-    "scheduled-review": 3600,
+    // Never longer than the interval itself — a cooldown above it would silence
+    // the very review it is meant to space out, which is how a configurable
+    // cadence quietly becomes no cadence.
+    "scheduled-review": Math.min(3600, Math.max(30, Math.floor(scheduledInterval() / 2))),
     // A person asking is not rate-limited to half an hour, but it is still
     // bounded — a stuck client must not become a spend loop.
     "user-request": 60,


### PR DESCRIPTION
Shadow mode's job is to learn what Brain does before it matters. At a four-hour
scheduled review, ten real production decisions take a day and a half to gather
— the wrong clock for evaluation, the right one for production. So it becomes
`MERRYMEN_BRAIN_INTERVAL_SEC` rather than a constant.

**Bounded on the side that costs money, not the side that saves it.**

| Input | Result |
|---|---|
| `900` | 900s |
| `" 600 "` | 600s — whitespace off a Railway variable is not a parse failure |
| `60` | 60s — the floor itself is allowed |
| `120.9` | 120s — fractional seconds mean nothing against a 240s tick |
| `0` `-1` `30` `59` `""` `"soon"` `"NaN"` `"Infinity"` unset | **4 hours** |

Every parse failure falls back to the expensive default. A typo must not
silently become 360 runs a day — this fleet has already had one incident where
an unwatched background feature emptied a daily token allowance, and a spend
control fails toward the cautious end.

The scheduled cooldown is derived as `interval/2` clamped to `[30s, 1h]`, so it
can never exceed the interval it exists to space out. A cooldown above the
interval silences the very review it spaces — which is how a configurable
cadence quietly becomes no cadence. A test pins that relationship rather than
the two numbers, so it survives a future retune.

**What this does not change.** Per-reason cooldowns, per-agent concurrency of 1,
and the per-run budget all still apply underneath. This only changes how often
the clock asks; it cannot make a run cheaper to refuse or more expensive to
allow. Execution stays disconnected.

The child inherits the orchestrator's environment minus `CHILD_SECRET_STRIP`, so
setting this on the orchestrator reaches every worker with no plumbing.

`npm run typecheck` clean; 17 trigger tests, 33 brain tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)