### PR TITLE
accounting: a read-only gas audit, because the average is the bug

### DIFF
--- a/worker/src/gas-audit.test.ts
+++ b/worker/src/gas-audit.test.ts
@@ -1,0 +1,211 @@
+/**
+ * THE AVERAGE IS THE BUG.
+ *
+ * The canary's four landed operations cost 6.969946 USDG of gas between them.
+ * Divided evenly that is 1.742 USDG a trade, on trades sized ~1.67 — a number
+ * which, handed to a model deciding whether the next trade is worth making,
+ * says "never trade again". If most of that total was spent once, deploying the
+ * account, then the honest marginal cost is a fraction of it and the answer
+ * flips.
+ *
+ * So these tests are about refusing to average: separating what was paid once
+ * from what will be paid again, refusing to guess when there is nothing to
+ * compare against, and never quietly dropping a cost that could not be valued.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import { decomposeGas, gasAuditLines, type GasOp } from "./gas-audit";
+
+const op = (over: Partial<GasOp> = {}): GasOp => ({
+  id: 1,
+  kind: "swap",
+  target: "TSLA",
+  amountUsdg: 1.6665,
+  status: "landed",
+  userOpHash: "0xaaaa000000000000000000000000000000000000000000000000000000000001",
+  txHash: "0xbbbb000000000000000000000000000000000000000000000000000000000001",
+  gasWei: "1000000000000000",
+  sponsoredGasWei: null,
+  gasUsdg: 0.05,
+  epoch: 1,
+  createdAt: 1_788_000_000,
+  ...over,
+});
+
+/** The shape the canary is expected to have: one expensive op, then three cheap. */
+const deployedThenTraded = (): GasOp[] => [
+  op({ id: 1, gasUsdg: 6.8, createdAt: 1_788_000_000 }),
+  op({ id: 2, gasUsdg: 0.06, createdAt: 1_788_000_100 }),
+  op({ id: 3, gasUsdg: 0.05, createdAt: 1_788_000_200 }),
+  op({ id: 4, gasUsdg: 0.059946, createdAt: 1_788_000_300 }),
+];
+
+describe("one-time cost is not marginal cost", () => {
+  it("does not let a deployment-inflated first op set the price of the next trade", () => {
+    const d = decomposeGas("0xacct", 1, deployedThenTraded());
+    assert.equal(d.totalLandedGasUsdg.toFixed(6), "6.969946");
+    // The naive answer, and the one this module exists to refuse.
+    assert.equal((d.totalLandedGasUsdg / 4).toFixed(3), "1.742");
+    // The honest one.
+    assert.equal(d.marginalGasUsdg, 0.059946);
+    assert.equal(d.setupPremiumUsdg!.toFixed(6), "6.740054");
+  });
+
+  it("uses the median rather than the mean, so one outlier cannot set the rate", () => {
+    // A single expensive later op — a congested block, a failed retry — must not
+    // drag the expectation for every future trade with it.
+    const d = decomposeGas("0xacct", 1, [
+      op({ id: 1, gasUsdg: 6.8 }),
+      op({ id: 2, gasUsdg: 0.05, createdAt: 1_788_000_100 }),
+      op({ id: 3, gasUsdg: 0.05, createdAt: 1_788_000_200 }),
+      op({ id: 4, gasUsdg: 4.0, createdAt: 1_788_000_300 }),
+    ]);
+    assert.equal(d.marginalGasUsdg, 0.05, "median, not the 1.37 mean");
+    assert.equal(d.steadyMeanUsdg!.toFixed(4), "1.3667", "the mean is still reported, just not used");
+    assert.equal(d.steadyMaxUsdg, 4.0, "and the worst case is visible");
+  });
+
+  it("refuses to call anything a setup premium when there is nothing to compare against", () => {
+    // One landed op tells you nothing about which part of it was one-time.
+    // Attributing all of it to setup would be a guess wearing a decomposition's
+    // clothes, and the honest answer is that the question is unanswerable yet.
+    const d = decomposeGas("0xacct", 1, [op({ gasUsdg: 6.8 })]);
+    assert.equal(d.setupPremiumUsdg, null);
+    assert.equal(d.marginalGasUsdg, null);
+    assert.match(gasAuditLines(d).join("\n"), /not derivable — no later op to compare against/);
+  });
+
+  it("reports no premium when the first op was not the expensive one", () => {
+    const d = decomposeGas("0xacct", 1, [
+      op({ id: 1, gasUsdg: 0.05 }),
+      op({ id: 2, gasUsdg: 0.06, createdAt: 1_788_000_100 }),
+    ]);
+    assert.equal(d.setupPremiumUsdg, null, "a first op below the steady rate has no premium to report");
+  });
+
+  it("says the deployment claim is unproven until somebody checks the chain", () => {
+    // "The first op cost more" is arithmetic. "Because it deployed the account"
+    // is a claim about the EntryPoint's AccountDeployed event, and this module
+    // has not looked.
+    const d = decomposeGas("0xacct", 1, deployedThenTraded());
+    assert.equal(d.deploymentConfirmed, null);
+    const text = gasAuditLines(d).join("\n");
+    assert.match(text, /deployment NOT yet confirmed on-chain/);
+    assert.ok(!/AccountDeployed confirmed/.test(text));
+  });
+});
+
+describe("what counts as the owner's cost", () => {
+  it("excludes sponsored gas, because somebody else paid it", () => {
+    // `gas_wei` means "what this owner spent" and `sponsored_gas_wei` means
+    // "what somebody else did" — the store keeps two columns precisely so this
+    // distinction survives into a P&L.
+    const d = decomposeGas("0xacct", 1, [
+      op({ id: 1, gasUsdg: 0.05 }),
+      op({ id: 2, gasUsdg: 9.99, sponsoredGasWei: "5000000000000000", createdAt: 1_788_000_100 }),
+    ]);
+    assert.equal(d.totalLandedGasUsdg, 0.05);
+    assert.equal(d.sponsored.length, 1);
+    assert.match(gasAuditLines(d).join("\n"), /SPONSORED .* somebody else paid/);
+  });
+
+  it("names an unpriced op rather than treating it as free", () => {
+    // A gas figure that could not be valued is unknown, and unknown is not
+    // zero. A total that silently drops it understates the real cost, which is
+    // the direction that flatters the product.
+    const d = decomposeGas("0xacct", 1, [
+      op({ id: 1, gasUsdg: 0.05 }),
+      op({ id: 2, gasUsdg: null, createdAt: 1_788_000_100 }),
+    ]);
+    assert.equal(d.unpriced.length, 1);
+    assert.equal(d.totalLandedGasUsdg, 0.05);
+    assert.match(gasAuditLines(d).join("\n"), /UNPRICED .* cost unknown, not zero/);
+  });
+
+  it("surfaces gas burned on reverted ops, which the published figure omits", () => {
+    // The leaderboard sums gas WHERE status='landed'. A reverted op still burned
+    // the owner's ETH, so the published loss understates what was actually
+    // spent — worth knowing before anyone calls the number complete.
+    const d = decomposeGas("0xacct", 1, [
+      op({ id: 1, gasUsdg: 0.05 }),
+      op({ id: 2, status: "reverted", gasUsdg: 0.04, createdAt: 1_788_000_100 }),
+    ]);
+    assert.equal(d.totalLandedGasUsdg, 0.05);
+    assert.equal(d.revertedGasUsdg, 0.04);
+    assert.match(gasAuditLines(d).join("\n"), /reverted gas .* does NOT count/);
+  });
+
+  it("ignores rejected ops entirely — nothing was broadcast, nothing was burned", () => {
+    const d = decomposeGas("0xacct", 1, [op({ id: 1, gasUsdg: 0.05 }), op({ id: 2, status: "rejected", gasUsdg: null })]);
+    assert.equal(d.landed.length, 1);
+    assert.equal(d.reverted.length, 0);
+  });
+});
+
+describe("the gas-to-trade ratio uses trade sizes only", () => {
+  it("does not divide by a vault deposit, which is not a trade", () => {
+    // A vault deposit shuffles money between two pockets inside the same wall.
+    // Its 500 USDG "size" is not a position, and letting it into the denominator
+    // would make gas look negligible by dividing by money nobody traded.
+    const d = decomposeGas("0xacct", 1, [
+      op({ id: 1, gasUsdg: 6.8 }),
+      op({ id: 2, kind: "vault-deposit", amountUsdg: 500, gasUsdg: 0.05, createdAt: 1_788_000_100 }),
+      op({ id: 3, kind: "swap", amountUsdg: 1.6665, gasUsdg: 0.05, createdAt: 1_788_000_200 }),
+    ]);
+    assert.equal(d.typicalTradeUsdg, 1.6665, "the swap, not the 500 USDG shuffle");
+    assert.equal(d.marginalShareOfTradePct!.toFixed(1), "3.0");
+    // But its gas is still counted — it cost real money.
+    assert.equal(d.totalLandedGasUsdg.toFixed(2), "6.90");
+  });
+
+  it("says so rather than inventing a ratio when nothing trade-sized landed", () => {
+    const d = decomposeGas("0xacct", 1, [
+      op({ id: 1, kind: "vault-deposit", amountUsdg: 500, gasUsdg: 0.05 }),
+      op({ id: 2, kind: "vault-deposit", amountUsdg: 500, gasUsdg: 0.05, createdAt: 1_788_000_100 }),
+    ]);
+    assert.equal(d.marginalShareOfTradePct, null);
+    assert.match(gasAuditLines(d).join("\n"), /no trade-sized op to measure against/);
+  });
+
+  it("breaks the total down by kind, so a costly operation type is visible", () => {
+    const d = decomposeGas("0xacct", 1, [
+      op({ id: 1, kind: "swap", gasUsdg: 0.05 }),
+      op({ id: 2, kind: "vault-deposit", amountUsdg: 500, gasUsdg: 0.30, createdAt: 1_788_000_100 }),
+      op({ id: 3, kind: "swap", gasUsdg: 0.05, createdAt: 1_788_000_200 }),
+    ]);
+    assert.equal(d.byKind["swap"]!.ops, 2);
+    assert.equal(d.byKind["vault-deposit"]!.gasUsdg, 0.30);
+  });
+});
+
+describe("ordering and purity", () => {
+  it("takes the caller's order as given — first means first", () => {
+    // The runner sorts ascending by created_at. If it ever sorted the other way
+    // the setup cost would be attributed to the most recent trade, which is the
+    // one number a marginal-cost estimate must not be built from.
+    const d = decomposeGas("0xacct", 1, deployedThenTraded());
+    assert.equal(d.first!.id, 1);
+    assert.equal(d.subsequent.map((o) => o.id).join(","), "2,3,4");
+  });
+
+  it("reads no database, no clock and no environment", () => {
+    // It is handed rows and returns strings. A reporting path that cannot write
+    // cannot be argued with — the same property `accounting-preview` has, for
+    // the same reason.
+    const src = readFileSync(new URL("./gas-audit.ts", import.meta.url), "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/(^|[^:])\/\/.*$/gm, "$1");
+    for (const forbidden of [/INSERT/i, /UPDATE\s/i, /DELETE/i, /getDb\(/, /process\.env/, /Date\.now/, /node:fs/]) {
+      assert.ok(!forbidden.test(src), `gas-audit must not contain ${forbidden}`);
+    }
+  });
+
+  it("handles an account with nothing recorded", () => {
+    const d = decomposeGas("0xacct", 1, []);
+    assert.equal(d.totalLandedGasUsdg, 0);
+    assert.equal(d.first, null);
+    assert.equal(d.marginalGasUsdg, null);
+    assert.doesNotThrow(() => gasAuditLines(d));
+  });
+});

--- a/worker/src/gas-audit.ts
+++ b/worker/src/gas-audit.ts
@@ -1,0 +1,282 @@
+/**
+ * WHERE THE GAS ACTUALLY WENT, operation by operation.
+ *
+ * The canary publishes a return of −73.8% on a 10.000000 USDG book. Only −4.1%
+ * of that is the market: the other 69.7 percentage points are gas —
+ * 6.969946 USDG across four landed operations, ~94% of the entire published
+ * loss. A user reading that number believes the strategy lost three quarters of
+ * their money. That is not what happened, and the difference between those two
+ * stories is the whole reason this module exists.
+ *
+ * WHY A SINGLE AVERAGE IS THE WRONG ANSWER. An ERC-4337 account's FIRST
+ * UserOperation carries `initCode`: the factory call that deploys the account,
+ * plus whatever modules the grant installs. That is a one-time authorization
+ * cost, it is charged as gas on whichever operation happens to be first, and it
+ * lands in `trades.gas_usdg` on a row whose `kind` says `swap` — there is no
+ * `enable` kind, so nothing in the schema marks it as setup. Divide the total
+ * by the operation count and you get an "average trade costs 1.74 USDG"
+ * that is wrong in the most expensive direction: it teaches every future
+ * decision that trading is uneconomic when the money was spent once, on
+ * turning the account on, and is already sunk.
+ *
+ * So this splits the total into:
+ *
+ *   setup / authorization    the first landed op's excess over the steady rate
+ *   steady-state execution   what the NEXT trade will actually cost
+ *   sponsored               what somebody else paid, never the owner's cost
+ *   unpriced                landed ops whose gas could not be valued — named,
+ *                           never silently treated as free
+ *   reverted                gas burned on operations that did not land, which
+ *                           the published figure does not count at all
+ *
+ * PURE, and every figure carries its evidence. `gasWei` and the userOp/tx
+ * hashes travel with each line so any claim here can be checked against the
+ * chain rather than believed.
+ *
+ * THE PREMIUM IS DERIVED, NOT PROVEN. "The first op cost more than the others"
+ * is arithmetic this module can do. "Because it deployed the account" is a
+ * claim about the chain, and `deploymentConfirmed` is only ever set by a caller
+ * that went and looked at the EntryPoint's `AccountDeployed` event. Until then
+ * the field says `null`, and the wording says "excess over steady state" rather
+ * than "deployment".
+ */
+
+/** One operation as the ledger recorded it. Column names are the table's. */
+export interface GasOp {
+  id: number;
+  kind: string;
+  target: string;
+  amountUsdg: number;
+  status: string;
+  userOpHash: string | null;
+  txHash: string | null;
+  /** Wei this owner paid. Null when the op never reached a receipt. */
+  gasWei: string | null;
+  /** Wei somebody ELSE paid. Never the owner's cost — see the store's comment. */
+  sponsoredGasWei: string | null;
+  /** The valued cost, USDG. NULL means could-not-price, which is not zero. */
+  gasUsdg: number | null;
+  epoch: number;
+  createdAt: number;
+}
+
+export interface KindTotal {
+  ops: number;
+  gasUsdg: number;
+  /** Sum of `amount_usdg` — what was being traded, for a gas-to-size ratio. */
+  notionalUsdg: number;
+}
+
+export interface GasDecomposition {
+  account: string;
+  epoch: number;
+  /** Every landed op, oldest first. */
+  landed: GasOp[];
+  /** Landed ops that carry a gas figure. The others are named, not assumed. */
+  priced: GasOp[];
+  unpriced: GasOp[];
+  /** Landed ops somebody else paid for. Excluded from the owner's total. */
+  sponsored: GasOp[];
+  /** Ops that burned gas without landing. Real spend the published figure omits. */
+  reverted: GasOp[];
+
+  /** What the published P&L subtracts: landed gas only. */
+  totalLandedGasUsdg: number;
+  revertedGasUsdg: number;
+  byKind: Record<string, KindTotal>;
+
+  /** The account's first landed op — the one that carries any setup cost. */
+  first: GasOp | null;
+  /** Every priced landed op after the first. */
+  subsequent: GasOp[];
+  steadyMedianUsdg: number | null;
+  steadyMeanUsdg: number | null;
+  steadyMaxUsdg: number | null;
+
+  /**
+   * First-op cost less the steady-state rate, when both are known and the
+   * first genuinely cost more. Null when there is nothing to compare against —
+   * one landed op tells you nothing about which part of it was one-time.
+   */
+  setupPremiumUsdg: number | null;
+  /** Only a caller that checked the chain may set this. */
+  deploymentConfirmed: boolean | null;
+
+  /** What the NEXT trade should be expected to cost. */
+  marginalGasUsdg: number | null;
+  /** That cost as a share of a typical trade, in percent. */
+  marginalShareOfTradePct: number | null;
+  /** The typical trade size the share above is measured against. */
+  typicalTradeUsdg: number | null;
+}
+
+const median = (xs: readonly number[]): number | null => {
+  if (xs.length === 0) return null;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m]! : (s[m - 1]! + s[m]!) / 2;
+};
+
+/**
+ * WHICH OPERATIONS ARE TRADES.
+ *
+ * A vault deposit moves money between two pockets inside the same wall — it is
+ * not a position and its size is not a trade size, so folding it into a
+ * gas-per-trade ratio would divide real gas by a notional nobody traded. It
+ * still COSTS gas, so it stays in the total; it is only excluded from the
+ * denominator.
+ */
+const TRADE_KINDS = new Set(["swap", "curve-trade"]);
+
+/**
+ * Decompose. PURE — no database, no clock, no environment.
+ *
+ * `ops` must be every row for one account in one epoch, oldest first. The
+ * ordering is load-bearing: "first" means first, and a caller that sorts by id
+ * descending would attribute the setup cost to the most recent trade.
+ */
+export function decomposeGas(account: string, epoch: number, ops: readonly GasOp[]): GasDecomposition {
+  const landed = ops.filter((o) => o.status === "landed");
+  const reverted = ops.filter((o) => o.status === "reverted");
+
+  // SPONSORED IS NOT THE OWNER'S COST. `gas_wei` means "what this owner spent"
+  // and `sponsored_gas_wei` means "what somebody else did" — the store keeps
+  // them in separate columns precisely so this distinction survives.
+  const sponsored = landed.filter((o) => o.sponsoredGasWei !== null && o.sponsoredGasWei !== "");
+  const owned = landed.filter((o) => !sponsored.includes(o));
+
+  const priced = owned.filter((o) => typeof o.gasUsdg === "number" && Number.isFinite(o.gasUsdg));
+  const unpriced = owned.filter((o) => !priced.includes(o));
+
+  const totalLandedGasUsdg = priced.reduce((n, o) => n + (o.gasUsdg ?? 0), 0);
+  const revertedGasUsdg = reverted.reduce((n, o) => n + (o.gasUsdg ?? 0), 0);
+
+  const byKind: Record<string, KindTotal> = {};
+  for (const o of priced) {
+    const k = (byKind[o.kind] ??= { ops: 0, gasUsdg: 0, notionalUsdg: 0 });
+    k.ops += 1;
+    k.gasUsdg += o.gasUsdg ?? 0;
+    k.notionalUsdg += Number.isFinite(o.amountUsdg) ? o.amountUsdg : 0;
+  }
+
+  const first = priced[0] ?? null;
+  const subsequent = priced.slice(1);
+  const rest = subsequent.map((o) => o.gasUsdg ?? 0);
+
+  const steadyMedianUsdg = median(rest);
+  const steadyMeanUsdg = rest.length ? rest.reduce((a, b) => a + b, 0) / rest.length : null;
+  const steadyMaxUsdg = rest.length ? Math.max(...rest) : null;
+
+  // A PREMIUM NEEDS SOMETHING TO BE A PREMIUM OVER. With one landed op there is
+  // no steady state to compare against, and calling the whole of it "setup"
+  // would be a guess dressed as a decomposition.
+  const setupPremiumUsdg =
+    first !== null && steadyMedianUsdg !== null && (first.gasUsdg ?? 0) > steadyMedianUsdg
+      ? (first.gasUsdg ?? 0) - steadyMedianUsdg
+      : null;
+
+  // WHAT THE NEXT TRADE COSTS. The median of the ops after the first — not the
+  // mean, which one deployment-inflated outlier drags upward, and not the
+  // overall average, which is the mistake this module exists to prevent.
+  const marginalGasUsdg = steadyMedianUsdg;
+
+  const tradeSizes = priced
+    .filter((o) => TRADE_KINDS.has(o.kind) && Number.isFinite(o.amountUsdg) && o.amountUsdg > 0)
+    .map((o) => o.amountUsdg);
+  const typicalTradeUsdg = median(tradeSizes);
+  const marginalShareOfTradePct =
+    marginalGasUsdg !== null && typicalTradeUsdg !== null && typicalTradeUsdg > 0
+      ? (marginalGasUsdg / typicalTradeUsdg) * 100
+      : null;
+
+  return {
+    account,
+    epoch,
+    landed,
+    priced,
+    unpriced,
+    sponsored,
+    reverted,
+    totalLandedGasUsdg,
+    revertedGasUsdg,
+    byKind,
+    first,
+    subsequent,
+    steadyMedianUsdg,
+    steadyMeanUsdg,
+    steadyMaxUsdg,
+    setupPremiumUsdg,
+    deploymentConfirmed: null,
+    marginalGasUsdg,
+    marginalShareOfTradePct,
+    typicalTradeUsdg,
+  };
+}
+
+const usd = (n: number | null): string => (n === null ? "—" : n.toFixed(6));
+const short = (h: string | null): string => (h ? `${h.slice(0, 10)}…` : "—");
+
+/**
+ * The report, one line at a time.
+ *
+ * Sized for a log window that holds 503 lines and is shared with a mirror that
+ * writes 200 a minute, so it stays compact and puts the evidence — userOp and
+ * tx hashes — on the per-operation lines where a reader can check them.
+ */
+export function gasAuditLines(d: GasDecomposition): string[] {
+  const out: string[] = [];
+  out.push(
+    `${d.account} epoch ${d.epoch} — ${d.landed.length} landed, ${d.priced.length} priced, ` +
+      `${d.unpriced.length} unpriced, ${d.sponsored.length} sponsored, ${d.reverted.length} reverted`,
+  );
+
+  for (const [i, o] of d.priced.entries()) {
+    out.push(
+      `  #${i + 1} ${o.kind.padEnd(14)} ${usd(o.gasUsdg)} USDG gas · ` +
+        `${o.amountUsdg.toFixed(4)} USDG notional · op ${short(o.userOpHash)} tx ${short(o.txHash)} ` +
+        `· wei ${o.gasWei ?? "—"}`,
+    );
+  }
+  for (const o of d.unpriced) {
+    // NAMED, never dropped. An op whose gas could not be valued is not free,
+    // and a total that quietly excludes it understates the real cost.
+    out.push(`  UNPRICED ${o.kind} · op ${short(o.userOpHash)} · wei ${o.gasWei ?? "—"} — cost unknown, not zero`);
+  }
+  for (const o of d.sponsored) {
+    out.push(`  SPONSORED ${o.kind} · op ${short(o.userOpHash)} · wei ${o.sponsoredGasWei} — somebody else paid`);
+  }
+
+  for (const [kind, k] of Object.entries(d.byKind)) {
+    out.push(
+      `  by kind ${kind.padEnd(14)} ${k.ops} op(s) ${usd(k.gasUsdg)} USDG gas over ` +
+        `${k.notionalUsdg.toFixed(4)} USDG notional`,
+    );
+  }
+
+  out.push(`  TOTAL landed gas      ${usd(d.totalLandedGasUsdg)} USDG  (this is what the published P&L subtracts)`);
+  if (d.revertedGasUsdg > 0) {
+    out.push(
+      `  reverted gas          ${usd(d.revertedGasUsdg)} USDG  — real spend the published figure does NOT count`,
+    );
+  }
+  out.push(`  first landed op       ${usd(d.first?.gasUsdg ?? null)} USDG  op ${short(d.first?.userOpHash ?? null)}`);
+  out.push(
+    `  steady state          median ${usd(d.steadyMedianUsdg)} · mean ${usd(d.steadyMeanUsdg)} · ` +
+      `max ${usd(d.steadyMaxUsdg)} USDG over ${d.subsequent.length} later op(s)`,
+  );
+  out.push(
+    `  setup premium         ${usd(d.setupPremiumUsdg)} USDG  ` +
+      (d.setupPremiumUsdg === null
+        ? "(not derivable — no later op to compare against)"
+        : d.deploymentConfirmed === true
+          ? "(EntryPoint AccountDeployed confirmed on the first op)"
+          : "(excess of the first op over the steady rate; deployment NOT yet confirmed on-chain)"),
+  );
+  out.push(
+    `  MARGINAL next trade   ${usd(d.marginalGasUsdg)} USDG` +
+      (d.marginalShareOfTradePct !== null
+        ? ` = ${d.marginalShareOfTradePct.toFixed(1)}% of a typical ${usd(d.typicalTradeUsdg)} USDG trade`
+        : " (no trade-sized op to measure against)"),
+  );
+  return out;
+}

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -54,6 +54,7 @@ import { planReconstruction, reconstructionLines } from "./accounting-reconstruc
 import type { AccountPlan } from "./accounting-reconstruction";
 import { accountPreviewLines, previewRequested, rosterLines, runPreview } from "./accounting-preview";
 import { parseRepairOptions, repairLines, runRepair } from "./accounting-repair";
+import { decomposeGas, gasAuditLines, type GasOp } from "./gas-audit";
 import { scanFleetCapital } from "./chain-capital";
 import { getFollowStore, MAX_FOLLOWS } from "./follow-store";
 import { MIRROR_STATE_DDL, mirrorTenant, openChildLedger } from "./ledger-mirror";
@@ -699,6 +700,84 @@ async function runAccountingDiagnosisIfAsked(): Promise<void> {
  * private network — and because this half additionally needs the RPC, which the
  * orchestrator already has configured.
  */
+/**
+ * WHERE THE GAS WENT, for one or more named accounts. READ ONLY.
+ *
+ * `MERRYMEN_GAS_AUDIT=0xabc,0xdef` (or `all`). Only SELECTs, and the module it
+ * calls has no database handle at all — it is handed rows and returns strings,
+ * which is the same shape `accounting-preview` uses and for the same reason:
+ * a reporting path that cannot write cannot be argued with.
+ *
+ * Named accounts rather than a fleet default because this prints per-operation
+ * evidence, and `railway logs` is a 503-line snapshot shared with a mirror that
+ * writes ~200 lines a minute. A report that does not fit is not a report.
+ */
+async function runGasAuditIfAsked(): Promise<void> {
+  const want = (process.env.MERRYMEN_GAS_AUDIT ?? "").trim();
+  if (!want) return;
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    log("gas audit asked for, but there is no DATABASE_URL");
+    return;
+  }
+  try {
+    const shared = await makePgDb(url);
+    const wanted = want
+      .split(",")
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean);
+    const all = wanted.includes("all");
+
+    const agents = (await shared
+      .prepare("SELECT smart_account, COALESCE(epoch, 1) AS epoch FROM agents")
+      .all()) as unknown as { smart_account: string; epoch: number }[];
+
+    for (const a of agents) {
+      const account = String(a.smart_account ?? "");
+      const key = account.toLowerCase();
+      if (!all && !wanted.some((w) => key.startsWith(w))) continue;
+      const epoch = Number(a.epoch ?? 1);
+
+      // OLDEST FIRST, and that ordering is load-bearing: "the first landed op"
+      // is where any account-deployment cost lands, and a descending sort would
+      // attribute it to the most recent trade instead.
+      const rows = (await shared
+        .prepare(
+          `SELECT id, kind, target, amount_usdg, status, user_op_hash, tx_hash,
+                  gas_wei, sponsored_gas_wei, gas_usdg, epoch, created_at
+             FROM trades
+            WHERE LOWER(agent_id) = ? AND epoch = ?
+            ORDER BY created_at ASC, id ASC`,
+        )
+        .all(key, epoch)) as unknown as Record<string, unknown>[];
+
+      const ops: GasOp[] = rows.map((r) => ({
+        id: Number(r.id ?? 0),
+        kind: String(r.kind ?? ""),
+        target: String(r.target ?? ""),
+        amountUsdg: Number(r.amount_usdg ?? 0),
+        status: String(r.status ?? ""),
+        userOpHash: r.user_op_hash === null || r.user_op_hash === undefined ? null : String(r.user_op_hash),
+        txHash: r.tx_hash === null || r.tx_hash === undefined ? null : String(r.tx_hash),
+        gasWei: r.gas_wei === null || r.gas_wei === undefined ? null : String(r.gas_wei),
+        sponsoredGasWei:
+          r.sponsored_gas_wei === null || r.sponsored_gas_wei === undefined ? null : String(r.sponsored_gas_wei),
+        gasUsdg: r.gas_usdg === null || r.gas_usdg === undefined ? null : Number(r.gas_usdg),
+        epoch: Number(r.epoch ?? 1),
+        createdAt: Number(r.created_at ?? 0),
+      }));
+
+      if (ops.length === 0) {
+        log(`gas| ${account} epoch ${epoch} — no operations recorded`);
+        continue;
+      }
+      for (const line of gasAuditLines(decomposeGas(account, epoch, ops))) log(`gas| ${line}`);
+    }
+  } catch (e) {
+    log(`gas audit failed — ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
 async function runReconstructionDryRunIfAsked(): Promise<void> {
   if ((process.env.MERRYMEN_ACCOUNTING_RECONSTRUCT ?? "").trim() !== "1") return;
   const url = process.env.DATABASE_URL;
@@ -1096,6 +1175,7 @@ export async function runOrchestrator(): Promise<void> {
   log(`starting — home ${merrymenHome()}, worker ${WORKER_ENTRY}`);
   await runAccountingDiagnosisIfAsked();
   await runReconstructionDryRunIfAsked();
+  await runGasAuditIfAsked();
 
   const stop = () => {
     stopping = true;


### PR DESCRIPTION
The canary publishes **−73.8%** on a 10.000000 USDG book. Only **−4.06%** of
that is the market. The other 69.7 points are gas: **6.969946 USDG** across four
landed operations — about **94% of the entire published loss**.

Divided evenly that is 1.742 USDG a trade, on trades sized ~1.67. Handed to a
model deciding whether the next trade is worth making, that number says *never
trade again*.

But an ERC-4337 account's **first** UserOperation carries `initCode` — the
factory call that deploys the account, plus whatever modules the grant installs.
That is a one-time authorization cost, charged as gas on whichever operation
happens to be first, landing in `trades.gas_usdg` on a row whose `kind` says
`swap`. There is no `enable` kind, so **nothing in the schema marks it as
setup**.

## What it splits the total into

| Bucket | Meaning |
|---|---|
| setup / authorization | the first landed op's excess over the steady rate |
| steady-state execution | what the **next** trade will actually cost |
| sponsored | what somebody else paid — never the owner's cost |
| unpriced | landed ops whose gas could not be valued, **named** not zeroed |
| reverted | gas burned on ops that did not land, which the published figure omits entirely |

**Median, not mean**, for the steady rate — one congested block must not set the
price of every future trade. The gas-to-size ratio divides by **swap sizes
only**: a vault deposit shuffles money between two pockets inside the same wall,
and letting its 500 USDG into the denominator would make gas look negligible by
dividing by money nobody traded. Its gas still counts; only its notional does
not.

## It refuses to guess

With one landed op there is no steady state to compare against, so
`setupPremiumUsdg` is `null` rather than "all of it" — a guess wearing a
decomposition's clothes.

"The first op cost more" is arithmetic this module can do. "Because it deployed
the account" is a claim about the EntryPoint's `AccountDeployed` event, so
`deploymentConfirmed` stays `null` and the report says *"excess over steady
state; deployment NOT yet confirmed on-chain"* until somebody goes and looks.

## Read-only, like `accounting-preview`

The module has **no database handle at all** — it is handed rows and returns
strings. A test pins the absence of `INSERT`, `UPDATE`, `DELETE`, `getDb(`,
`process.env` and `Date.now`. Triggered per account by `MERRYMEN_GAS_AUDIT`
(comma-separated prefixes, or `all`), never fleet-wide by default, because it
prints per-operation evidence and `railway logs` is a 503-line snapshot shared
with a mirror writing ~200 lines a minute.

`npm run typecheck` clean · 15 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)