### PR TITLE
accounting: auditability becomes a property, and stops being an epoch number

### DIFF
--- a/packages/core/src/portfolio-snapshot.test.ts
+++ b/packages/core/src/portfolio-snapshot.test.ts
@@ -21,6 +21,7 @@ import {
 const GOOD: PortfolioQuality = {
   auditPassed: true,
   epoch: 2,
+  currentAccountingHistoryAuditable: true,
   contributionsKnown: true,
   equityComplete: true,
   gasBasis: "net",
@@ -132,9 +133,9 @@ describe("P&L refuses rather than fabricating", () => {
     assert.equal(pnlPercent(s), null);
   });
 
-  it("REFUSES in epoch 1, which is forensic by construction", () => {
-    const s = build({ quality: { ...GOOD, epoch: 1 } });
-    assert.equal(s.pnl.unavailable, "epoch-unauditable");
+  it("REFUSES when the epoch holds rows from before the accounting fix", () => {
+    const s = build({ quality: { ...GOOD, currentAccountingHistoryAuditable: false } });
+    assert.equal(s.pnl.unavailable, "legacy-accounting-history");
   });
 
   it("REFUSES on a gappy equity series", () => {
@@ -143,10 +144,13 @@ describe("P&L refuses rather than fabricating", () => {
   });
 
   it("reports the reasons in the order they actually bite", () => {
-    // Unknown contributions and epoch 1 together must report UNKNOWN, not
-    // EPOCH: they send whoever reads it to different places, and the
+    // Unknown contributions and a legacy history together must report UNKNOWN,
+    // not LEGACY: they send whoever reads it to different places, and the
     // denominator is the more fundamental problem.
-    const s = build({ netContributionsUsdg: null, quality: { ...GOOD, epoch: 1, contributionsKnown: false } });
+    const s = build({
+      netContributionsUsdg: null,
+      quality: { ...GOOD, currentAccountingHistoryAuditable: false, contributionsKnown: false },
+    });
     assert.equal(s.pnl.unavailable, "contributions-unknown");
   });
 });
@@ -210,5 +214,115 @@ describe("computePnl is the only gate", () => {
       quality: s.quality,
     });
     assert.deepEqual(direct, s.pnl, "one implementation, not two that drift");
+  });
+});
+
+/**
+ * THE PROXY THAT FORBADE EVERY NEW AGENT FROM EVER BEING MEASURED.
+ *
+ * `epoch < 2` stood in for "this history predates the accounting fix". The
+ * substitution was false in one direction and permanent: the epoch boundary
+ * only ever opens for an account that HAS pre-cutover rows, so an agent minted
+ * after the fix writes perfectly good rows into epoch 1, never trips the
+ * boundary, and could never publish a return — nor be sized by anything that
+ * defers to this gate. Measured on the live fleet: 24 of 24 accounts at epoch 1.
+ *
+ * The property is now asked directly, and THE NUMBER 1 OR 2 DECIDES NOTHING.
+ * The case that matters most is the first one below.
+ */
+describe("auditability is a property, not an epoch number", () => {
+  it("a clean agent created after the cutover is measurable, at epoch 1", () => {
+    // THE TEST THAT MATTERS. This agent is brand new, running current code,
+    // with evidenced contributions and complete marks. Its epoch happens to be
+    // 1 because nothing has ever needed to quarantine anything for it. That
+    // must not forbid it from being measured — which is exactly what it did.
+    const s = build({ quality: { ...GOOD, epoch: 1, currentAccountingHistoryAuditable: true } });
+    assert.equal(s.pnl.publishable, true, "epoch 1 with a clean history is publishable");
+    assert.equal(s.pnl.unavailable, null);
+    assert.notEqual(s.pnl.usdgSinceContribution, null);
+  });
+
+  it("a legacy agent at epoch 1 with pre-cutover history is still refused", () => {
+    // The case the old proxy got right, and which must keep working. Nothing
+    // here is a weakening of the accounting requirement.
+    const s = build({ quality: { ...GOOD, epoch: 1, currentAccountingHistoryAuditable: false } });
+    assert.equal(s.pnl.publishable, false);
+    assert.equal(s.pnl.unavailable, "legacy-accounting-history");
+  });
+
+  it("an epoch-2 agent past a legitimate boundary is measurable", () => {
+    const s = build({ quality: { ...GOOD, epoch: 2, currentAccountingHistoryAuditable: true } });
+    assert.equal(s.pnl.publishable, true);
+  });
+
+  it("an epoch-2 agent whose new epoch somehow holds legacy rows is REFUSED", () => {
+    // The number 2 is not a licence either. If a bad row ever lands in a fresh
+    // epoch — a backfill, a mirror replaying an old cursor — the gate must
+    // still catch it, and under the old rule it could not have.
+    const s = build({ quality: { ...GOOD, epoch: 2, currentAccountingHistoryAuditable: false } });
+    assert.equal(s.pnl.publishable, false);
+    assert.equal(s.pnl.unavailable, "legacy-accounting-history");
+  });
+
+  it("REFUSES when nobody could establish whether the history is clean", () => {
+    // FAILS CLOSED, and says which failure it was. "We found rows we cannot
+    // vouch for" and "we could not look" send an operator to different places,
+    // so they are different arms rather than one shrug.
+    const s = build({ quality: { ...GOOD, currentAccountingHistoryAuditable: null } });
+    assert.equal(s.pnl.publishable, false);
+    assert.equal(s.pnl.unavailable, "history-auditability-unknown");
+  });
+
+  it("a repaired account with evidence-backed contributions is measurable", () => {
+    // The fleet repair's whole output: contributions that rest on receipts. An
+    // account that has been through it, at epoch 1, with its phantom rows
+    // quarantined out of the current epoch, is exactly the clean case.
+    const s = build({
+      netContributionsUsdg: toMicro(10),
+      quality: { ...GOOD, epoch: 1, currentAccountingHistoryAuditable: true, contributionsKnown: true },
+    });
+    assert.equal(s.pnl.publishable, true);
+  });
+
+  it("still refuses on unknown contributions, whatever the history says", () => {
+    // The denominator is the more fundamental fact and is checked first — a
+    // clean history is not permission to divide by an unknown.
+    const s = build({
+      netContributionsUsdg: null,
+      quality: { ...GOOD, currentAccountingHistoryAuditable: true, contributionsKnown: false },
+    });
+    assert.equal(s.pnl.unavailable, "contributions-unknown");
+  });
+
+  it("still refuses on incomplete marks, whatever the history says", () => {
+    const s = build({ quality: { ...GOOD, currentAccountingHistoryAuditable: true, equityComplete: false } });
+    assert.equal(s.pnl.unavailable, "equity-incomplete");
+  });
+
+  it("publishes with a gross or unknown gas basis, but carries the qualifier", () => {
+    // Gas accounting downgrades the FIGURE's meaning, it does not withhold it —
+    // and the basis travels WITH the number so it cannot be quoted bare.
+    for (const gasBasis of ["gross", "unknown"] as const) {
+      const s = build({ quality: { ...GOOD, epoch: 1, currentAccountingHistoryAuditable: true, gasBasis } });
+      assert.equal(s.pnl.publishable, true, `${gasBasis} basis still publishes`);
+      assert.equal(s.pnl.gasBasis, gasBasis, "and says which basis it is");
+    }
+  });
+
+  it("the epoch number alone changes no verdict, in either direction", () => {
+    // The load-bearing statement of the whole change: hold the property fixed,
+    // vary the number, and nothing moves.
+    for (const epoch of [1, 2, 7]) {
+      assert.equal(
+        build({ quality: { ...GOOD, epoch, currentAccountingHistoryAuditable: true } }).pnl.publishable,
+        true,
+        `epoch ${epoch} with a clean history`,
+      );
+      assert.equal(
+        build({ quality: { ...GOOD, epoch, currentAccountingHistoryAuditable: false } }).pnl.publishable,
+        false,
+        `epoch ${epoch} with a legacy history`,
+      );
+    }
   });
 });

--- a/packages/core/src/portfolio-snapshot.ts
+++ b/packages/core/src/portfolio-snapshot.ts
@@ -52,8 +52,38 @@ export const microToString = (m: MicroUsdg): string => {
 export interface PortfolioQuality {
   /** The ledger recomputed from fills/flows/marks and matched. */
   auditPassed: boolean;
-  /** Accounting epoch. Epoch 1 predates auditable flows and is forensic only. */
+  /**
+   * Accounting epoch. A ROW-SCOPING KEY, and nothing more.
+   *
+   * It used to decide whether a P&L could be published, via `epoch < 2`. That
+   * was a proxy for "this history predates the accounting fix", and it was
+   * wrong for every agent minted after the fix: `hasEpochOneHistory` only opens
+   * epoch 2 for an account that HAS pre-cutover rows, so a brand-new agent
+   * writing perfectly good rows stays in epoch 1 for ever and could never
+   * publish a return. The whole fleet — all 24 accounts — was epoch 1.
+   *
+   * The question the proxy was standing in for is now asked directly. See
+   * `currentAccountingHistoryAuditable`.
+   */
   epoch: number;
+  /**
+   * DOES THIS EPOCH'S HISTORY CONSIST ONLY OF ROWS WE CAN VOUCH FOR?
+   *
+   * The real property, tested rather than inferred from an integer:
+   *
+   *   true   no rows in the current epoch predate the accounting cutover
+   *   false  legacy rows are present — flows were not tracked, fills were
+   *          booked from a slippage floor, equity rows can hold a phantom
+   *          crater from a failed balance read
+   *   null   could not be determined
+   *
+   * NULL FAILS CLOSED, and that is a different failure direction from the one
+   * the epoch-bump decision uses. Deciding whether to OPEN a new epoch on an
+   * unreadable ledger should do nothing; deciding whether to PUBLISH a return
+   * on an unreadable ledger should refuse. Same evidence, opposite defaults,
+   * because the cost of being wrong points the other way.
+   */
+  currentAccountingHistoryAuditable: boolean | null;
   /** Contributed capital rests on receipts, not on inference. */
   contributionsKnown: boolean;
   /** The equity series has no gaps in the window this snapshot covers. */
@@ -96,7 +126,10 @@ export type PnlUnavailable =
   | "contributions-unknown"
   | "no-capital-contributed"
   | "equity-incomplete"
-  | "epoch-unauditable";
+  /** Rows in this epoch predate the accounting fix and cannot be audited. */
+  | "legacy-accounting-history"
+  /** Nobody could establish whether they do. Refused, not assumed clean. */
+  | "history-auditability-unknown";
 
 export interface SnapshotPnl {
   /** equity − contributions − gas, in micro-USDG. Null when not publishable. */
@@ -224,10 +257,28 @@ export function computePnl(args: {
   if (args.netContributionsUsdg === null || !args.quality.contributionsKnown) {
     return { usdgSinceContribution: null, publishable: false, unavailable: "contributions-unknown", gasBasis: basis };
   }
-  if (args.quality.epoch < 2) {
-    // Epoch 1 predates auditable flows by construction. Its rows are kept for
-    // forensics and must never be presented as measured.
-    return { usdgSinceContribution: null, publishable: false, unavailable: "epoch-unauditable", gasBasis: basis };
+  if (args.quality.currentAccountingHistoryAuditable !== true) {
+    // THE PROPERTY, NOT THE PROXY.
+    //
+    // This was `epoch < 2`, on the reasoning that "epoch 1 predates auditable
+    // flows by construction". That reasoning was false for every agent created
+    // after the cutover: the epoch boundary only opens for an account that HAS
+    // pre-cutover rows, so a brand-new agent writing perfectly good rows stays
+    // at epoch 1 permanently — and was permanently forbidden from publishing a
+    // return, or from being sized by anything that defers to this gate.
+    //
+    // Unknown is refused alongside legacy, and separately named, because "we
+    // found bad rows" and "we could not look" send whoever reads it to two
+    // different places.
+    return {
+      usdgSinceContribution: null,
+      publishable: false,
+      unavailable:
+        args.quality.currentAccountingHistoryAuditable === false
+          ? "legacy-accounting-history"
+          : "history-auditability-unknown",
+      gasBasis: basis,
+    };
   }
   if (args.netContributionsUsdg <= 0) {
     // KNOWN, and zero. That is knowledge — no real capital is at stake — but it

--- a/services/brain/brain/fixtures/scenarios.py
+++ b/services/brain/brain/fixtures/scenarios.py
@@ -36,6 +36,7 @@ USDG = 1_000_000  # micro-USDG in one USDG
 GOOD_QUALITY = PortfolioQuality(
     audit_passed=True,
     epoch=2,
+    current_accounting_history_auditable=True,
     contributions_known=True,
     equity_complete=True,
     gas_basis="net",
@@ -246,7 +247,17 @@ def all_scenarios() -> list[Scenario]:
                     50.0,
                     999.48,
                     None,
-                    quality=PortfolioQuality(contributions_known=False, epoch=1, gas_basis="unknown"),
+                    # Auditability is stated TRUE on purpose, so this scenario
+                    # tests the thing it is named for — an unknown denominator —
+                    # rather than passing because a defaulted field refused
+                    # first. A fixture that succeeds for the wrong reason is a
+                    # fixture that stops testing anything.
+                    quality=PortfolioQuality(
+                        contributions_known=False,
+                        epoch=1,
+                        current_accounting_history_auditable=True,
+                        gas_basis="unknown",
+                    ),
                 ),
                 _market("TSLA", "equity-token", "1481.20", {"technical": "Uptrend."}),
             ),

--- a/services/brain/brain/fixtures/suite.py
+++ b/services/brain/brain/fixtures/suite.py
@@ -73,6 +73,7 @@ DEPEG = {
 _DEGRADED = PortfolioQuality(
     audit_passed=False,
     epoch=2,
+    current_accounting_history_auditable=True,
     contributions_known=True,
     equity_complete=False,
     gas_basis="gross",
@@ -247,16 +248,34 @@ def extended_scenarios() -> list[Scenario]:
             quality=_DEGRADED, expect_hold=True,
         ),
         _case(
-            "epoch_one",
-            "epoch 1 is forensic by construction, whatever the signals say",
+            "legacy_history",
+            "a history holding pre-cutover rows cannot be measured, whatever the signals say",
             symbol="NVDA", klass="equity-token", price="212.40", signals=BULLISH,
             cash=300.0, equity=300.0, contributions=300.0,
-            quality=PortfolioQuality(**{**GOOD_QUALITY.model_dump(), "epoch": 1}),
-            # REFUSAL, not hold. Epoch 1 is forensic by construction, so there
-            # is no book to reason about at all — and a refusal costs nothing,
-            # which a hold does not. The fixture said hold while the gate said
-            # refuse, and the gate was right.
+            # WAS `epoch_one`, and the rename is the finding. The old fixture
+            # asserted that epoch 1 is "forensic by construction" — which is
+            # false for every agent minted after the accounting cutover, and was
+            # the rule that left all 24 live accounts permanently unsizeable.
+            # What actually makes a book unmeasurable is rows we cannot vouch
+            # for, so that is what the fixture now says.
+            quality=PortfolioQuality(
+                **{**GOOD_QUALITY.model_dump(), "current_accounting_history_auditable": False}
+            ),
+            # REFUSAL, not hold. There is no book to reason about at all — and a
+            # refusal costs nothing, which a hold does not. The fixture said
+            # hold while the gate said refuse, and the gate was right.
             expect_refusal=True,
+        ),
+        _case(
+            "clean_epoch_one",
+            "a brand-new agent at epoch 1 with nothing to quarantine is fully measurable",
+            symbol="NVDA", klass="equity-token", price="212.40", signals=BULLISH,
+            cash=300.0, equity=300.0, contributions=300.0,
+            # THE CASE THE OLD PROXY GOT WRONG, now pinned as a scenario rather
+            # than only as a unit test: this is every agent created after
+            # 2026-08-26, and it must be able to reach a real decision.
+            quality=PortfolioQuality(**{**GOOD_QUALITY.model_dump(), "epoch": 1}),
+            expect_hold=False,
         ),
         _case(
             "contributions_unknown_but_bullish",

--- a/services/brain/brain/gate.py
+++ b/services/brain/brain/gate.py
@@ -34,7 +34,23 @@ Verdict = Literal["proceed", "downgrade-to-hold", "refuse"]
 #: flows by construction; its rows are kept for forensics and are never presented
 #: as measured. If core changes this, this changes — it is one rule with two
 #: homes, and the homes must not drift.
-MIN_AUDITABLE_EPOCH = 2
+#: THE EPOCH FLOOR IS GONE, and its absence is the point.
+#:
+#: This was `MIN_AUDITABLE_EPOCH = 2`, mirroring the same constant in core. One
+#: rule with two homes — and the homes did not drift, they were both wrong
+#: together. `epoch >= 2` was a proxy for "this history predates the accounting
+#: fix", and the epoch boundary only ever opens for an account that HAS
+#: pre-cutover rows. Every agent minted after the fix writes good rows into
+#: epoch 1, never trips the boundary, and was permanently unsizeable: the whole
+#: fleet, 24 of 24 accounts, sat at epoch 1, so every Brain decision was a
+#: forced hold no matter what the analysts concluded.
+#:
+#: Brain now CONSUMES the verdict rather than recomputing it. The property is
+#: `quality.current_accounting_history_auditable`, decided in packages/core from
+#: evidence the worker gathered, and there is no second implementation here to
+#: disagree with it — the same reason `pnl_publishable` is carried rather than
+#: re-derived. Accounting has one home.
+_EPOCH_FLOOR_REMOVED = True
 
 
 @dataclass(frozen=True)
@@ -49,19 +65,21 @@ class GateResult:
         return self.verdict == "proceed"
 
 
-def assess(portfolio: PortfolioState, *, min_epoch: int = MIN_AUDITABLE_EPOCH) -> GateResult:
+def assess(portfolio: PortfolioState) -> GateResult:
     """
     Decide what this book supports. PURE.
 
-    `min_epoch` MATCHES CORE. It defaulted to 1 while the accounting repair was
-    still running, and the 36-scenario ablation caught what that cost:
-    `epoch_one` returned BUY on a book that packages/core reports as
-    unpublishable. Two epoch rules is exactly the second accounting
-    implementation the canonical snapshot exists to prevent — and the local one
-    was the LENIENT half, which is the dangerous direction to drift in.
+    THERE IS NO LOCAL FLOOR LEFT TO TUNE. `min_epoch` used to be a parameter so
+    a caller could "state a different floor deliberately"; it defaulted to 1
+    while the accounting repair ran, and the 36-scenario ablation caught what
+    that cost — `epoch_one` returned BUY on a book core reports as
+    unpublishable. The fix at the time was to make the default agree with core.
 
-    It stays a parameter so a caller can state a different floor deliberately,
-    but the default now agrees with `computePnl`.
+    The real fix is that there is nothing here to agree or disagree WITH: the
+    auditability verdict arrives on the snapshot, decided once in
+    packages/core from evidence the worker gathered. A knob that can be set to
+    the lenient value is a knob that will be, and the second implementation is
+    exactly what the canonical snapshot exists to prevent.
     """
     q = portfolio.quality
     caveats: list[str] = []
@@ -102,10 +120,19 @@ def assess(portfolio: PortfolioState, *, min_epoch: int = MIN_AUDITABLE_EPOCH) -
             caveats=[],
         )
 
-    if q.epoch < min_epoch:
+    if q.current_accounting_history_auditable is not True:
+        # THE PROPERTY, NOT THE EPOCH NUMBER — and not re-derived here either.
+        # `false` and `None` are refused alike but named apart: "we found rows
+        # we cannot vouch for" and "we could not look" send an operator to two
+        # different places.
         return GateResult(
             verdict="refuse",
-            why=f"epoch {q.epoch} is below the auditable floor of {min_epoch}",
+            why=(
+                f"this epoch's accounting history contains rows from before the accounting fix, "
+                f"so no figure over it can be audited (epoch {q.epoch})"
+                if q.current_accounting_history_auditable is False
+                else "whether this epoch's accounting history can be audited could not be established"
+            ),
             caveats=[],
         )
 

--- a/services/brain/brain/schemas.py
+++ b/services/brain/brain/schemas.py
@@ -257,7 +257,17 @@ class PortfolioQuality(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     audit_passed: bool = False
+    #: A ROW-SCOPING KEY, carried for the record and for log lines. It decides
+    #: nothing — see `current_accounting_history_auditable`.
     epoch: int = 1
+    #: DOES THIS EPOCH HOLD ONLY ROWS WE CAN VOUCH FOR? True / False / None,
+    #: where None means nobody could establish it.
+    #:
+    #: DEFAULTS TO None so a snapshot from a worker that predates the field is
+    #: refused rather than assumed clean. The failure direction for a money gate
+    #: is silence, and a missing field is exactly the case where the old code
+    #: would otherwise have quietly started sizing.
+    current_accounting_history_auditable: bool | None = None
     contributions_known: bool = False
     equity_complete: bool = False
     gas_basis: Literal["gross", "net", "unknown"] = "unknown"

--- a/services/brain/brain/snapshot.py
+++ b/services/brain/brain/snapshot.py
@@ -58,6 +58,16 @@ def from_canonical(payload: dict[str, Any]) -> PortfolioState:
     quality = PortfolioQuality(
         audit_passed=bool(q.get("auditPassed", False)),
         epoch=int(q.get("epoch", 1)),
+        # CARRIED, NEVER COERCED. `bool(None)` is False, and False here means
+        # "we found legacy rows" while None means "we could not look" — both
+        # refuse, but they are different facts and the refusal says which. A
+        # missing key stays None, so a snapshot from an older worker is refused
+        # rather than read as a clean history.
+        current_accounting_history_auditable=(
+            None
+            if q.get("currentAccountingHistoryAuditable") is None
+            else bool(q["currentAccountingHistoryAuditable"])
+        ),
         contributions_known=bool(q.get("contributionsKnown", False)),
         equity_complete=bool(q.get("equityComplete", False)),
         gas_basis=q.get("gasBasis", "unknown"),

--- a/services/brain/tests/test_boundary.py
+++ b/services/brain/tests/test_boundary.py
@@ -204,28 +204,95 @@ def test_an_ordinary_add_to_a_working_position_does_not_escalate():
     assert v.primary == "no-escalation"
 
 
-def test_brains_epoch_floor_agrees_with_core():
-    # The 36-scenario ablation caught this: the local gate defaulted to an epoch
-    # floor of 1 while packages/core reports anything below 2 as unpublishable,
-    # so `epoch_one` returned BUY on a book core calls unmeasurable. Two epoch
-    # rules is a second accounting implementation, and the local one was the
-    # LENIENT half — the dangerous direction to drift in.
-    from brain.gate import MIN_AUDITABLE_EPOCH
+def test_brain_consumes_cores_auditability_verdict_and_keeps_no_floor():
+    """
+    THERE IS NO SECOND ACCOUNTING IMPLEMENTATION HERE.
+
+    The 36-scenario ablation once caught a local epoch floor defaulting to 1
+    while packages/core refused anything below 2 — `epoch_one` returned BUY on a
+    book core called unmeasurable, and the local rule was the LENIENT half. The
+    fix at the time was to make the two constants agree.
+
+    Both constants were wrong together. `epoch >= 2` was a proxy for "this
+    history predates the accounting fix", and the epoch boundary only opens for
+    an account that HAS pre-cutover rows — so every agent minted after the fix
+    sat at epoch 1 for ever and could never be sized. Measured on the live
+    fleet: 24 of 24 accounts.
+
+    So the floor is gone rather than corrected, and the verdict arrives on the
+    snapshot. A knob that can be set to the lenient value is a knob that will be.
+    """
+    import inspect
+
+    from brain import gate as gate_mod
     from brain.schemas import PortfolioQuality, PortfolioState
 
-    assert MIN_AUDITABLE_EPOCH == 2, "must match computePnl in packages/core"
-
-    epoch_one = PortfolioState(
-        snapshot_id="s", as_of=1, cash_usdg=300_000_000, equity_usdg=300_000_000,
-        net_contributions_usdg=300_000_000,
-        quality=PortfolioQuality(
-            audit_passed=True, epoch=1, contributions_known=True, equity_complete=True,
-            gas_basis="net", position_history_available=True,
-        ),
+    assert not hasattr(gate_mod, "MIN_AUDITABLE_EPOCH"), "the local floor must be gone, not renamed"
+    assert "min_epoch" not in inspect.signature(gate_mod.assess).parameters, (
+        "and not survive as a tunable parameter"
     )
-    g = gate_assess(epoch_one)
-    assert g.verdict == "refuse"
-    assert not g.may_size, "epoch 1 is forensic; nothing may be sized against it"
+
+    def book(**q):
+        return PortfolioState(
+            snapshot_id="s", as_of=1, cash_usdg=300_000_000, equity_usdg=300_000_000,
+            net_contributions_usdg=300_000_000,
+            quality=PortfolioQuality(
+                audit_passed=True, contributions_known=True, equity_complete=True,
+                gas_basis="net", position_history_available=True, **q,
+            ),
+        )
+
+    # THE CASE THAT MATTERS: a clean agent created after the cutover, still at
+    # epoch 1 because nothing ever needed quarantining for it, may be sized.
+    clean_new = gate_assess(book(epoch=1, current_accounting_history_auditable=True))
+    assert clean_new.may_size, "a clean epoch-1 book must be sizeable"
+
+    # The case the old proxy got right, which must keep working.
+    legacy = gate_assess(book(epoch=1, current_accounting_history_auditable=False))
+    assert legacy.verdict == "refuse"
+    assert not legacy.may_size
+    assert "before the accounting fix" in legacy.why
+
+    # A fresh epoch is not a licence either.
+    dirty_two = gate_assess(book(epoch=2, current_accounting_history_auditable=False))
+    assert not dirty_two.may_size, "the number 2 does not clear a legacy row"
+
+    # FAILS CLOSED on could-not-ask, and says so distinctly.
+    unknown = gate_assess(book(epoch=2, current_accounting_history_auditable=None))
+    assert unknown.verdict == "refuse"
+    assert "could not be established" in unknown.why
+
+    # And a snapshot from a worker that predates the field defaults to None,
+    # so it is refused rather than read as clean.
+    assert PortfolioQuality().current_accounting_history_auditable is None
+
+    # The number alone moves nothing, in either direction.
+    for epoch in (1, 2, 7):
+        assert gate_assess(book(epoch=epoch, current_accounting_history_auditable=True)).may_size
+        assert not gate_assess(book(epoch=epoch, current_accounting_history_auditable=False)).may_size
+
+
+def test_the_auditability_verdict_survives_the_wire():
+    """A parser that coerced None to False would turn "could not look" into a
+    finding, and lose the distinction the refusal message rests on."""
+    from brain.snapshot import from_canonical
+
+    base = {
+        "schemaVersion": "1.0.0", "snapshotId": "s", "agentId": "0xa", "asOf": 1, "epoch": 1,
+        "cashUsdg": 1, "vaultUsdg": 0, "positionsUsdg": 0, "quarantinedUsdg": 0, "equityUsdg": 1,
+        "netContributionsUsdg": 1, "gasUsdg": 0, "positions": [],
+        "pnl": {"usdgSinceContribution": 0, "publishable": True, "unavailable": None, "gasBasis": "net"},
+    }
+    q = {"auditPassed": True, "epoch": 1, "contributionsKnown": True, "equityComplete": True,
+         "gasBasis": "net", "positionHistoryAvailable": True, "quarantinedAssetsPresent": False}
+
+    for sent, expected in ((True, True), (False, False), (None, None)):
+        snap = from_canonical({**base, "quality": {**q, "currentAccountingHistoryAuditable": sent}})
+        assert snap.quality.current_accounting_history_auditable is expected, f"sent {sent!r}"
+
+    # Absent means unknown, not clean.
+    snap = from_canonical({**base, "quality": q})
+    assert snap.quality.current_accounting_history_auditable is None
 
 
 # ── the measurement boundary ────────────────────────────────────────────────

--- a/spikes/emit-canary-snapshot.mts
+++ b/spikes/emit-canary-snapshot.mts
@@ -21,7 +21,7 @@ const snap = buildPortfolioSnapshot({
     costBasisUsdg: toMicro(6.666), priceSource: "chainlink", quarantined: false,
   }],
   quality: {
-    auditPassed: false, epoch: 1, contributionsKnown: true, equityComplete: false,
+    auditPassed: false, epoch: 1, currentAccountingHistoryAuditable: true, contributionsKnown: true, equityComplete: false,
     gasBasis: "unknown", positionHistoryAvailable: false,
     quarantinedAssetsPresent: false, assessedAt: 1788600000,
   },

--- a/worker/src/brain-client.ts
+++ b/worker/src/brain-client.ts
@@ -252,6 +252,9 @@ function snapshotToRequest(s: PortfolioSnapshot) {
     quality: {
       audit_passed: s.quality.auditPassed,
       epoch: s.quality.epoch,
+      // The auditability VERDICT, carried the way `pnl_publishable` is. Brain
+      // consumes it and keeps no second implementation to disagree with.
+      current_accounting_history_auditable: s.quality.currentAccountingHistoryAuditable,
       contributions_known: s.quality.contributionsKnown,
       equity_complete: s.quality.equityComplete,
       gas_basis: s.quality.gasBasis,

--- a/worker/src/gas-audit.ts
+++ b/worker/src/gas-audit.ts
@@ -231,11 +231,17 @@ export function gasAuditLines(d: GasDecomposition): string[] {
   );
 
   for (const [i, o] of d.priced.entries()) {
+    // FULL HASHES on the per-operation lines. The summary below can abbreviate
+    // because it is a pointer; these are the evidence, and a truncated hash
+    // cannot be looked up — which makes it a decoration rather than a citation.
+    // NOTE `tx_hash` is the BUNDLED transaction and is shared with other
+    // people's operations; `user_op_hash` is the one that identifies ours.
     out.push(
       `  #${i + 1} ${o.kind.padEnd(14)} ${usd(o.gasUsdg)} USDG gas · ` +
-        `${o.amountUsdg.toFixed(4)} USDG notional · op ${short(o.userOpHash)} tx ${short(o.txHash)} ` +
-        `· wei ${o.gasWei ?? "—"}`,
+        `${o.amountUsdg.toFixed(4)} USDG notional · wei ${o.gasWei ?? "—"}`,
     );
+    out.push(`      op ${o.userOpHash ?? "—"}`);
+    out.push(`      tx ${o.txHash ?? "—"} (bundled — shared with other senders)`);
   }
   for (const o of d.unpriced) {
     // NAMED, never dropped. An op whose gas could not be valued is not free,

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -214,6 +214,7 @@ import {
   recentTradeTxHashes,
   getAgentEpoch,
   getAgentFinancials,
+  accountingHistoryAuditable,
   hasEpochOneHistory,
   lastKnownEquityUsdg,
   lastKnownCashUsdg,
@@ -5260,6 +5261,8 @@ async function main() {
         const epochNow = await getAgentEpoch(agentId);
         const netContrib = await getNetContributionsUsdg(agentId);
         const gasNow = await getGasPaidUsdg(agentId, epochNow);
+        // Asked once per run, from the ledger this agent actually has.
+        const historyAuditable = await accountingHistoryAuditable(agentId, epochNow);
         // THE BIGGEST HOLDING IS WHAT THIS RUN IS ABOUT. One instrument per run
         // keeps the question answerable and the bill bounded; a Brain asked
         // about a whole book at once produces a paragraph, not a decision.
@@ -5303,17 +5306,27 @@ async function main() {
             grossContributionsUsdg: null,
             grossWithdrawalsUsdg: null,
             gasUsdg: gasNow.unpricedTrades > 0 ? null : Math.round(gasNow.usdg * 1e6),
+            // NO `as never`. It used to carry one, which made this literal
+            // completely unchecked against core's interface — it even held a
+            // `gasAccounting` field that exists on the WORKER's unrelated
+            // PortfolioQuality and not on this one. A snapshot's quality object
+            // is the thing every downstream refusal is decided from; typing it
+            // as `never` meant core could add, rename or remove a field and
+            // nothing here would fail to compile.
             quality: {
               auditPassed: false,
               epoch: epochNow,
+              // THE PROPERTY, ASKED DIRECTLY, replacing the `epoch >= 2` proxy.
+              // Null when the ledger could not be read, and core refuses on
+              // null rather than assuming a clean history.
+              currentAccountingHistoryAuditable: historyAuditable,
               contributionsKnown: accounting.contributionsKnown,
               equityComplete: !bookIncomplete,
-              gasAccounting: undefined,
               gasBasis: gasNow.unpricedTrades > 0 ? "gross" : gasNow.usdg > 0 ? "net" : "unknown",
               positionHistoryAvailable: false,
               quarantinedAssetsPresent: quarantine.totalCostUsdg > 0n,
               assessedAt: Math.floor(Date.now() / 1000),
-            } as never,
+            },
             market: {
               instrumentId: `merrymen:${focus.symbol.toLowerCase()}`,
               symbol: focus.symbol,

--- a/worker/src/store.ts
+++ b/worker/src/store.ts
@@ -1106,22 +1106,58 @@ export async function getAgentEpoch(agentId: string): Promise<number> {
 export const ACCOUNTING_FIXED_AT = 1_787_704_075;
 
 /**
+ * Does this agent's CURRENT epoch contain rows written before the accounting
+ * was fixed? The evidence behind `PortfolioQuality.currentAccountingHistoryAuditable`.
+ *
+ * NULL MEANS COULD-NOT-ASK, and it is a distinct answer from `false`. A caller
+ * deciding whether a return may be published must refuse on null; a caller
+ * deciding whether to open a new epoch must do nothing on it. Same evidence,
+ * opposite defaults — see the two wrappers below.
+ */
+export async function legacyRowsInEpoch(agentId: string, epoch: number): Promise<boolean | null> {
+  try {
+    const row = (await getDb()
+      .prepare(
+        `SELECT (SELECT COUNT(*) FROM trades WHERE agent_id = ? AND epoch = ? AND created_at < ?)
+              + (SELECT COUNT(*) FROM equity WHERE agent_id = ? AND epoch = ? AND at < ?) AS n`,
+      )
+      .get(agentId, epoch, ACCOUNTING_FIXED_AT, agentId, epoch, ACCOUNTING_FIXED_AT)) as
+      | { n: number }
+      | undefined;
+    if (row === undefined) return null;
+    return Number(row.n ?? 0) > 0;
+  } catch {
+    // A ledger with no `trades` table yet is a read we could not make, not an
+    // account we have cleared.
+    return null;
+  }
+}
+
+/**
+ * CAN THIS EPOCH'S HISTORY BE AUDITED? The property, for the publication gate.
+ *
+ * Replaces `epoch >= 2`, which was a proxy for exactly this and gave the wrong
+ * answer for every agent minted after the cutover — those write good rows into
+ * epoch 1, never trip the boundary, and were therefore permanently unpublishable.
+ *
+ * FAILS CLOSED: null propagates, and `computePnl` refuses on it.
+ */
+export async function accountingHistoryAuditable(agentId: string, epoch: number): Promise<boolean | null> {
+  const legacy = await legacyRowsInEpoch(agentId, epoch);
+  return legacy === null ? null : !legacy;
+}
+
+/**
  * Does this agent have rows from BEFORE the audit work? Used once, at the first
  * arm, to decide whether an epoch boundary is needed. A brand-new agent has
  * nothing to quarantine and stays in epoch 1.
+ *
+ * FAILS OPEN, deliberately and differently from `accountingHistoryAuditable`:
+ * a read failure here must not manufacture an epoch boundary, because opening
+ * one writes an opening-balance flow and is not something to do on a guess.
  */
 export async function hasEpochOneHistory(agentId: string): Promise<boolean> {
-  try {
-    const row = await getDb()
-      .prepare(
-        `SELECT (SELECT COUNT(*) FROM trades WHERE agent_id = ? AND epoch = 1 AND created_at < ?)
-              + (SELECT COUNT(*) FROM equity WHERE agent_id = ? AND epoch = 1 AND at < ?) AS n`,
-      )
-      .get(agentId, ACCOUNTING_FIXED_AT, agentId, ACCOUNTING_FIXED_AT) as { n: number } | undefined;
-    return (row?.n ?? 0) > 0;
-  } catch {
-    return false;
-  }
+  return (await legacyRowsInEpoch(agentId, 1)) === true;
 }
 
 /**


### PR DESCRIPTION
`epoch >= 2` was a **proxy** for "this history predates the accounting fix". The
substitution was false in one direction, and permanent.

`index.ts` only opens epoch 2 for an account that **has** pre-cutover rows
(`hasEpochOneHistory`). A brand-new agent running current code writes perfectly
good rows into epoch 1, never trips the boundary, and stays there for ever. So:

- `computePnl` returned `epoch-unauditable` for it **permanently** — no user
  could ever see a return;
- Brain's `may_size` was permanently false, and `_assemble` forced
  `hold, delta 0`.

Measured on the live fleet with the read-only roster: **24 of 24 accounts at
epoch 1**. Every production shadow decision was a forced hold regardless of what
the analysts concluded.

The codebase already contradicted itself:

> `store.ts` — "a brand-new agent running today's code writes its own perfectly good rows into epoch 1"
>
> `portfolio-snapshot.ts` — "epoch 1 predates auditable flows **by construction**"

Both shipped. Only one was true.

## The property, asked directly

`PortfolioQuality.currentAccountingHistoryAuditable: boolean | null`, derived
from the evidence `hasEpochOneHistory` was already gathering — *are there rows
in **this** epoch older than `ACCOUNTING_FIXED_AT`?* `epoch` stays on the object
as a row-scoping key and decides nothing.

**This is not a weakening.** A legacy epoch-1 account is still refused, and an
epoch-2 account whose fresh epoch somehow holds a legacy row is **now** refused —
which the old rule could not do. What changes is that the number stops being the
test.

## Fails closed, in the right direction, twice

`legacyRowsInEpoch` returns `null` on a read failure and the gate refuses on
null. `hasEpochOneHistory` keeps failing **open**, because deciding whether to
*open* an epoch on an unreadable ledger must do nothing (it writes an
opening-balance flow), while deciding whether to *publish* on one must refuse.
Same evidence, opposite defaults. The Python field defaults to `None`, so a
snapshot from an older worker is refused rather than read as clean.

## Brain keeps no second implementation

`MIN_AUDITABLE_EPOCH` is **deleted**, not corrected — and `assess`'s `min_epoch`
parameter with it. A knob that can be set to the lenient value is a knob that
will be, and that already happened once: the 36-scenario ablation caught a local
floor of 1 returning BUY on a book core called unmeasurable. Accounting has one
home.

## The `as never` is gone

The worker's quality literal was cast to `never`, which made it **completely
unchecked** against core's interface — it carried a `gasAccounting` field
belonging to the worker's *unrelated* `PortfolioQuality`, and core could have
added, renamed or removed anything with no compile error. That cast is why this
change compiled everywhere else on the first try; removing it is what makes the
type mean something.

## Tests

Every case requested, in `portfolio-snapshot.test.ts` and `test_boundary.py`:

| Case | Verdict |
|---|---|
| **clean agent created after the cutover, still epoch 1** | **publishable / sizeable** |
| legacy epoch-1 agent with pre-cutover history | refused (`legacy-accounting-history`) |
| repaired account, evidence-backed contributions | publishable |
| epoch-2 agent past a legitimate boundary | publishable |
| epoch-2 agent whose fresh epoch holds a legacy row | refused (new — the old rule couldn't) |
| auditability unknown | refused (`history-auditability-unknown`) |
| contributions unknown | refused (checked first) |
| incomplete marks | refused |
| gross / unknown gas basis | publishable, qualifier carried |
| **epoch number alone, held property fixed** | **moves nothing, either direction** |

Plus a wire test that `None` survives the JSON round-trip uncoerced, and that an
absent field reads as unknown. The `epoch_one` fixture is renamed
`legacy_history`, with a new `clean_epoch_one` case beside it.

`npm run typecheck` clean · **2271/2271** TS tests · **24/24** pytest.

Execution stays disconnected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)