### PR TITLE
brain: put the lens verdicts and the economics on the trace line

### DIFF
--- a/worker/src/brain-shadow.ts
+++ b/worker/src/brain-shadow.ts
@@ -303,12 +303,28 @@ async function persist(
   }
 
   const d: BrainDecision = result.decision;
+  // WHERE THE LENSES LANDED, on the line rather than only in signals_json.
+  //
+  // The tape is the durable record and carries everything; this is the only
+  // view an operator has while a run is happening, and "it held" without "and
+  // every lens said no-data" is a trace that cannot be acted on. It is the
+  // difference between a hold that means the market is quiet and a hold that
+  // means the agent is blind — which is the distinction the whole shadow
+  // evaluation turns on.
+  const lenses = (d.analyst_views ?? [])
+    .map((v) => `${v.lens}:${v.direction}${v.direction === "no-data" ? "" : `/${v.confidence.toFixed(2)}`}`)
+    .join(" ");
   log(
     `[brain] ${d.action.toUpperCase()} ${d.symbol} conf=${d.confidence.toFixed(2)} ` +
       `delta=${d.suggested_delta_usdg} · depth=${d.depth_used}` +
       (d.escalation_reasons.length ? ` (escalated: ${d.escalation_reasons.join(", ")})` : "") +
       ` · ${d.cost.model_calls} calls ${d.cost.tokens_in + d.cost.tokens_out} tok ` +
       `$${d.cost.usd.toFixed(4)} ${result.seconds.toFixed(1)}s · decision ${d.decision_id}`,
+  );
+  if (lenses) log(`[brain] lenses ${lenses}`);
+  log(
+    `[brain] economics ${d.economics ?? "unknown"} · edge ${d.expected_edge_usdg ?? "—"} vs gas ` +
+      `${d.expected_trade_gas_usdg ?? "unpriced"} micro-USDG (advisory; nothing enforces it yet)`,
   );
 
   await addDecision({


### PR DESCRIPTION
The tape is the durable record and carries all of this in `signals_json`. The
log line is the only view an operator has **while a run is happening**, and
*"it held"* without *"and every lens returned `no-data`"* is a trace nobody can
act on.

That is the distinction the whole shadow evaluation turns on:

- a hold because **the market is quiet** — the reasoner working;
- a hold because **the agent is blind** — the reasoner correctly refusing.

Same word, completely different findings. Every production decision so far has
been the second one, and that was only visible by reading the thesis prose.

The trace now reads:

```
[brain] HOLD TSLA conf=0.00 delta=0 · depth=analysts · 5 calls 3797 tok $0.0010 1.9s · decision dec_…
[brain] lenses technical:no-data news:no-data sentiment:no-data fundamentals:no-data
[brain] economics unknown · edge — vs gas 764720 micro-USDG (advisory; nothing enforces it yet)
```

`npm run typecheck` clean · 48 brain tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)