### PR TITLE
web: stop baking an empty database into the image

### DIFF
--- a/web/src/app/(app)/leaderboard/page.tsx
+++ b/web/src/app/(app)/leaderboard/page.tsx
@@ -12,7 +12,25 @@ import "@/styles/shell.css";
 import "@/styles/feed.css";
 import "@/styles/board.css";
 
-export const revalidate = 60;
+/**
+ * NOT PRERENDERED AT BUILD, and that is a correctness rule rather than a
+ * performance one.
+ *
+ * `export const revalidate = <n>` on an App-Router route or page is an OPT-IN
+ * TO BUILD-TIME PRERENDERING — Next runs the handler once inside `docker build`
+ * and ships the body. It is not "cache the response for n seconds at runtime",
+ * which is what it reads like.
+ *
+ * There is no DATABASE_URL inside the image build, so `withReadDb` handed the
+ * handler `null` and the baked body was `{"source":"none", …}` — the shape that
+ * means "the ledger could not be read", not "nobody said anything". Every first
+ * visitor after every deploy was served an empty product and a false reason for
+ * it, until the next request regenerated it.
+ *
+ * So this is dynamic. The read has no session in it — every visitor still gets
+ * the same bytes — but they are bytes computed against a database that exists.
+ */
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "Leaderboard — merrymen",

--- a/web/src/app/(app)/page.tsx
+++ b/web/src/app/(app)/page.tsx
@@ -24,7 +24,25 @@ import "@/styles/wall.css";
  * is load-bearing — if a session read ever appears in readTheses, this page and
  * /api/theses both have to stop being cached.
  */
-export const revalidate = 30;
+/**
+ * NOT PRERENDERED AT BUILD, and that is a correctness rule rather than a
+ * performance one.
+ *
+ * `export const revalidate = <n>` on an App-Router route or page is an OPT-IN
+ * TO BUILD-TIME PRERENDERING — Next runs the handler once inside `docker build`
+ * and ships the body. It is not "cache the response for n seconds at runtime",
+ * which is what it reads like.
+ *
+ * There is no DATABASE_URL inside the image build, so `withReadDb` handed the
+ * handler `null` and the baked body was `{"source":"none", …}` — the shape that
+ * means "the ledger could not be read", not "nobody said anything". Every first
+ * visitor after every deploy was served an empty product and a false reason for
+ * it, until the next request regenerated it.
+ *
+ * So this is dynamic. The read has no session in it — every visitor still gets
+ * the same bytes — but they are bytes computed against a database that exists.
+ */
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: "merrymen — agents that trade, and say why",

--- a/web/src/app/api/leaderboard/route.ts
+++ b/web/src/app/api/leaderboard/route.ts
@@ -12,7 +12,25 @@
 import { NextResponse } from "next/server";
 import { readLeaderboard } from "@/lib/read-leaderboard";
 
-export const revalidate = 60;
+/**
+ * NOT PRERENDERED AT BUILD, and that is a correctness rule rather than a
+ * performance one.
+ *
+ * `export const revalidate = <n>` on an App-Router route or page is an OPT-IN
+ * TO BUILD-TIME PRERENDERING — Next runs the handler once inside `docker build`
+ * and ships the body. It is not "cache the response for n seconds at runtime",
+ * which is what it reads like.
+ *
+ * There is no DATABASE_URL inside the image build, so `withReadDb` handed the
+ * handler `null` and the baked body was `{"source":"none", …}` — the shape that
+ * means "the ledger could not be read", not "nobody said anything". Every first
+ * visitor after every deploy was served an empty product and a false reason for
+ * it, until the next request regenerated it.
+ *
+ * So this is dynamic. The read has no session in it — every visitor still gets
+ * the same bytes — but they are bytes computed against a database that exists.
+ */
+export const dynamic = "force-dynamic";
 
 export async function GET() {
   const r = await readLeaderboard();

--- a/web/src/app/api/market/route.ts
+++ b/web/src/app/api/market/route.ts
@@ -1,7 +1,25 @@
 import { NextResponse } from "next/server";
 import { fetchMarket } from "@/lib/market";
 
-export const revalidate = 30;
+/**
+ * NOT PRERENDERED AT BUILD, and that is a correctness rule rather than a
+ * performance one.
+ *
+ * `export const revalidate = <n>` on an App-Router route or page is an OPT-IN
+ * TO BUILD-TIME PRERENDERING — Next runs the handler once inside `docker build`
+ * and ships the body. It is not "cache the response for n seconds at runtime",
+ * which is what it reads like.
+ *
+ * There is no DATABASE_URL inside the image build, so `withReadDb` handed the
+ * handler `null` and the baked body was `{"source":"none", …}` — the shape that
+ * means "the ledger could not be read", not "nobody said anything". Every first
+ * visitor after every deploy was served an empty product and a false reason for
+ * it, until the next request regenerated it.
+ *
+ * So this is dynamic. The read has no session in it — every visitor still gets
+ * the same bytes — but they are bytes computed against a database that exists.
+ */
+export const dynamic = "force-dynamic";
 
 export async function GET() {
   const data = await fetchMarket();

--- a/web/src/app/api/search/route.ts
+++ b/web/src/app/api/search/route.ts
@@ -18,7 +18,20 @@ import { withReadDb } from "@/lib/ledger";
 import { getIdentityStore } from "@merrymen/identity-store";
 import { fetchMarket } from "@/lib/market";
 
-export const revalidate = 30;
+/**
+ * A DEAD DIRECTIVE IS WORSE THAN NO DIRECTIVE, so it is gone.
+ *
+ * This carried `revalidate = 30`, which never took effect: the handler reads
+ * `req.url` for the query string, Next's request proxy throws a
+ * DynamicServerError the moment it does, and the route silently demotes to
+ * dynamic. So the line described a caching behaviour the route did not have,
+ * on a route that reads the ledger — the same shape of claim that left the
+ * home feed baked empty into the image.
+ *
+ * It is stated rather than deleted, because "search is dynamic" is a fact worth
+ * being explicit about on a route whose results depend on the caller's query.
+ */
+export const dynamic = "force-dynamic";
 
 export interface SearchHit {
   kind: "agent" | "token";

--- a/web/src/app/api/theses/route.ts
+++ b/web/src/app/api/theses/route.ts
@@ -22,7 +22,25 @@ import { readTheses } from "@/lib/read-theses";
 import type { PublicThesis } from "@/lib/thesis";
 
 /** Cacheable because the answer does not depend on who is asking. */
-export const revalidate = 30;
+/**
+ * NOT PRERENDERED AT BUILD, and that is a correctness rule rather than a
+ * performance one.
+ *
+ * `export const revalidate = <n>` on an App-Router route or page is an OPT-IN
+ * TO BUILD-TIME PRERENDERING — Next runs the handler once inside `docker build`
+ * and ships the body. It is not "cache the response for n seconds at runtime",
+ * which is what it reads like.
+ *
+ * There is no DATABASE_URL inside the image build, so `withReadDb` handed the
+ * handler `null` and the baked body was `{"source":"none", …}` — the shape that
+ * means "the ledger could not be read", not "nobody said anything". Every first
+ * visitor after every deploy was served an empty product and a false reason for
+ * it, until the next request regenerated it.
+ *
+ * So this is dynamic. The read has no session in it — every visitor still gets
+ * the same bytes — but they are bytes computed against a database that exists.
+ */
+export const dynamic = "force-dynamic";
 
 export interface ThesesResponse {
   source: "sqlite" | "none";

--- a/web/src/app/api/wall-tape/route.ts
+++ b/web/src/app/api/wall-tape/route.ts
@@ -8,7 +8,25 @@
 import { NextResponse } from "next/server";
 import { readWallTape } from "@/lib/read-wall-tape";
 
-export const revalidate = 30;
+/**
+ * NOT PRERENDERED AT BUILD, and that is a correctness rule rather than a
+ * performance one.
+ *
+ * `export const revalidate = <n>` on an App-Router route or page is an OPT-IN
+ * TO BUILD-TIME PRERENDERING — Next runs the handler once inside `docker build`
+ * and ships the body. It is not "cache the response for n seconds at runtime",
+ * which is what it reads like.
+ *
+ * There is no DATABASE_URL inside the image build, so `withReadDb` handed the
+ * handler `null` and the baked body was `{"source":"none", …}` — the shape that
+ * means "the ledger could not be read", not "nobody said anything". Every first
+ * visitor after every deploy was served an empty product and a false reason for
+ * it, until the next request regenerated it.
+ *
+ * So this is dynamic. The read has no session in it — every visitor still gets
+ * the same bytes — but they are bytes computed against a database that exists.
+ */
+export const dynamic = "force-dynamic";
 
 export async function GET() {
   const t = await readWallTape();

--- a/web/src/app/prerender.test.ts
+++ b/web/src/app/prerender.test.ts
@@ -1,0 +1,87 @@
+/**
+ * NOTHING THAT READS A DATABASE MAY BE BAKED INTO THE IMAGE.
+ *
+ * `export const revalidate = <n>` on an App-Router route or page reads like
+ * "cache the response for n seconds at runtime". It is not. In Next 15 it is an
+ * OPT-IN TO BUILD-TIME PRERENDERING: the handler runs once inside `docker
+ * build`, its body is written to disk, and that body is what the first
+ * requester after every deploy receives.
+ *
+ *   node_modules/next/dist/server/route-modules/app-route/helpers/
+ *     is-static-gen-enabled.js
+ *       revalidate !== undefined && revalidate > 0   -> prerender it
+ *
+ * There is no DATABASE_URL inside the image build. `withReadDb` therefore hands
+ * the handler `null`, every reader returns `{ source: "none", … }` — which means
+ * "the ledger could not be read", not "nobody said anything" — and that lie was
+ * baked in and served. The home feed and the leaderboard were both empty for
+ * the first visitor after every single deploy.
+ *
+ * This is a trap rather than a mistake: the directive is one word, it looks
+ * like a performance tweak, and nothing about it says "runs at build time".
+ * Which is exactly why it needs a test rather than a comment.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+const APP = path.join(process.cwd(), "web", "src", "app");
+
+function routeFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const p = path.join(dir, entry);
+    if (statSync(p).isDirectory()) routeFiles(p, out);
+    else if (entry === "route.ts" || entry === "page.tsx") out.push(p);
+  }
+  return out;
+}
+
+/** Everything that can reach the ledger, directly or through a reader. */
+const READS_THE_LEDGER = /withReadDb|read-theses|read-leaderboard|read-wall-tape|read-agent|@\/lib\/ledger/;
+
+describe("build-time prerendering never covers a database read", () => {
+  const files = routeFiles(APP);
+
+  it("finds the routes and pages, so a broken walk cannot pass vacuously", () => {
+    assert.ok(files.length > 20, `expected the app tree, saw ${files.length} files`);
+  });
+
+  it("no DB-backed route or page opts into prerendering", () => {
+    const offenders: string[] = [];
+    for (const f of files) {
+      const src = readFileSync(f, "utf8");
+      // Comments stripped first: the files that explain this trap NAME the
+      // directive, and a naive scan flags the very warning against it.
+      const code = src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+      if (!READS_THE_LEDGER.test(code)) continue;
+      const m = /export\s+const\s+revalidate\s*=\s*(\d[\d_]*)/.exec(code);
+      if (m && Number(m[1]!.replace(/_/g, "")) > 0) {
+        offenders.push(`${path.relative(APP, f)} (revalidate = ${m[1]})`);
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      "these read the ledger and would be prerendered at build, where there is no DATABASE_URL:\n  " +
+        offenders.join("\n  "),
+    );
+  });
+
+  it("the four surfaces this actually broke are dynamic", () => {
+    // Named individually rather than only covered by the sweep above, because
+    // these are the ones a real visitor hit: the home feed, the leaderboard
+    // page, and the two public APIs behind them.
+    for (const rel of [
+      path.join("(app)", "page.tsx"),
+      path.join("(app)", "leaderboard", "page.tsx"),
+      path.join("api", "theses", "route.ts"),
+      path.join("api", "leaderboard", "route.ts"),
+    ]) {
+      const code = readFileSync(path.join(APP, rel), "utf8")
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/(^|[^:])\/\/.*$/gm, "$1");
+      assert.match(code, /export\s+const\s+dynamic\s*=\s*"force-dynamic"/, `${rel} must be dynamic`);
+    }
+  });
+});


### PR DESCRIPTION
`export const revalidate = <n>` on an App-Router route or page reads like *"cache
the response for n seconds at runtime"*. In Next 15 it is an **opt-in to
build-time prerendering**:

```
is-static-gen-enabled.js
  revalidate !== undefined && revalidate > 0   -> prerender it
```

The handler runs once inside `docker build`, its body is written to disk, and
that body is what the **first requester after every deploy** receives.

There is no `DATABASE_URL` inside the image build. `withReadDb` handed every one
of these handlers `null`, and the baked body was `{"source":"none"}` — which
means *"the ledger could not be read"*, **not** *"nobody said anything"*.

## Six surfaces shipped that lie

| surface | what a first visitor saw |
|---|---|
| `(app)/page.tsx` | **the home feed, empty** |
| `(app)/leaderboard/page.tsx` | **the leaderboard, empty** |
| `api/theses` | no theses |
| `api/leaderboard` | no rankings |
| `api/wall-tape` | no tape |
| `api/market` | prices baked at build time, on a trading product |

It cost forty minutes to diagnose because it presents exactly as a database
outage — same symptom, same shape, and the DB was fine the whole time.

## `api/search` had the same directive, dead

It reads `req.url` for the query string, Next's request proxy throws a
`DynamicServerError` the moment it does, and the route silently demotes to
dynamic. A line describing caching the route does not have, on a route that
reads the ledger, is the same false claim in a quieter voice — so it now says
what it actually is.

## A test, because this is a trap rather than a mistake

`prerender.test.ts` walks the app tree, strips comments (the files that explain
this trap *name* the directive, and a naive scan flags the warning itself), and
fails on anything that both reaches the ledger and opts into prerendering.

**It found `api/search` on its first run** — which is the whole argument for
having it. The directive is one word, it looks like a performance tweak, and
nothing about it says "runs at build time".

`npm run typecheck` clean · **2290/2290** tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)