### PR TITLE
brain: give the analysts something to reason about, and durable memory to do it with

### DIFF
--- a/services/brain/brain/graph.py
+++ b/services/brain/brain/graph.py
@@ -324,7 +324,21 @@ class BrainGraph:
                 dossier += f"\n\nRISK ({stance})\n{r.text}"
 
         if req.memory:
-            dossier += "\n\nWHAT THIS AGENT THOUGHT BEFORE\n" + "\n".join(f"- {m}" for m in req.memory[:6])
+            # FENCED, like every other block that is not ours.
+            #
+            # Memory reads as the agent's own past words, which makes it feel
+            # like trusted context. It is not: a remembered thesis is model
+            # prose that was itself written while reading scraped news and
+            # social text, so anything that steered the agent last week arrives
+            # here wearing its own voice. That is the "permanent foothold" case
+            # — an injection that survives into every later prompt because it
+            # was written down — and it is worse than the live one, not better.
+            #
+            # It was unfenced while `memory` was always empty. It is being
+            # populated now, which is exactly when the gap stops being dormant.
+            dossier += "\n\nWHAT THIS AGENT THOUGHT BEFORE\n" + _fence(
+                "own-memory", "\n".join(f"- {m}" for m in req.memory[:6])
+            )
 
         data = await self._decide(req, budget, gate, dossier)
         return self._assemble(

--- a/services/brain/tests/test_boundary.py
+++ b/services/brain/tests/test_boundary.py
@@ -309,3 +309,26 @@ def test_the_signal_survives_a_lens_that_said_nothing():
         evidence_strength=view.evidence_strength,
     )
     assert s.direction == "no-data" and s.confidence == 0.0
+
+
+def test_memory_is_fenced_like_everything_else_we_did_not_write():
+    """
+    Memory reads as the agent's own past words, which is what makes it feel
+    trusted. It is not: a remembered thesis is model prose written while reading
+    scraped news and social text, so anything that steered the agent last week
+    arrives wearing its own voice. That is the permanent-foothold case — an
+    injection that survives into every later prompt because it was written down.
+
+    It was unfenced for as long as `memory` was always empty. The worker now
+    populates it, which is exactly when the gap stops being dormant.
+    """
+    import inspect
+
+    from brain import graph as graph_mod
+
+    src = inspect.getsource(graph_mod.BrainGraph._think)
+    i = src.index("WHAT THIS AGENT THOUGHT BEFORE")
+    # The fence must be applied to the memory block itself, not merely present
+    # somewhere else in the method.
+    assert "_fence(" in src[i : i + 400], "the memory block must be fenced"
+    assert "own-memory" in src[i : i + 400], "and labelled as what it is"

--- a/worker/src/brain-material.test.ts
+++ b/worker/src/brain-material.test.ts
@@ -1,0 +1,183 @@
+/**
+ * WHAT REACHES A PROMPT, AND WHAT MUST NOT.
+ *
+ * Two different failures live in this module and they pull in opposite
+ * directions. Send too little and Brain answers "no data" forever, which is
+ * what production actually did — every early shadow decision was a hold
+ * justified by the absence of any input at all. Send too much, or send the
+ * wrong thing, and an owner's counterparty address ends up in a model's context
+ * and then in `signals_json`, where the next prompt reads it back.
+ *
+ * The resolution is that this module RENDERS and never SOURCES: everything it
+ * is given has already been through `publishableThesis`, and these tests pin
+ * that it does not reach around that.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import { memoryLines, sentimentLine, technicalLine } from "./brain-material";
+import { publishableThesis, type PublicThesis } from "./thesis-policy";
+
+const post = (over: Partial<PublicThesis> = {}): PublicThesis => ({
+  name: "Vermilion",
+  slug: null,
+  handle: null,
+  head: "buy NVDA 16.66 USDG",
+  action: "buy",
+  symbol: "NVDA",
+  sizeUsdg: 16.66,
+  paper: false,
+  outcome: "landed",
+  outcomeText: "landed",
+  shadow: false,
+  reason: "Depth cleared the floor on the third pass.",
+  said: 1,
+  at: 1_800_000_000,
+  firstAt: 1_800_000_000,
+  ...over,
+});
+
+describe("the technical lens says what the worker knows", () => {
+  const f = {
+    symbol: "TSLA",
+    priceUsd: "412.5000",
+    priceSource: "pool",
+    priceStale: false,
+    valueUsdg: 5_000_000,
+    equityUsdg: 20_000_000,
+    cashUsdg: 3_000_000,
+    positionCount: 2,
+  };
+
+  it("carries price, provenance, concentration and cash", () => {
+    const s = technicalLine(f);
+    assert.match(s, /TSLA marked at 412\.5000 USD from pool/);
+    assert.match(s, /5\.00 USDG of TSLA/);
+    assert.match(s, /25\.0% of 20\.00 USDG total equity/);
+    assert.match(s, /2 positions/);
+    assert.match(s, /Uncommitted cash is 3\.00 USDG/);
+  });
+
+  it("says STALE in words rather than leaving it to be inferred", () => {
+    // A model told a price is stale and left to guess how stale assumes it is
+    // usable. The first production run discounted a stale price the moment it
+    // was told plainly, which is the whole argument for saying it.
+    assert.match(technicalLine({ ...f, priceStale: true }), /STALE, treat this price as unreliable/);
+    assert.ok(!/STALE/.test(technicalLine(f)), "and never says it when the price is fresh");
+  });
+
+  it("states concentration without scoring it", () => {
+    // "84% of the book is in one name" is a fact the worker has. "That is too
+    // concentrated" is a judgement the risk side exists to make, and an input
+    // that arrives pre-judged is a signal that has started deciding.
+    const hot = technicalLine({ ...f, valueUsdg: 19_000_000 });
+    assert.match(hot, /95\.0%/);
+    for (const verdict of [/too concentrated/i, /risky/i, /should/i, /recommend/i, /overweight/i]) {
+      assert.ok(!verdict.test(hot), `the technical line must not render a verdict: ${verdict}`);
+    }
+  });
+
+  it("survives an empty book without dividing by zero", () => {
+    const s = technicalLine({ ...f, valueUsdg: 0, equityUsdg: 0, positionCount: 1 });
+    assert.match(s, /0\.0% of 0\.00 USDG/);
+    assert.ok(!/NaN|Infinity/.test(s));
+  });
+});
+
+describe("the sentiment lens is other Merrymen, or nothing", () => {
+  it("is absent rather than empty when nobody spoke", () => {
+    // An empty section reads as "we looked and there was nothing to find". The
+    // truth is that nobody said anything, and Brain's own NO DATA AVAILABLE
+    // says that better than a heading with no rows under it.
+    assert.equal(sentimentLine([], "TSLA"), null);
+  });
+
+  it("puts views about the instrument under consideration first", () => {
+    const s = sentimentLine([post({ name: "A", symbol: "PEPE" }), post({ name: "B", symbol: "TSLA" })], "TSLA")!;
+    assert.ok(s.indexOf("B:") < s.indexOf("A:"), "the on-name view leads");
+    assert.match(s, /\(1 about TSLA\)/);
+  });
+
+  it("never reports a peer's shadow thesis as a trade", () => {
+    // The conditional lives in `head`, so it travels into another agent's
+    // prompt for free — which is the reason it was put there rather than in a
+    // badge. A peer that only thought about buying must not be reported to
+    // Brain as one that bought.
+    const s = sentimentLine(
+      [post({ shadow: true, outcome: "shadow", head: "would buy TSLA 5.00 USDG", outcomeText: "a stated intention — not traded" })],
+      "TSLA",
+    )!;
+    assert.match(s, /would buy TSLA 5\.00 USDG/);
+    assert.match(s, /not traded/);
+  });
+
+  it("is bounded, because every analyst call is billed for it", () => {
+    const many = Array.from({ length: 50 }, (_, i) =>
+      post({ name: `Agent${i}`, reason: "x".repeat(300) }),
+    );
+    assert.ok(sentimentLine(many, "TSLA")!.length <= 1200);
+  });
+});
+
+describe("memory is what this agent could have said in public", () => {
+  it("carries the ending, not just the thesis", () => {
+    // "I said buy and it landed" and "I said buy and the wall refused it" are
+    // different lessons. A thesis remembered without its outcome teaches none.
+    const [line] = memoryLines([post({ at: 1_800_000_000 })], 1_800_000_600);
+    assert.match(line!, /^10m ago: buy NVDA 16\.66 USDG · landed — "Depth cleared/);
+  });
+
+  it("switches to hours once minutes stop being readable", () => {
+    const [line] = memoryLines([post({ at: 1_800_000_000 })], 1_800_000_000 + 5 * 3600);
+    assert.match(line!, /^5h ago:/);
+  });
+
+  it("notes repetition, which is itself the lesson", () => {
+    // An agent that has said the same thing six times is not gathering six
+    // pieces of evidence.
+    const [line] = memoryLines([post({ said: 38 })], 1_800_000_000);
+    assert.match(line!, /\(said 38×\)/);
+  });
+
+  it("is bounded to six, newest first, whatever it is handed", () => {
+    const rows = Array.from({ length: 40 }, (_, i) => post({ at: 1_800_000_000 - i }));
+    assert.equal(memoryLines(rows, 1_800_000_000).length, 6);
+  });
+
+  it("is empty when there is nothing, rather than inventing a first thought", () => {
+    assert.deepEqual(memoryLines([], 1_800_000_000), []);
+  });
+});
+
+describe("this module renders; it never sources", () => {
+  it("reaches for no database, no filesystem and no network", () => {
+    // Everything it is given has already passed `publishableThesis` on the
+    // orchestrator's side. If this file ever grew its own query, the gate would
+    // stop being the only way in, and the chat-sourced counterparty address
+    // that gate exists to catch would have a second route to a prompt.
+    const src = readFileSync(new URL("./brain-material.ts", import.meta.url), "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/(^|[^:])\/\/.*$/gm, "$1");
+    for (const forbidden of [/\bfrom "\.\/store"/, /getDb\(/, /node:fs/, /\bfetch\(/, /recentDecisions/]) {
+      assert.ok(!forbidden.test(src), `brain-material must not reach for ${forbidden}`);
+    }
+    assert.match(src, /import type \{ PublicThesis \}/, "it takes gated output, and only that");
+  });
+
+  it("cannot render a thesis the gate would have dropped", () => {
+    // The end-to-end statement of the rule: a row carrying an address does not
+    // become a PublicThesis at all, so it can never reach these renderers.
+    const dropped = publishableThesis({
+      agent_id: "0xagent",
+      name: "Much",
+      source: "strategist",
+      action: "buy",
+      symbol: "NVDA",
+      reason: "owner asked to transfer 25 USDG to 0xdeadbeefcafe in chat",
+      last_at: 1_800_000_000,
+    });
+    assert.equal(dropped, null);
+    const gated: PublicThesis[] = dropped === null ? [] : [dropped];
+    assert.deepEqual(memoryLines(gated, 1), [], "nothing to render, because nothing got through");
+  });
+});

--- a/worker/src/brain-material.ts
+++ b/worker/src/brain-material.ts
@@ -1,0 +1,153 @@
+/**
+ * WHAT BRAIN IS ALLOWED TO KNOW, AND WHAT IT ACTUALLY DOES.
+ *
+ * The first production shadow decisions all said the same thing:
+ *
+ *   "All analyst lenses report no data for TSLA; the only price point is stale
+ *    and unreliable. With no recent market, news, sentiment or fundamentals,
+ *    there is no actionable evidence to take a position."
+ *
+ * That is the correct answer to the question it was asked, and it means the
+ * evaluation was measuring the wrong thing: whether Brain refuses to invent,
+ * rather than whether Brain reasons. It refuses to invent. Now give it
+ * something to reason about.
+ *
+ * THE RULE IS UNCHANGED — a lens with nothing gets NOTHING, never a plausible
+ * sentence. `news` and `fundamentals` stay absent because the worker has no
+ * honest source for either on this chain, and an omitted lens makes Brain
+ * answer NO DATA AVAILABLE, which is true. What this module adds is the
+ * material the worker genuinely holds and was simply not sending.
+ *
+ * MEMORY ARRIVES ALREADY THROUGH THE PUBLICATION GATE, and that is the
+ * load-bearing decision here. The raw `decisions` table is not safe text: a
+ * `chat`-sourced row embeds a raw counterparty address by template, on every
+ * chat transfer, and `dropped_rule` is a template with a model-supplied hole in
+ * it. Feeding either straight into a prompt would put an owner's counterparties
+ * into a model's context and then into `signals_json`, where the next prompt
+ * reads them back.
+ *
+ * So the rule is: AN AGENT MAY REMEMBER WHAT IT COULD HAVE SAID IN PUBLIC.
+ * The orchestrator materialises exactly that — the same `publishableThesis`
+ * output the feed publishes, with its source allowlist, its 220-character cap
+ * on model prose, its address backstop and its fail-closed default — into the
+ * child's peer file. This module renders it and adds nothing, so memory cannot
+ * drift from publication, and a new decision source stays unreadable by Brain
+ * until somebody classifies it. That is the correct default for a field which,
+ * if it is ever wrong, is wrong permanently.
+ *
+ * Everything here is bounded on length as well as on source, because this text
+ * is billed by the token on every analyst call, and prompt size is the real
+ * cost driver — not call count.
+ */
+
+import type { PublicThesis } from "./thesis-policy";
+
+/** How many past decisions Brain is reminded of. */
+const MEMORY_LINES = 6;
+/** How many peer voices reach the sentiment lens. */
+const PEER_LINES = 5;
+/** Hard ceiling per lens. A dossier is billed on every analyst call. */
+const LENS_MAX = 1200;
+
+export interface FocusView {
+  symbol: string;
+  priceUsd: string;
+  priceSource: string;
+  priceStale: boolean;
+  /** Micro-USDG. */
+  valueUsdg: number;
+  equityUsdg: number;
+  cashUsdg: number;
+  /** How many names the book holds, this one included. */
+  positionCount: number;
+}
+
+const usdg = (micro: number): string => (micro / 1e6).toFixed(2);
+
+/**
+ * The technical lens, from what the worker can see without asking anybody.
+ *
+ * Staleness is stated rather than hidden. A model told the price is stale and
+ * left to guess how stale will assume the number is usable; told plainly, it
+ * discounts it — and the first production run proves it does, because that is
+ * exactly what it did with the one line it had.
+ */
+export function technicalLine(f: FocusView): string {
+  const share = f.equityUsdg > 0 ? (f.valueUsdg / f.equityUsdg) * 100 : 0;
+  const parts = [
+    `${f.symbol} marked at ${f.priceUsd} USD from ${f.priceSource}` +
+      (f.priceStale ? " — STALE, treat this price as unreliable" : "") +
+      ".",
+    `The book holds ${usdg(f.valueUsdg)} USDG of ${f.symbol}, which is ` +
+      `${share.toFixed(1)}% of ${usdg(f.equityUsdg)} USDG total equity, ` +
+      `across ${f.positionCount} position${f.positionCount === 1 ? "" : "s"}.`,
+    `Uncommitted cash is ${usdg(f.cashUsdg)} USDG.`,
+  ];
+  // WHY CONCENTRATION IS STATED AND NOT SCORED. "84% of the book is in one
+  // name" is a fact the worker knows; "that is too concentrated" is a judgement
+  // the risk side is there to make. Handing the model a verdict dressed as an
+  // input is how a signal starts deciding.
+  return parts.join(" ").slice(0, LENS_MAX);
+}
+
+/**
+ * What other Merrymen have published, as the sentiment lens.
+ *
+ * These are real opinions from real agents on the same chain, and they are the
+ * only genuine sentiment source this fleet has. They arrive having already
+ * passed `publishableThesis` on the orchestrator's side, so they carry no
+ * address and no unclassified source — and Brain fences them as untrusted
+ * before any model sees them, which is what makes it safe to pass another
+ * model's words into a prompt at all.
+ *
+ * SAME NAME FIRST, then the rest. A peer talking about the instrument under
+ * consideration is evidence; a peer talking about something else is context,
+ * and context that crowds out evidence is just cost.
+ */
+export function sentimentLine(peers: readonly PublicThesis[], symbol: string): string | null {
+  if (!peers.length) return null;
+  const want = symbol.trim().toUpperCase();
+  const onName = peers.filter((p) => (p.symbol ?? "").toUpperCase() === want);
+  const rest = peers.filter((p) => (p.symbol ?? "").toUpperCase() !== want);
+  const chosen = [...onName, ...rest].slice(0, PEER_LINES);
+  if (!chosen.length) return null;
+
+  const lines = chosen.map((p) => {
+    // `head` already carries the conditional for a shadow post — "would buy
+    // TSLA 5.00 USDG" — so a peer that only thought about a trade is never
+    // reported to Brain as one that made it.
+    const what = [p.head, p.outcomeText].filter(Boolean).join(" · ");
+    const why = (p.reason ?? "").trim();
+    return `${p.name}: ${what}${why ? ` — "${why}"` : ""}`;
+  });
+
+  return (
+    `Other Merrymen on this chain have published these views (${onName.length} about ${want}):\n` +
+    lines.join("\n")
+  ).slice(0, LENS_MAX);
+}
+
+/**
+ * What this agent thought before, and what came of it.
+ *
+ * THROUGH THE PUBLICATION GATE — see the module comment. The outcome is the
+ * half that makes memory worth having: "I said buy and it landed" and "I said
+ * buy and the wall refused it" are different lessons, and a thesis remembered
+ * without its ending teaches nothing.
+ */
+export function memoryLines(
+  own: readonly PublicThesis[],
+  now: number,
+): string[] {
+  const out: string[] = [];
+  for (const t of own) {
+    const age = Math.max(0, Math.floor((now - (t.at || now)) / 60));
+    const when = age < 90 ? `${age}m ago` : `${Math.floor(age / 60)}h ago`;
+    const said = t.said > 1 ? ` (said ${t.said}×)` : "";
+    out.push(
+      `${when}${said}: ${t.head || "a view"} · ${t.outcomeText}${t.reason ? ` — "${t.reason}"` : ""}`,
+    );
+    if (out.length >= MEMORY_LINES) break;
+  }
+  return out;
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -92,6 +92,7 @@ import { grantHasDeadRateLimit } from "./session-account";
 import { claimCommandFile, writeCommandResult } from "./command-files";
 import { bookGaps, composeEquityUsdg } from "./equity";
 import { runShadow, type ShadowInputs } from "./brain-shadow";
+import { memoryLines, sentimentLine, technicalLine } from "./brain-material";
 import { shadowBrainEnabledFor } from "./brain-enabled";
 import { priceGas, wethPriceToken } from "./gas-price";
 import { createPaperOrderExecutor, type OrderExecutor } from "./executor-order";
@@ -5264,6 +5265,14 @@ async function main() {
         // about a whole book at once produces a paragraph, not a decision.
         const focus = [...positions].sort((a, b) => Number(b.valueUsdg - a.valueUsdg))[0];
         if (focus) {
+          // The orchestrator materialises both of these from shared Postgres,
+          // through the publication gate, into a file this child can read.
+          // `readPeers` never throws: absent, unreadable and malformed all mean
+          // "nothing this window", which is a correct state and not a fault.
+          const wire = readPeers(merrymenHome());
+          const brainPeers = wire.theses;
+          const brainOwn = wire.own ?? [];
+          const sentiment = sentimentLine(brainPeers, focus.symbol);
           const inputs: ShadowInputs = {
             agentId,
             now: Math.floor(Date.now() / 1000),
@@ -5314,15 +5323,35 @@ async function main() {
               // no data is OMITTED rather than filled with a plausible sentence
               // — Brain answers NO DATA AVAILABLE for what is missing, which is
               // the truthful input and the one the fixtures were built against.
+              //
+              // `news` and `fundamentals` are absent for exactly that reason:
+              // this chain has no honest source for either yet. Every early
+              // production decision said so in its own words, and the answer to
+              // that is a real source, not a filler sentence.
               signals: {
-                technical:
-                  `Price ${(Number(focus.price8) / 1e8).toFixed(4)} USD from ${focus.priceSource}` +
-                  `${focus.priceStale ? " (STALE)" : ""}. Position value ` +
-                  `${usdgNum(focus.valueUsdg).toFixed(6)} USDG of a ${usdgNum(equityUsdg).toFixed(6)} USDG book.`,
+                technical: technicalLine({
+                  symbol: focus.symbol,
+                  priceUsd: (Number(focus.price8) / 1e8).toFixed(4),
+                  priceSource: focus.priceSource,
+                  priceStale: focus.priceStale,
+                  valueUsdg: Number(focus.valueUsdg),
+                  equityUsdg: Number(equityUsdg),
+                  cashUsdg: Number(balances.cashUsdg),
+                  positionCount: positions.length,
+                }),
+                // The only genuine sentiment this fleet has: what other
+                // Merrymen actually published. OMITTED ENTIRELY when nobody
+                // said anything — an empty section reads as "we looked and
+                // there was nothing", and the truth is that nobody spoke.
+                ...(sentiment ? { sentiment } : {}),
               },
             },
             persona: cfg.agentName ? `You are ${cfg.agentName}, a Merryman.` : "",
-            memory: [],
+            // ITS OWN PUBLISHED THESES, and what came of them. Read from the
+            // peer file rather than the child's `decisions` table because that
+            // table is wiped by every redeploy — an agent reading memory from
+            // it would permanently be having its first thought.
+            memory: memoryLines(brainOwn, Math.floor(Date.now() / 1000)),
           };
           const outcome = await runShadow(
             { url: cfg.brainUrl, token: cfg.brainToken, timeoutMs: 90_000 },

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -58,7 +58,8 @@ import { scanFleetCapital } from "./chain-capital";
 import { getFollowStore, MAX_FOLLOWS } from "./follow-store";
 import { MIRROR_STATE_DDL, mirrorTenant, openChildLedger } from "./ledger-mirror";
 import { writePeersForChild } from "./peer-files";
-import { peerThesesForSlugs } from "./peer-theses";
+import { peerThesesForSlugs, readPeerTheses } from "./peer-theses";
+import type { PublicThesis } from "./thesis-policy";
 import { applyLedgerSchema } from "./store";
 import { drainCommandResults, writeCommand } from "./command-files";
 
@@ -1019,8 +1020,34 @@ async function writePeersFor(tenant: `0x${string}`, shared: Db): Promise<void> {
       shared,
       edges.slice(0, MAX_FOLLOWS).map((e) => e.target),
     );
-    writePeersForChild(childHome(tenant), { at: Math.floor(Date.now() / 1000), theses });
-    if (theses.length > 0) log(`wire: ${tenant} +${theses.length} peer thesis/theses from ${edges.length} follow(s)`);
+
+    // THE AGENT'S OWN THESES, from the durable copy.
+    //
+    // The child holds a `decisions` table and could read this itself. It must
+    // not: that sqlite is wiped by every redeploy, so an agent reading its own
+    // memory from it is permanently having its first thought. Shared Postgres
+    // is the durable copy and the child cannot reach it — `CHILD_SECRET_STRIP`
+    // removes `DATABASE_URL` on purpose — so it is materialised here, through
+    // the same gate, the same file and the same atomic write as the peers.
+    //
+    // `readPeerTheses` is reused rather than re-queried: memory and publication
+    // must not be able to disagree about what this agent said.
+    let own: PublicThesis[] = [];
+    try {
+      const id = await getIdentityStore().get(tenant);
+      if (id?.accounts.length) own = await readPeerTheses(shared, id.accounts);
+    } catch {
+      // An agent with no identity yet has no published theses to remember, and
+      // a peer file is still worth writing without them.
+    }
+
+    writePeersForChild(childHome(tenant), { at: Math.floor(Date.now() / 1000), theses, own });
+    if (theses.length > 0 || own.length > 0) {
+      log(
+        `wire: ${tenant} +${theses.length} peer thesis/theses from ${edges.length} follow(s), ` +
+          `+${own.length} of its own`,
+      );
+    }
   } catch (e) {
     // Never fatal. The wire is additional evidence; a child with a stale or
     // absent peer file trades exactly as it did before the feature existed.

--- a/worker/src/peer-files.test.ts
+++ b/worker/src/peer-files.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
@@ -62,13 +62,13 @@ describe("the peer file", () => {
   it("NEVER THROWS — absent, malformed and wrong-shaped all read as nothing", async () => {
     // It is read on the tick, so a throw here stops an agent trading over a
     // feature that is meant to be additional evidence.
-    assert.deepEqual(readPeers(home), { at: 0, theses: [] });
+    assert.deepEqual(readPeers(home), { at: 0, theses: [], own: [] });
     await writeFile(peerFilePath(home), "{ not json", "utf8");
-    assert.deepEqual(readPeers(home), { at: 0, theses: [] });
+    assert.deepEqual(readPeers(home), { at: 0, theses: [], own: [] });
     await writeFile(peerFilePath(home), JSON.stringify({ at: 1 }), "utf8");
-    assert.deepEqual(readPeers(home), { at: 0, theses: [] });
+    assert.deepEqual(readPeers(home), { at: 0, theses: [], own: [] });
     await writeFile(peerFilePath(home), JSON.stringify([1, 2, 3]), "utf8");
-    assert.deepEqual(readPeers(home), { at: 0, theses: [] });
+    assert.deepEqual(readPeers(home), { at: 0, theses: [], own: [] });
   });
 
   it("AN EMPTY FILE AND NO FILE ARE DIFFERENT THINGS on disk", async () => {
@@ -195,5 +195,31 @@ describe("the tool the model actually gets", () => {
     assert.match(DESK, /weakest evidence\s+here — weaker than a curve mark/);
     assert.match(DESK, /correlation between models given similar data, not\s+confirmation/);
     assert.match(DESK, /Never size off\s+one/);
+  });
+});
+
+describe("the agent's own theses ride the same wire", () => {
+  it("round-trips `own` beside the peers", async () => {
+    const own = [thesis({ name: "Self", head: "hold TSLA 0.00 USDG", outcome: "shadow", shadow: true })];
+    writePeersForChild(home, { at: 5, theses: [thesis()], own });
+    const back = readPeers(home);
+    assert.equal(back.own?.length, 1);
+    assert.equal(back.own![0]!.head, "hold TSLA 0.00 USDG");
+    assert.equal(back.theses.length, 1, "and does not disturb the peers");
+  });
+
+  it("reads a file written before `own` existed, rather than failing it", () => {
+    // A peer file from an older orchestrator is VALID and its peers are still
+    // worth having. Failing the whole file over a missing optional would take
+    // the wire down on the very deploy that added the field.
+    writeFileSync(peerFilePath(home), JSON.stringify({ at: 5, theses: [thesis()] }), "utf8");
+    const back = readPeers(home);
+    assert.equal(back.theses.length, 1);
+    assert.deepEqual(back.own, [], "absent reads as nothing remembered, not as a fault");
+  });
+
+  it("treats a malformed `own` as nothing remembered", () => {
+    writeFileSync(peerFilePath(home), JSON.stringify({ at: 5, theses: [], own: "everything" }), "utf8");
+    assert.deepEqual(readPeers(home).own, []);
   });
 });

--- a/worker/src/peer-files.ts
+++ b/worker/src/peer-files.ts
@@ -40,6 +40,22 @@ export interface PeerFile {
   at: number;
   /** Published theses from the agents this owner wired in, newest first. */
   theses: PublicThesis[];
+  /**
+   * THIS AGENT'S OWN PUBLISHED THESES, newest first — its durable memory.
+   *
+   * The child already has a `decisions` table and could read its own rows from
+   * it. It must not: the child's sqlite is WIPED BY EVERY REDEPLOY, so memory
+   * read from there resets to nothing several times a day and an agent would
+   * permanently be having its first thought. The durable copy lives in shared
+   * Postgres, which the child cannot reach by design (`CHILD_SECRET_STRIP`
+   * removes `DATABASE_URL`), so the orchestrator materialises it here — the
+   * same transport, the same atomic write, and the same publication gate the
+   * peer theses above already travel through.
+   *
+   * Optional because a peer file written by an older orchestrator does not have
+   * it, and an agent with no remembered theses is a correct state, not a fault.
+   */
+  own?: PublicThesis[];
 }
 
 export function peerFilePath(home: string): string {
@@ -71,13 +87,17 @@ export function writePeersForChild(home: string, file: PeerFile): void {
  * trade in every direction.
  */
 export function readPeers(home: string): PeerFile {
-  const empty: PeerFile = { at: 0, theses: [] };
+  const empty: PeerFile = { at: 0, theses: [], own: [] };
   try {
     const raw = JSON.parse(readFileSync(peerFilePath(home), "utf8")) as unknown;
     if (!raw || typeof raw !== "object") return empty;
     const f = raw as Partial<PeerFile>;
     if (!Array.isArray(f.theses)) return empty;
-    return { at: Number(f.at) || 0, theses: f.theses };
+    // `own` is checked separately rather than folded into the guard above: a
+    // file from an orchestrator that predates the field is VALID and its peers
+    // are still worth reading. Failing the whole file over a missing optional
+    // would silently take the wire down on the deploy that added it.
+    return { at: Number(f.at) || 0, theses: f.theses, own: Array.isArray(f.own) ? f.own : [] };
   } catch {
     return empty;
   }


### PR DESCRIPTION
Every production shadow decision so far has said the same thing:

> *"All analyst lenses report **no data** for TSLA; the only price point is
> stale and unreliable. With no recent market, news, sentiment or fundamentals,
> there is no actionable evidence to take a position."*

That is the correct answer to the question it was asked — and it means the
evaluation was measuring whether Brain refuses to invent, not whether Brain
reasons. It refuses to invent, consistently, on every run. That is a floor, not
a result.

The worker was sending **one** signal — a single price sentence, usually marked
stale — and `memory: []`. It was holding considerably more.

## What the lenses now get

| Lens | Material |
|---|---|
| `technical` | price with provenance and staleness **in words**, position size as a share of equity, position count, uncommitted cash |
| `sentiment` | what other Merrymen actually published — views on the instrument under consideration first |
| `news`, `fundamentals` | **still absent** |

`news` and `fundamentals` stay absent on purpose. This chain has no honest
source for either; an omitted lens makes Brain answer `NO DATA AVAILABLE`, and
that is true. The answer to a missing source is a source, not a filler
sentence.

Concentration is **stated, never scored**. "84% of the book is in one name" is a
fact the worker has; "that is too concentrated" is a judgement the risk side
exists to make. An input that arrives pre-judged is a signal that has started
deciding — there is a test for it.

## Memory is durable, and deliberately not read from the child

The child holds a `decisions` table and could read its own rows. It must not:
**that sqlite is wiped by every redeploy**, so an agent reading memory from it
is permanently having its first thought. The durable copy is in shared
Postgres, which the child cannot reach by design (`CHILD_SECRET_STRIP`), so the
orchestrator materialises the agent's own published theses into the peer file
it already writes — same transport, same atomic write, same gate. `readPeerTheses`
is reused rather than re-queried, so memory and publication cannot disagree
about what this agent said.

## Two security properties

**The gate is the point.** Raw `decisions.reason` is not safe text: a
`chat`-sourced row embeds a counterparty address by template, and `dropped_rule`
is a template with a model-supplied hole in it. Feeding either into a prompt
puts an owner's counterparties into a model's context and then into
`signals_json`, where the next prompt reads them back. So: **an agent may
remember what it could have said in public.** `publishableThesis` already
decides that, and a new decision source stays unreadable by Brain until
somebody classifies it.

**Memory is now fenced.** It reads as the agent's own past words, which is what
makes it feel trusted. It is model prose written while reading scraped news and
social text, so whatever steered the agent last week arrives wearing its own
voice — the permanent-foothold case, worse than the live one rather than
better. It was unfenced for as long as `memory` was always empty, which is
exactly when a dormant gap stops being dormant.

## Verification

`npm run typecheck` clean · **2246/2246** TS tests · **23/23** pytest ·
15 new tests in `brain-material.test.ts` (no verdict in the technical line,
absent-vs-empty sentiment, a peer's shadow thesis never reported as a trade,
memory bounded and outcome-carrying, and that this module reaches for no
database, filesystem or network), 3 new peer-file round-trip tests including a
file written before `own` existed, and a pytest pinning the memory fence.

Execution stays disconnected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)