### PR TITLE
social: a Merryman that cannot trade must not say it is trading

### DIFF
--- a/web/src/components/ThesisCard.tsx
+++ b/web/src/components/ThesisCard.tsx
@@ -84,7 +84,9 @@ export function ThesisCard({
 
         {/* Subordinate. A thesis has none of this — its words are the post. */}
         {trade && (
-          <div className={`mm-trade${turned ? " turned" : ""}${t.paper ? " sim" : ""}`}>
+          <div
+            className={`mm-trade${turned ? " turned" : ""}${t.paper ? " sim" : ""}${t.shadow ? " shadow" : ""}`}
+          >
             {t.symbol && <span className="sym mono">{t.symbol}</span>}
             {t.sizeUsdg !== null && <span className="amt mono">{money(t.sizeUsdg)}</span>}
             {t.outcomeText && <span className="out mono">{t.outcomeText}</span>}

--- a/web/src/lib/read-theses.ts
+++ b/web/src/lib/read-theses.ts
@@ -37,7 +37,7 @@
  * sheet — is not in the SELECT at all: absent, rather than filtered.
  */
 import { withReadDb } from "@/lib/ledger";
-import { PUBLISHABLE_STRATEGIES, publishableThesis, type PublicThesis, type ThesisRow } from "@/lib/thesis";
+import { PUBLISHABLE_SOURCES, publishableThesis, type PublicThesis, type ThesisRow } from "@/lib/thesis";
 import { getIdentityStore } from "@merrymen/identity-store";
 
 /** How far back a post can be and still be news. */
@@ -46,7 +46,12 @@ export const WINDOW_SEC = 24 * 3600;
 const SCAN = 90;
 const SHOW = 40;
 
-const SOURCES = ["strategist", ...PUBLISHABLE_STRATEGIES.map((s) => `strategy:${s}`)];
+// DERIVED, never listed again here. The SQL narrowing is an optimisation and
+// `publishableThesis` is the rule — but a second hand-maintained list makes the
+// optimisation quietly authoritative for anything the policy later admits. That
+// is how `brain-shadow` would have been added to the policy and stayed invisible
+// on the feed, looking for all the world like a bug in the gate.
+const SOURCES: readonly string[] = PUBLISHABLE_SOURCES;
 
 export interface ThesesRead {
   /** "none" means the ledger could not be read — NOT that nobody said anything. */

--- a/web/src/lib/thesis-badge.test.ts
+++ b/web/src/lib/thesis-badge.test.ts
@@ -1,0 +1,102 @@
+/**
+ * THE WORD ON THE CARD IS A CLAIM ABOUT WHAT AN AGENT DID.
+ *
+ * `badgeOf` is one line of text, which is why it is easy to treat as styling.
+ * It is not styling: it is the sentence a reader believes. "bought" says money
+ * moved, "buying" says money is moving, "thesis" says an opinion was formed.
+ *
+ * The case these tests exist for is Brain in shadow mode. Its decision arrives
+ * as a buy, with a symbol and a size and NO status — which is byte-for-byte
+ * what a real buy looks like before its trade lands. Every test in this
+ * function was written before Brain existed, and the buy arm reads exactly that
+ * shape as "buying". An agent with no path to the executor would have announced
+ * that it was trading, in its own voice, on a page anybody can read.
+ *
+ * So `shadow` is checked FIRST, and the ordering is the property.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { badgeOf, hasTrade } from "./thesis-badge";
+import type { PublicThesis } from "./thesis";
+
+const post = (over: Partial<PublicThesis> = {}): PublicThesis => ({
+  name: "Much",
+  slug: null,
+  handle: null,
+  head: "buy TSLA 5.00 USDG",
+  action: "buy",
+  symbol: "TSLA",
+  sizeUsdg: 5,
+  paper: false,
+  outcome: "pending",
+  outcomeText: "no trade came of it",
+  shadow: false,
+  reason: "momentum is intact",
+  said: 1,
+  at: 1_700_000_000,
+  firstAt: 1_700_000_000,
+  ...over,
+});
+
+describe("a shadow post never claims a trade", () => {
+  it("says 'would buy', not 'buying'", () => {
+    // The exact regression: same row, one flag apart.
+    assert.deepEqual(badgeOf(post()), { label: "buying", kind: "bought" });
+    assert.deepEqual(badgeOf(post({ shadow: true, outcome: "shadow" })), {
+      label: "would buy",
+      kind: "thesis",
+    });
+  });
+
+  it("says 'would sell', not 'selling'", () => {
+    assert.deepEqual(badgeOf(post({ shadow: true, outcome: "shadow", action: "sell" })), {
+      label: "would sell",
+      kind: "thesis",
+    });
+  });
+
+  it("wins over every other arm, whatever else the row says", () => {
+    // A shadow row carrying a trade status is a contradiction that
+    // `publishableThesis` drops before it can reach here. If one ever does
+    // reach here, the conditional still wins — the badge is the last surface
+    // before a reader, and it fails toward the claim that is safe to be wrong
+    // about.
+    for (const outcome of ["landed", "reverted", "refused", "dropped", "pending"] as const) {
+      const b = badgeOf(post({ shadow: true, outcome }));
+      assert.equal(b.kind, "thesis", `${outcome} must not out-rank shadow`);
+      assert.ok(!/^(bought|sold|buying|selling)$/.test(b.label), `${outcome} produced "${b.label}"`);
+    }
+  });
+
+  it("keeps its strip, because that is where the disclaimer renders", () => {
+    // `outcomeText` — "a stated intention — not traded" — is rendered inside the
+    // trade strip and nowhere else. Suppressing the strip for a shadow post,
+    // which is what a thesis badge normally does, leaves a card reading "would
+    // buy" with no name, no size and nothing saying the trade did not happen.
+    assert.equal(hasTrade(post({ shadow: true, outcome: "shadow" })), true);
+    // But a shadow post about the book rather than one name still has none.
+    assert.equal(
+      hasTrade(post({ shadow: true, outcome: "shadow", symbol: null, sizeUsdg: null })),
+      false,
+    );
+    assert.equal(hasTrade(post()), true);
+    assert.equal(hasTrade(post({ action: "hold", outcome: "view" })), false);
+  });
+
+  it("leaves every non-shadow badge exactly as it was", () => {
+    assert.deepEqual(badgeOf(post({ outcome: "landed" })), { label: "bought", kind: "bought" });
+    assert.deepEqual(badgeOf(post({ action: "sell", outcome: "landed" })), {
+      label: "sold",
+      kind: "sold",
+    });
+    assert.deepEqual(badgeOf(post({ outcome: "refused" })), { label: "turned back", kind: "turned" });
+    assert.deepEqual(badgeOf(post({ outcome: "dropped" })), {
+      label: "thought better of it",
+      kind: "quiet",
+    });
+    assert.deepEqual(badgeOf(post({ action: "hold", outcome: "view" })), {
+      label: "thesis",
+      kind: "thesis",
+    });
+  });
+});

--- a/web/src/lib/thesis-badge.ts
+++ b/web/src/lib/thesis-badge.ts
@@ -20,6 +20,22 @@ export interface Badge {
 }
 
 export function badgeOf(t: PublicThesis): Badge {
+  // SHADOW IS CHECKED FIRST, and the ordering is the whole safety property.
+  //
+  // A shadow decision arrives as a buy with a size and no status, which every
+  // test below reads as "a buy that has not landed yet" — and the buy arm turns
+  // that into the word "BUYING". Brain has no path to the executor at all, so
+  // that badge would be an agent announcing a trade it cannot make, in its own
+  // voice, on a page anybody can read.
+  //
+  // The conditional is already in `t.head` ("would buy TSLA 5.00 USDG"), which
+  // is what the non-React surfaces render. This is the same claim, in the one
+  // place a reader looks first.
+  if (t.shadow) {
+    if (t.action === "buy") return { label: "would buy", kind: "thesis" };
+    if (t.action === "sell") return { label: "would sell", kind: "thesis" };
+    return { label: "thesis", kind: "thesis" };
+  }
   if (t.outcome === "refused" || t.outcome === "reverted") {
     return { label: "turned back", kind: "turned" };
   }
@@ -42,5 +58,14 @@ export function badgeOf(t: PublicThesis): Badge {
  * biggest visual difference between the two kinds of card.
  */
 export function hasTrade(t: PublicThesis): boolean {
+  // A SHADOW POST KEEPS ITS STRIP, even though its badge is a thesis badge.
+  //
+  // The first cut hid it, on the reasoning that a thesis's words are the post.
+  // That is backwards here: the strip is where `outcomeText` renders, and for a
+  // shadow post that text is the disclaimer — "a stated intention — not
+  // traded". Hiding the strip left a card reading "would buy" with no name, no
+  // size, and nothing at all saying the trade did not happen. The qualifier
+  // belongs beside the number it qualifies, not in a caption somewhere else.
+  if (t.shadow) return t.symbol !== null || t.sizeUsdg !== null;
   return badgeOf(t).kind !== "thesis" && (t.symbol !== null || t.sizeUsdg !== null);
 }

--- a/web/src/lib/thesis.test.ts
+++ b/web/src/lib/thesis.test.ts
@@ -2,7 +2,14 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { PUBLISHABLE_STRATEGIES, classifyDrop, publishableThesis, type ThesisRow } from "./thesis";
+import {
+  PUBLISHABLE_SOURCES,
+  PUBLISHABLE_STRATEGIES,
+  SHADOW_SOURCES,
+  classifyDrop,
+  publishableThesis,
+  type ThesisRow,
+} from "./thesis";
 
 /**
  * This guard is the only thing between the decisions table and a page anybody
@@ -261,5 +268,126 @@ describe("the policy cannot drift from the strategies", () => {
       .replace(/(^|[^:])\/\/.*$/gm, "$1");
     assert.ok(!/signals_json/.test(src), "signals_json must never be selected");
     assert.ok(!/tenantOf/.test(src), "a public route must not read a session");
+  });
+});
+
+/**
+ * A MERRYMAN THAT CANNOT TRADE MUST NOT SAY IT IS TRADING.
+ *
+ * Brain runs in shadow: it thinks, its decision is persisted, and there is no
+ * path from it into `proposalsToIntents` or the executor — a separate test
+ * proves that absence by reading the imports. These tests are about the trip
+ * from that decision to a public page, which is where the disconnection nearly
+ * failed to survive.
+ *
+ * A shadow row is a buy, with a symbol, a size, and a NULL status. That is
+ * indistinguishable — to every gate written before Brain existed — from a real
+ * buy whose trade has not landed yet. It resolves to `outcome: "pending"`, and
+ * the feed's badge turns a pending buy into the word "BUYING".
+ */
+describe("shadow decisions say the conditional out loud", () => {
+  const shadow = (over: Partial<ThesisRow> = {}): ThesisRow =>
+    ok({
+      source: "brain-shadow",
+      action: "buy",
+      symbol: "TSLA",
+      size_usdg: 5,
+      reason: "momentum is intact and the position is small relative to the book",
+      status: null,
+      ...over,
+    });
+
+  it("never renders as a trade that happened, or is about to", () => {
+    const t = publishableThesis(shadow())!;
+    assert.equal(t.shadow, true);
+    assert.equal(t.outcome, "shadow");
+    assert.equal(t.head, "would buy TSLA 5.00 USDG");
+    assert.match(t.outcomeText, /not traded/);
+    // The three outcomes that assert something reached the chain, and the one
+    // that asserts it is on its way. A shadow decision is none of them.
+    assert.ok(!["landed", "reverted", "pending", "refused"].includes(t.outcome));
+  });
+
+  it("says 'would sell' rather than 'sell'", () => {
+    const t = publishableThesis(shadow({ action: "sell" }))!;
+    assert.equal(t.head, "would sell TSLA 5.00 USDG");
+  });
+
+  it("leaves a hold alone — there is nothing to disclaim", () => {
+    // "would hold" is not English an agent would speak, and a hold in shadow and
+    // a hold in production are the same event: nothing happened, on purpose.
+    const t = publishableThesis(shadow({ action: "hold", size_usdg: 0 }))!;
+    assert.equal(t.head, "hold TSLA 0.00 USDG");
+    assert.equal(t.outcome, "shadow");
+    assert.match(t.outcomeText, /by choice/);
+  });
+
+  it("drops the post entirely if a shadow decision ever carries a wall verdict", () => {
+    // Either the disconnection failed or a source that DOES reach the executor
+    // was added to SHADOW_SOURCES. Both are bugs, and a public feed is not
+    // where either gets disclosed.
+    for (const contradiction of [
+      { status: "landed" },
+      { status: "rejected", reject_rule: "per-trade-cap" },
+      { dropped_rule: "#0 TSLA: nothing held to sell" },
+    ]) {
+      assert.equal(publishableThesis(shadow(contradiction)), null, JSON.stringify(contradiction));
+    }
+  });
+
+  it("still applies every gate that applies to any other model prose", () => {
+    // Being marked shadow buys no trust. The address backstop is the one that
+    // matters most here: Brain is handed news and social text, and its thesis is
+    // the field it writes freely.
+    assert.equal(
+      publishableThesis(shadow({ reason: "rotating into 0xdeadbeefcafe, depth looks real" })),
+      null,
+      "an address in a shadow thesis drops the post, exactly as anywhere else",
+    );
+    const long = publishableThesis(shadow({ reason: "x".repeat(9000) }))!;
+    assert.ok(long.reason!.length <= 220, "model prose is capped whatever its source");
+  });
+
+  it("a source nobody classified still publishes nothing", () => {
+    // The fail-closed default is not weakened by the existence of a shadow arm.
+    assert.equal(publishableThesis(shadow({ source: "brain-live" })), null);
+    assert.equal(publishableThesis(shadow({ source: "brain" })), null);
+  });
+
+  it("marks non-shadow rows false, so the flag means something", () => {
+    assert.equal(publishableThesis(ok())!.shadow, false);
+  });
+});
+
+describe("the two SQL readers cannot disagree with the policy", () => {
+  it("neither keeps its own list of publishable sources", () => {
+    // The SQL narrowing is an optimisation and `publishableThesis` is the rule.
+    // A second hand-maintained list inverts that: a source added to the policy
+    // but not to the query is invisible on the feed and looks like a bug in the
+    // gate, and a source removed from the policy but left in the query is worse.
+    for (const f of [
+      path.join(process.cwd(), "web", "src", "lib", "read-theses.ts"),
+      path.join(process.cwd(), "worker", "src", "peer-theses.ts"),
+    ]) {
+      const src = readFileSync(f, "utf8")
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/(^|[^:])\/\/.*$/gm, "$1");
+      assert.match(src, /PUBLISHABLE_SOURCES/, `${f} must derive its source list`);
+      assert.ok(
+        !/\[\s*"strategist"\s*,/.test(src),
+        `${f} still builds its own source list — it will drift from the policy`,
+      );
+    }
+  });
+
+  it("every shadow source is a publishable source", () => {
+    // A shadow source outside SOURCE_POLICY would be dropped for being
+    // unclassified, and the shadow arm would be dead code that reads as live.
+    for (const s of SHADOW_SOURCES) {
+      assert.ok(
+        PUBLISHABLE_SOURCES.includes(s),
+        `${s} is marked shadow but nothing classified it for publication`,
+      );
+    }
   });
 });

--- a/web/src/lib/thesis.ts
+++ b/web/src/lib/thesis.ts
@@ -18,7 +18,9 @@
  * exact asymmetry the move was made to prevent.
  */
 export {
+  PUBLISHABLE_SOURCES,
   PUBLISHABLE_STRATEGIES,
+  SHADOW_SOURCES,
   REJECT_RULES,
   classifyDrop,
   outcomeOf,

--- a/web/src/styles/feed.css
+++ b/web/src/styles/feed.css
@@ -188,6 +188,28 @@
   color: var(--mm-warn);
 }
 
+/* NOTHING WAS EVEN ATTEMPTED. A shadow decision is the agent saying what it
+   would do; the machinery that would have done it is not connected.
+
+   Dotted rather than `sim`'s dashed, and the distinction is worth a line: a
+   paper fill DID happen, against pretend money, so a dashed edge says "real
+   event, fake capital". This is a rung below that — no event at all — so the
+   line is lighter still, and the figure is quiet because it is a proposal
+   rather than an amount anybody moved. Not struck through: `turned` earns that
+   by having been refused, and a decision nobody asked the wall about was not
+   refused. */
+.mm-trade.shadow {
+  border-style: dotted;
+  border-color: color-mix(in srgb, var(--mm-edge) 80%, transparent);
+  background: none;
+}
+
+.mm-trade.shadow .sym,
+.mm-trade.shadow .amt {
+  color: var(--mm-tx-2);
+  font-weight: 500;
+}
+
 .mm-said {
   margin: var(--mm-2) 0 0;
   font-size: var(--mm-t-meta);

--- a/worker/src/peer-files.test.ts
+++ b/worker/src/peer-files.test.ts
@@ -34,6 +34,7 @@ const thesis = (over: Partial<PublicThesis> = {}): PublicThesis => ({
   paper: false,
   outcome: "landed",
   outcomeText: "landed",
+  shadow: false,
   reason: "Depth cleared the floor on the third pass and the buyer count held.",
   said: 1,
   at: 1_800_000_000,

--- a/worker/src/peer-theses.ts
+++ b/worker/src/peer-theses.ts
@@ -24,7 +24,7 @@
 import type { Db } from "./db";
 import { getIdentityStore } from "./identity-store";
 import {
-  PUBLISHABLE_STRATEGIES,
+  PUBLISHABLE_SOURCES,
   publishableThesis,
   type PublicThesis,
   type ThesisRow,
@@ -41,7 +41,10 @@ export const PEER_WINDOW_SEC = 24 * 3600;
  * a source that publishableThesis is perfectly happy to publish, so a peer would
  * quietly go quiet. Built from the same constant thesis-policy gates on.
  */
-const SOURCES: readonly string[] = ["strategist", ...PUBLISHABLE_STRATEGIES.map((s) => `strategy:${s}`)];
+// The same list the public feed uses, from the same module. "A peer file can
+// only contain what the public feed publishes" is a property only while these
+// two readers are incapable of disagreeing about what that is.
+const SOURCES: readonly string[] = PUBLISHABLE_SOURCES;
 
 /** At most this many theses reach one child, newest first. A prompt has a budget. */
 export const PEER_THESIS_LIMIT = 24;

--- a/worker/src/thesis-policy.ts
+++ b/worker/src/thesis-policy.ts
@@ -132,8 +132,18 @@ export interface PublicThesis {
    * came of it" — a failure sentence for the one case that is not a failure.
    * The same was true of an explicit hold. A hold is an answer.
    */
-  outcome: "landed" | "reverted" | "refused" | "dropped" | "pending" | "view";
+  outcome: "landed" | "reverted" | "refused" | "dropped" | "pending" | "view" | "shadow";
   outcomeText: string;
+  /**
+   * The agent said this; nothing could have come of it.
+   *
+   * A separate boolean rather than `outcome === "shadow"` alone, because a
+   * renderer that forgets the new outcome arm still has to answer this
+   * question, and because the two facts are genuinely different: `outcome` is
+   * what happened to the decision, `shadow` is whether the machinery that would
+   * have made something happen was connected at all.
+   */
+  shadow: boolean;
   reason: string | null;
   /** How many times this exact thesis was said in the window. */
   said: number;
@@ -162,12 +172,54 @@ export const PUBLISHABLE_STRATEGIES = [
 const SOURCE_POLICY: Readonly<Record<string, "strategy" | "model">> = Object.freeze({
   // The model's own words. Capped and address-checked before they are shown.
   strategist: "model",
+  // Brain, running in shadow. Its words are a model's words and are treated as
+  // such; what makes it different is not the trust level but the TENSE — see
+  // SHADOW_SOURCES.
+  "brain-shadow": "model",
   ...Object.fromEntries(PUBLISHABLE_STRATEGIES.map((s) => [`strategy:${s}`, "strategy" as const])),
   // NOT here, and each for its own reason:
   //   chat     — carries a counterparty address by template
   //   selftest — a dust probe, not a market view; it says so itself
   //   strategy:<a tenant's own file> — a string we did not write
 });
+
+/**
+ * SOURCES WHOSE DECISIONS CANNOT REACH A TRADE.
+ *
+ * Brain is wired to think and to nothing else: there is no path from a
+ * `BrainDecision` into `proposalsToIntents` or the executor, and a test proves
+ * the absence by reading the imports rather than by trusting this comment.
+ *
+ * That absence has to survive the trip to a public page, and it very nearly did
+ * not. A shadow row arrives with `action: "buy"`, a symbol, a size and a NULL
+ * status — which is indistinguishable, to every gate below, from a real buy
+ * whose trade has not landed yet. It would have been published as
+ * `outcome: "pending"`, and the feed's badge function turns a pending buy into
+ * the word "BUYING". An agent that cannot trade would have announced that it
+ * was trading, in its own voice, on a page anybody can read.
+ *
+ * So a shadow source gets its own outcome arm and its own head, and both say
+ * the conditional out loud: "would buy TSLA 5.00 USDG · a stated intention".
+ * The reader is never left to infer from a missing status that nothing happened
+ * — the post says so.
+ *
+ * WHEN EXECUTION IS CONNECTED, a source moves OUT of this set rather than the
+ * set being deleted. The three states the feed then has to distinguish —
+ * THESIS, INTENT, EXECUTED — are exactly the distinction this set draws, and
+ * they do not collapse into one just because one agent graduated.
+ */
+export const SHADOW_SOURCES = ["brain-shadow"] as const;
+const IS_SHADOW: ReadonlySet<string> = new Set<string>(SHADOW_SOURCES);
+
+/**
+ * Every source a reader may put in a `WHERE source IN (…)`.
+ *
+ * Exported so the two SQL callers derive their list from the policy instead of
+ * keeping their own copy of it. The SQL narrowing is an OPTIMISATION and this
+ * module is the rule — but a hand-maintained second list is how the optimisation
+ * silently becomes the rule for anything the policy later admits.
+ */
+export const PUBLISHABLE_SOURCES: readonly string[] = Object.freeze(Object.keys(SOURCE_POLICY));
 
 /**
  * Anything that looks like an on-chain identifier.
@@ -288,13 +340,25 @@ export function outcomeOf(
   return { outcome: "refused", text: known ?? "the wall turned it back" };
 }
 
-/** "buy AAPL 16.66 USDG" — built structurally, never from prose. */
-function headOf(row: ThesisRow): string {
+/**
+ * "buy AAPL 16.66 USDG" — built structurally, never from prose.
+ *
+ * A shadow decision reads "would buy AAPL 16.66 USDG". The conditional is put
+ * in the HEAD rather than left to a badge because the head is the one string
+ * every surface renders: a share card, a feed row, a peer file the desk reads
+ * back to another agent. Only one of those three is a React component, so a
+ * claim that is only made conditional by CSS is not made conditional.
+ */
+function headOf(row: ThesisRow, shadow: boolean): string {
   const size =
     typeof row.size_usdg === "number" && Number.isFinite(row.size_usdg)
       ? `${row.size_usdg.toFixed(2)} USDG`
       : null;
-  return [row.action, row.symbol, size].filter(Boolean).join(" ");
+  // A hold is already the conditional's answer — "would hold" is not English an
+  // agent would speak, and there is nothing to disclaim.
+  const verb =
+    shadow && (row.action === "buy" || row.action === "sell") ? `would ${row.action}` : row.action;
+  return [verb, row.symbol, size].filter(Boolean).join(" ");
 }
 
 /**
@@ -326,7 +390,19 @@ export function publishableThesis(row: ThesisRow): PublicThesis | null {
     reason = classifyDrop(row.dropped_rule);
   }
 
-  const head = headOf(row);
+  // ── shadow ────────────────────────────────────────────────────────────────
+  // Resolved before the outcome chain, because every arm of that chain assumes
+  // the decision was at least ALLOWED to become a trade, and this one was not.
+  const shadow = IS_SHADOW.has(row.source!);
+
+  // A shadow decision that carries a wall verdict or a trade status is a
+  // CONTRADICTION, not a post: either the disconnection failed, or a source was
+  // added to SHADOW_SOURCES that does reach the executor. Both are bugs, and
+  // neither is disclosed on a public feed — the row is dropped and the
+  // disconnection test is the thing that should have caught it.
+  if (shadow && (row.status || row.dropped_rule || row.reject_rule)) return null;
+
+  const head = headOf(row, shadow);
 
   // DECIDED, versus FAILED TO HAPPEN.
   //
@@ -340,13 +416,19 @@ export function publishableThesis(row: ThesisRow): PublicThesis | null {
   // and reports what actually happened.
   const isView = !row.action && !row.symbol && !row.dropped_rule && !row.status;
   const isHold = row.action === "hold" && !row.status;
-  const { outcome, text } = isView
-    ? ({ outcome: "view", text: "a view, no trade" } as const)
-    : isHold
-      ? ({ outcome: "view", text: "held — no trade, by choice" } as const)
-      : row.dropped_rule && !row.status
-        ? ({ outcome: "dropped", text: "dropped before it reached the wall" } as const)
-        : outcomeOf(row.status, row.reject_rule);
+  const { outcome, text } = shadow
+    ? row.action === "hold" || !row.action
+      ? // A shadow hold and a live hold are the same event — nothing happened,
+        // on purpose — so it keeps the sentence a reader already understands.
+        ({ outcome: "shadow", text: "held — no trade, by choice" } as const)
+      : ({ outcome: "shadow", text: "a stated intention — not traded" } as const)
+    : isView
+      ? ({ outcome: "view", text: "a view, no trade" } as const)
+      : isHold
+        ? ({ outcome: "view", text: "held — no trade, by choice" } as const)
+        : row.dropped_rule && !row.status
+          ? ({ outcome: "dropped", text: "dropped before it reached the wall" } as const)
+          : outcomeOf(row.status, row.reject_rule);
 
   // A post with neither a head nor a reason says nothing at all.
   if (!head && !reason) return null;
@@ -384,6 +466,7 @@ export function publishableThesis(row: ThesisRow): PublicThesis | null {
       typeof row.size_usdg === "number" && Number.isFinite(row.size_usdg) ? row.size_usdg : null,
     outcome,
     outcomeText: text,
+    shadow,
     reason,
     said: Math.max(1, Number(row.said ?? 1)),
     at: Number(row.last_at ?? 0),


### PR DESCRIPTION
Brain's shadow decisions reach the public feed. The decision row already
existed; what was missing was the trip to a page anybody can read — and that
trip very nearly published a lie.

## The bug this is mostly about

A shadow row is a buy, with a symbol, a size, and a **NULL status**. That is
byte-for-byte what a real buy looks like before its trade lands, so every gate
written before Brain existed reads it as one:

```
publishableThesis(shadow row)  ->  outcome: "pending", head: "buy TSLA 5.00 USDG"
badgeOf(that)                  ->  { label: "BUYING", kind: "bought" }
```

An agent with **no path to the executor at all** would have announced that it
was trading, in its own voice, on a public page.

## The conditional is said in three places

Because three different kinds of surface render it:

| Surface | Says |
|---|---|
| `head` | `would buy TSLA 5.00 USDG` |
| `outcome` / `outcomeText` | new `shadow` arm — *"a stated intention — not traded"* |
| `badgeOf` | `would buy`, checked **first** |

The head matters most: it is the one string every surface uses — a feed row, a
share card, and the peer file another agent's desk reads back. Only one of
those is a React component, so a claim made conditional by CSS is not made
conditional.

## Fail-closed additions

- A shadow row carrying a trade status, a reject rule, or a `dropped_rule` is
  **dropped whole**. Either the disconnection failed or a source that does reach
  the executor was added to `SHADOW_SOURCES` — both are bugs, and a public feed
  is not where either gets disclosed.
- Both SQL readers (`read-theses.ts`, `peer-theses.ts`) now derive their source
  list from `PUBLISHABLE_SOURCES` instead of keeping a copy. A second
  hand-maintained list inverts which one is the rule: `brain-shadow` would have
  been added to the policy, stayed invisible on the feed, and looked like a bug
  in the gate. A test pins that neither file builds its own list.
- Being marked shadow buys **no trust**. The address backstop, the
  220-character cap and the unclassified-source default all still apply — Brain
  is handed news and social text, and its thesis is the field it writes freely.

## One reversal worth noting

The trade strip is **kept** for shadow posts, against the usual thesis-badge
rule. `outcomeText` renders inside that strip and nowhere else, so suppressing
it left a card reading "would buy" with no name, no size, and nothing saying
the trade did not happen. The qualifier belongs beside the number it qualifies.
It renders **dotted** rather than dashed: a paper fill is a real event against
pretend money; this is a rung below that — no event at all.

## Verification

`npm run typecheck` clean · **2228/2228** tests pass · 15 new tests covering
the badge ordering, the head, the contradiction drop, the source-list drift,
and that every non-shadow badge is byte-identical to before.

Execution stays disconnected; `brain-disconnected.test.ts` is untouched and
still proves the absence by reading imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)