### PR TITLE
brain: record where the lenses landed, on every run and not only escalated ones

### DIFF
--- a/services/brain/brain/graph.py
+++ b/services/brain/brain/graph.py
@@ -42,6 +42,7 @@ from .escalation import EscalationVerdict, assess as assess_escalation
 from .gate import GateResult, assess
 from .llm import Llm, ProviderError, extract_json
 from .schemas import (
+    AnalystSignal,
     BrainDecision,
     Cost,
     DecideRequest,
@@ -305,6 +306,7 @@ class BrainGraph:
                 return self._assemble(
                     req, budget, gate, candidate, bull="", bear="",
                     depth_used="analysts", escalation=escalation, candidate_action=candidate_action,
+                    views=views,
                 )
             stages = "full"
 
@@ -328,7 +330,7 @@ class BrainGraph:
         return self._assemble(
             req, budget, gate, data, bull=bull, bear=bear,
             depth_used="full" if stages == "full" else "analysts+debate",
-            escalation=escalation, candidate_action=candidate_action,
+            escalation=escalation, candidate_action=candidate_action, views=views,
         )
 
     def _assemble(
@@ -343,6 +345,7 @@ class BrainGraph:
         depth_used: str,
         escalation: EscalationVerdict,
         candidate_action: str | None,
+        views: list[AnalystView],
     ) -> BrainDecision:
         # ── THE GATE WINS, whatever the model said ──────────────────────────
         #
@@ -400,6 +403,23 @@ class BrainGraph:
             candidate_action=(
                 candidate_action if (candidate_action and depth_used != "analysts") else None
             ),  # type: ignore[arg-type]
+            # Recorded on EVERY run, escalated or not. `escalation_reasons` can
+            # only describe the runs that escalated, and in production almost
+            # none do — the size and opening rules are off on measured evidence,
+            # a hold never escalates by design, and every production decision so
+            # far has been a hold. Without this the live data says "no
+            # escalation" over and over and cannot say whether that was right.
+            # No extra model call: the analysts were already asked, and already
+            # answered in fields.
+            analyst_views=[
+                AnalystSignal(
+                    lens=v.lens[:40],
+                    direction=v.direction,
+                    confidence=v.confidence,
+                    evidence_strength=v.evidence_strength,
+                )
+                for v in views
+            ],
             cost=budget.cost(),
             models=budget.models,
         )

--- a/services/brain/brain/schemas.py
+++ b/services/brain/brain/schemas.py
@@ -112,6 +112,28 @@ class ChangedView(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
 
+class AnalystSignal(BaseModel):
+    """
+    One lens's verdict, as numbers.
+
+    A flattened `AnalystView` with the prose left behind — see the comment on
+    `BrainDecision.analyst_views`. There is no free-text field here at all,
+    which is what makes it safe to persist verbatim: `lens` is one of our own
+    names, `direction` is a closed set, and the two floats are clamped to [0,1]
+    by `parse_view` before they arrive.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    lens: str = Field(max_length=40)
+    direction: Literal["buy", "sell", "hold", "no-data"]
+    confidence: float = Field(ge=0.0, le=1.0)
+    #: How much the lens had to work with, as distinct from how sure it is. A
+    #: confident read of thin evidence and a confident read of thick evidence
+    #: are different things, and only one of them is worth escalating over.
+    evidence_strength: float = Field(ge=0.0, le=1.0)
+
+
 class BrainDecision(BaseModel):
     """
     The one object a Merryman's thinking produces.
@@ -164,6 +186,26 @@ class BrainDecision(BaseModel):
     #: The action the analysts alone arrived at, when a deeper pass then ran.
     #: This is the whole measurement: escalation only matters where these differ.
     candidate_action: Action | None = None
+    #: WHERE THE LENSES ACTUALLY LANDED, on every run — not only escalated ones.
+    #:
+    #: `escalation_reasons` records why a run escalated. It cannot record what a
+    #: run that did NOT escalate looked like, and in production almost none do:
+    #: the size and opening rules are off on measured evidence, a hold never
+    #: escalates by design, and every production decision so far has been a
+    #: hold. So the live data says "no escalation" over and over and cannot say
+    #: whether that was right.
+    #:
+    #: These are the fields the analysts already returned and the escalation
+    #: gate already compared. Carrying them costs no extra model call and makes
+    #: "how often did the lenses actually split, and should we have escalated?"
+    #: answerable from production rather than only from the fixture suite.
+    #:
+    #: STRUCTURE ONLY, NEVER THE NOTE. Each view also carries up to 400
+    #: characters of model prose derived from news and social text. That is an
+    #: injection surface, it is the largest thing in the record, and it is not
+    #: what the question needs — a direction and two floats are. The prose stays
+    #: in the thesis, which passes the address backstop before anyone reads it.
+    analyst_views: list[AnalystSignal] = Field(default_factory=list)
     cost: Cost
     models: list[ModelUse] = Field(default_factory=list)
 

--- a/services/brain/tests/test_boundary.py
+++ b/services/brain/tests/test_boundary.py
@@ -226,3 +226,86 @@ def test_brains_epoch_floor_agrees_with_core():
     g = gate_assess(epoch_one)
     assert g.verdict == "refuse"
     assert not g.may_size, "epoch 1 is forensic; nothing may be sized against it"
+
+
+# ── the measurement boundary ────────────────────────────────────────────────
+#
+# A rule that fires almost never in production is indistinguishable, from the
+# data, from a rule that is broken. Escalation is now exactly that: the size and
+# opening rules are off on measured evidence, a hold never escalates by design,
+# and every production decision so far has been a hold. `escalation_reasons`
+# describes only the runs that escalated, so the live record says "no
+# escalation" over and over and cannot say whether that was right.
+
+
+def test_every_run_records_where_the_lenses_landed():
+    """The analysts already answered in fields. Nothing throws that away."""
+    import inspect
+
+    from brain import graph as graph_mod
+
+    src = inspect.getsource(graph_mod.BrainGraph._assemble)
+    assert "analyst_views=" in src, "the decision must carry the lens verdicts"
+    assert "views" in inspect.signature(graph_mod.BrainGraph._assemble).parameters, (
+        "_assemble cannot record what it is not given"
+    )
+    # Both exits — the cheap one that stops at analyst depth and the deep one —
+    # have to pass them. The cheap exit is the common case in production, so a
+    # miss there is a miss everywhere that matters.
+    think = inspect.getsource(graph_mod.BrainGraph._think)
+    assert think.count("views=views") == 2, "both _assemble call sites must pass the views"
+
+
+def test_the_recorded_signal_carries_no_model_prose():
+    """
+    STRUCTURE ONLY. `AnalystView.note` is up to 400 characters derived from news
+    and social text — an injection surface, the largest thing in the record, and
+    not what the question needs. A direction and two floats are.
+    """
+    from brain.schemas import AnalystSignal
+
+    assert "note" not in AnalystSignal.model_fields
+    assert set(AnalystSignal.model_fields) == {
+        "lens",
+        "direction",
+        "confidence",
+        "evidence_strength",
+    }
+    # extra="forbid", so a note cannot be smuggled in by a caller either.
+    with pytest.raises(Exception):
+        AnalystSignal(lens="news", direction="buy", confidence=0.5, evidence_strength=0.5, note="x")
+
+
+def test_a_recorded_signal_is_bounded_on_every_field():
+    from brain.schemas import AnalystSignal
+
+    for bad in (
+        {"confidence": 1.4},
+        {"confidence": -0.1},
+        {"evidence_strength": 2.0},
+        {"direction": "moon"},
+        {"lens": "x" * 41},
+    ):
+        kw = {"lens": "news", "direction": "buy", "confidence": 0.5, "evidence_strength": 0.5}
+        kw.update(bad)
+        with pytest.raises(Exception):
+            AnalystSignal(**kw)
+
+
+def test_the_signal_survives_a_lens_that_said_nothing():
+    """
+    `no-data` is a real answer and the one most worth recording — a run where
+    three lenses had nothing is a run whose hold means something different from
+    a run where three lenses agreed. It must not be dropped for being empty.
+    """
+    from brain.schemas import AnalystSignal
+
+    view = parse_view("news", "the model returned prose instead of json")
+    assert view.direction == "no-data"
+    s = AnalystSignal(
+        lens=view.lens,
+        direction=view.direction,
+        confidence=view.confidence,
+        evidence_strength=view.evidence_strength,
+    )
+    assert s.direction == "no-data" and s.confidence == 0.0

--- a/worker/src/brain-client.ts
+++ b/worker/src/brain-client.ts
@@ -63,6 +63,21 @@ export interface BrainDecision {
   depth_used: string;
   escalation_reasons: string[];
   candidate_action: string | null;
+  /**
+   * Where each lens landed, on every run rather than only escalated ones.
+   *
+   * Structure only — no `note`, no prose. The service drops the model's words
+   * before sending, so nothing here needs the address backstop that `thesis`
+   * needs, and nothing here grows with what a news source decided to write.
+   * Optional because an older Brain build does not send it, and a decision that
+   * arrives without the measurement is still a decision.
+   */
+  analyst_views?: {
+    lens: string;
+    direction: "buy" | "sell" | "hold" | "no-data";
+    confidence: number;
+    evidence_strength: number;
+  }[];
   cost: BrainCost;
   models: { node: string; provider: string; model: string }[];
 }

--- a/worker/src/brain-shadow.ts
+++ b/worker/src/brain-shadow.ts
@@ -342,6 +342,14 @@ async function persist(
       depth_used: d.depth_used,
       escalation_reasons: d.escalation_reasons,
       candidate_action: d.candidate_action,
+      // WHERE THE LENSES LANDED. `escalation_reasons` can only describe a run
+      // that escalated, and in production almost none do — so without this the
+      // tape says "no escalation" every time and cannot say whether that was
+      // right. `?? []` rather than omitted: a decision from a Brain build that
+      // predates the field should read as "not recorded", and an absent key and
+      // an empty list say that equally well while the empty list keeps every
+      // row the same shape for whatever reads them later.
+      analyst_views: d.analyst_views ?? [],
       cost: d.cost,
       models: d.models,
       latency_seconds: result.seconds,


### PR DESCRIPTION
A rule that fires almost never is indistinguishable, **from the data**, from a
rule that is broken — and escalation is now exactly that:

- the size and opening rules are off on measured evidence (#85),
- a hold never escalates by design,
- every production decision so far has been a hold.

`escalation_reasons` can only describe the runs that *escalated*. So the live
tape says "no escalation" over and over, and cannot answer whether that was
right. The fixture suite can; production cannot.

## What changes

The analysts already return their verdict as fields — `direction`,
`confidence`, `evidence_strength` — and `assess_escalation` already compares
them. They were computed and thrown away. Now every `BrainDecision` carries
them, and `brain-shadow` persists them into `signals_json`.

**No extra model call.** The analyst was already being asked; it already
answered in fields.

## Structure only, never the note

Each `AnalystView` also carries up to 400 characters of model prose derived from
news and social text. That is:

- an injection surface, persisted to a database other prompts read,
- the largest thing in the record, ~4× the rest of it,
- not what the question needs — a direction and two floats are.

So `AnalystSignal` has **no free-text field at all**. `lens` is one of our own
names, `direction` is a closed set, both floats are clamped to `[0,1]` by
`parse_view` before they arrive, and `extra="forbid"` means a note cannot be
smuggled in by a caller either. That is what makes it safe to persist verbatim.
The prose stays in `thesis`, which passes the address backstop first.

## Tests

Four new, all free:

- both `_assemble` call sites pass the views — the cheap analyst-depth exit is
  the common case in production, so a miss there is a miss where it matters;
- `AnalystSignal` has no `note` and forbids extras;
- every field is bounded (confidence, evidence_strength, direction, lens length);
- a `no-data` lens still records. A hold where three lenses had nothing means
  something different from a hold where three lenses agreed, and dropping the
  empty ones would erase that distinction.

`pytest` 22/22 · `npm run typecheck` clean · 33 brain worker tests pass.

The field is optional on the TypeScript side: a decision from a Brain build
predating it is still a decision, and reads as "not recorded".

🤖 Generated with [Claude Code](https://claude.com/claude-code)