### PR TITLE
security: a derived address is a result, and a binding names its model

### DIFF
--- a/mobile/src/crypto/signGrant.ts
+++ b/mobile/src/crypto/signGrant.ts
@@ -14,6 +14,7 @@ import {
   WALL_POLICY_FLAG,
   robinhoodChain,
   usableExtraTokens,
+  assertDerivedAccount,
   type CustomToken,
   type GrantCaps,
   type StoredGrant,
@@ -129,6 +130,15 @@ export async function signGrant(args: {
     plugins: { sudo: ecdsaValidator },
   });
 
+  // BEFORE THE WALL PINS VALUE TO IT. createKernelAccount resolves this with a
+  // live getSenderAddress eth_call and answers the zero address, without
+  // throwing, when the Kernel factory does not respond on this chain. The wall
+  // below would then pin its swap recipient and vault receiver to zero, the
+  // assertion further down would be satisfied by two zeros, and the phone would
+  // seal a grant for an account nobody owns. Identical guard to
+  // web/src/lib/session.ts - the two signers must refuse the same things.
+  assertDerivedAccount(sudoOnlyAccount.address, "the smart account could not be derived");
+
   say("assembling the wall");
   // Uniswap v4 is OFF — see WallOptions.allowUniswapV4. Kept in lockstep with
   // the GRANT_V4 marker below, and identical to web/src/lib/session.ts: the
@@ -166,6 +176,7 @@ export async function signGrant(args: {
   // Same premise check the dashboard makes: the wall's recipient pins are only
   // correct while the permission plugin leaves the address alone. Fail before
   // sealing, never after.
+  assertDerivedAccount(account.address, "the permissioned account could not be derived");
   if (account.address.toLowerCase() !== sudoOnlyAccount.address.toLowerCase()) {
     throw new Error(
       `refusing to sign: the permission plugin changed the account address ` +

--- a/packages/core/src/derivation.test.ts
+++ b/packages/core/src/derivation.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 
@@ -34,13 +34,23 @@ describe("a derived account address is a result, not a string", () => {
     assert.equal(d.ok === false && d.failure, "zero");
   });
 
-  it("checksummed zero, uppercase zero and the padded form are all refused", () => {
-    for (const z of [
-      UNDERIVED_ADDRESS,
-      UNDERIVED_ADDRESS.toUpperCase().replace("0X", "0x"),
-      "0x0000000000000000000000000000000000000000",
-    ]) {
-      assert.equal(derivationOf(z).ok, false, z);
+  it("every spelling of nothing is refused, and each under the right arm", () => {
+    // The first version of this test looped over three byte-identical strings,
+    // because zero has no letters and so no checksummed variant — it proved
+    // none of the three things it named. These genuinely differ.
+    const zeroLike: [unknown, "zero" | "malformed"][] = [
+      [UNDERIVED_ADDRESS, "zero"],
+      ["0x" + "0".repeat(40), "zero"],
+      ["0X" + "0".repeat(40), "malformed"], // capital X fails the shape test
+      ["0x" + "0".repeat(64), "malformed"], // a 32-byte word, not an address
+      ["0x0", "malformed"],
+      ["0", "malformed"],
+      [" " + UNDERIVED_ADDRESS, "malformed"], // not trimmed on the way in
+    ];
+    for (const [value, arm] of zeroLike) {
+      const d = derivationOf(value);
+      assert.equal(d.ok, false, String(value));
+      assert.equal(d.ok === false && d.failure, arm, String(value));
     }
   });
 
@@ -144,6 +154,38 @@ describe("every derivation call site routes through the guard", () => {
     assert.match(src, /if \(!derived\.ok\) return NextResponse\.json\(\{ error: derived\.why \}/);
   });
 
+  it("EVERY createKernelAccount in the tree is followed by an assert", () => {
+    // Hand-listing the files is what let the phone signer ship unguarded while
+    // this suite stayed green. Enumerate instead.
+    const roots = ["web/src", "worker/src", "packages/core/src", "mobile/src"];
+    const files: string[] = [];
+    const walk = (dir: string) => {
+      for (const e of readdirSync(join(ROOT, dir), { withFileTypes: true })) {
+        const rel = `${dir}/${e.name}`;
+        if (e.isDirectory()) walk(rel);
+        else if (/\.tsx?$/.test(e.name) && !/\.test\.tsx?$/.test(e.name)) files.push(rel);
+      }
+    };
+    for (const r of roots) walk(r);
+
+    const unguarded: string[] = [];
+    let examined = 0;
+    for (const f of files) {
+      const src = read(f);
+      if (!src.includes("createKernelAccount(")) continue;
+      examined += 1;
+      // derive-account.ts returns the result itself rather than asserting.
+      if (src.includes("return derivationOf(account.address)")) continue;
+      const derivations = [...src.matchAll(/await createKernelAccount\(/g)].length;
+      const asserts = [...src.matchAll(/assertDerivedAccount\(/g)].length;
+      if (asserts < derivations) unguarded.push(`${f} (${derivations} derivations, ${asserts} asserts)`);
+    }
+    // Non-vacuity: a walk that finds nothing would pass silently, which is the
+    // failure mode of every enumerating test.
+    assert.ok(examined >= 4, `expected several derivation sites, examined ${examined}`);
+    assert.deepEqual(unguarded, [], `these derive an account without asserting it: ${unguarded.join(", ")}`);
+  });
+
   it("the browser signer asserts the account before the wall is pinned to it", () => {
     const src = read("web/src/lib/session.ts");
     const guard = src.indexOf("assertDerivedAccount(sudoOnlyAccount.address");
@@ -151,6 +193,16 @@ describe("every derivation call site routes through the guard", () => {
     assert.ok(guard > 0, "the sudo-only derivation must be asserted");
     assert.ok(wall > 0);
     assert.ok(guard < wall, "the assert must come BEFORE the wall pins value to that address");
+  });
+
+  it("all four of session.ts's derivations are asserted, not just the first", () => {
+    const src = read("web/src/lib/session.ts");
+    assert.match(src, /assertDerivedAccount\(sudoOnlyAccount\.address/);
+    assert.match(src, /assertDerivedAccount\(account\.address, "the permissioned account/);
+    assert.match(src, /assertDerivedAccount\(account\.address, "that owner key does not derive/);
+    // And the preview keeps EIP-55 casing rather than the lowercase the guard
+    // normalises to — it is rendered beside addresses that are checksummed.
+    assert.match(src, /return \{ smartAccount: account\.address, owner: ownerAccount\.address \};/);
   });
 
   it("the worker refuses to arm against a zero, on both sides of its own equality", () => {

--- a/packages/core/src/derivation.test.ts
+++ b/packages/core/src/derivation.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+/** Repo root, from packages/core/src. */
+const ROOT = join(import.meta.dirname, "..", "..", "..");
+const read = (p: string) => readFileSync(join(ROOT, p), "utf8");
+
+import {
+  UNDERIVED_ADDRESS,
+  accountsMatch,
+  assertDerivedAccount,
+  derivationOf,
+  derivationUnreachable,
+} from "./derivation";
+
+const REAL = "0x3E34E58e39DC6614e047dFD3BAD5B7DEA45DCd62";
+const OTHER = "0x1102b20c835ff07DCA4eDC15F0B4C7d805bbB22F";
+
+describe("a derived account address is a result, not a string", () => {
+  it("a real address derives", () => {
+    const d = derivationOf(REAL);
+    assert.equal(d.ok, true);
+    assert.equal(d.ok && d.address, REAL.toLowerCase());
+  });
+
+  it("THE ZERO ADDRESS IS NOT AN ACCOUNT", () => {
+    // What createKernelAccount returns when getSenderAddress does not answer.
+    // It is a well-formed address, which is exactly why every syntactic check
+    // in the codebase used to wave it through.
+    const d = derivationOf(UNDERIVED_ADDRESS);
+    assert.equal(d.ok, false);
+    assert.equal(d.ok === false && d.failure, "zero");
+  });
+
+  it("checksummed zero, uppercase zero and the padded form are all refused", () => {
+    for (const z of [
+      UNDERIVED_ADDRESS,
+      UNDERIVED_ADDRESS.toUpperCase().replace("0X", "0x"),
+      "0x0000000000000000000000000000000000000000",
+    ]) {
+      assert.equal(derivationOf(z).ok, false, z);
+    }
+  });
+
+  it("anything that is not 20 hex bytes is malformed, not an address", () => {
+    for (const bad of [undefined, null, "", "0x", "not-an-address", "0x123", 42, {}, [REAL]]) {
+      const d = derivationOf(bad);
+      assert.equal(d.ok, false, String(bad));
+      assert.equal(d.ok === false && d.failure, "malformed", String(bad));
+    }
+  });
+
+  it("an unreachable derivation is its own failure, and carries a bounded reason", () => {
+    const d = derivationUnreachable("x".repeat(1000));
+    assert.equal(d.ok, false);
+    assert.equal(d.ok === false && d.failure, "unreachable");
+    assert.ok(d.ok === false && d.why.length <= 300);
+  });
+});
+
+describe("two failed derivations must never compare equal", () => {
+  /**
+   * THE BUG THIS FILE EXISTS FOR.
+   *
+   * The browser derives the account and the server re-derives it, and the
+   * hosted custody boundary is the equality between them. Both call the same
+   * SDK against the same chain, so when the Kernel factory does not answer they
+   * fail IDENTICALLY — and an equality test on the returned strings then says
+   * the account is verified. The fault does not make the check fail; it makes
+   * the check pass.
+   */
+  it("browser derives zero, server derives zero, and that is NOT a match", () => {
+    const server = derivationOf(UNDERIVED_ADDRESS); // what the route computed
+    const browser = UNDERIVED_ADDRESS; // what the grant claimed
+    // The raw comparison the code used to make would have been true:
+    assert.equal(UNDERIVED_ADDRESS.toLowerCase() === browser.toLowerCase(), true);
+    // The one it makes now is not:
+    const m = accountsMatch(server, browser);
+    assert.equal(m.ok, false);
+    assert.match(m.ok === false ? m.why : "", /zero address/);
+  });
+
+  it("an unreachable derivation cannot be matched against anything, including itself", () => {
+    const m = accountsMatch(derivationUnreachable("rpc timeout"), REAL);
+    assert.equal(m.ok, false);
+  });
+
+  it("a real derivation still matches its own claim", () => {
+    assert.equal(accountsMatch(derivationOf(REAL), REAL).ok, true);
+    assert.equal(accountsMatch(derivationOf(REAL), REAL.toLowerCase()).ok, true);
+  });
+
+  it("a real derivation refuses a different claim", () => {
+    const m = accountsMatch(derivationOf(REAL), OTHER);
+    assert.equal(m.ok, false);
+    assert.match(m.ok === false ? m.why : "", /does not derive/);
+  });
+
+  it("a real derivation refuses a zero CLAIM as well as a zero derivation", () => {
+    // The other direction: the server derived fine, the client claimed zero.
+    const m = accountsMatch(derivationOf(REAL), UNDERIVED_ADDRESS);
+    assert.equal(m.ok, false);
+  });
+});
+
+describe("the signer refuses to seal a grant around a zero", () => {
+  it("assertDerivedAccount throws on zero, and names what failed", () => {
+    assert.throws(
+      () => assertDerivedAccount(UNDERIVED_ADDRESS, "the smart account could not be derived"),
+      /the smart account could not be derived/,
+    );
+  });
+
+  it("assertDerivedAccount returns the lowercased address on success", () => {
+    assert.equal(assertDerivedAccount(REAL, "x"), REAL.toLowerCase());
+  });
+});
+
+describe("every derivation call site routes through the guard", () => {
+  // Source-reading, because the property is "nobody returns account.address
+  // raw" and that cannot be asserted from behaviour without a live chain.
+
+  it("the server-side deriver returns a Derivation, never a bare address", () => {
+    const src = read("web/src/lib/derive-account.ts");
+    assert.match(src, /Promise<Derivation>/, "deriveKernelAccountAddress must return a result type");
+    assert.match(src, /return derivationOf\(account\.address\)/);
+    assert.doesNotMatch(src, /return account\.address;/, "a bare address would skip the zero check");
+  });
+
+  it("the hosted grant intake compares with accountsMatch, not with ===", () => {
+    const src = read("web/src/app/api/grants/route.ts");
+    assert.match(src, /accountsMatch\(derived, grant\.smartAccount\)/);
+    assert.doesNotMatch(
+      src,
+      /derived\.toLowerCase\(\)\s*!==\s*grant\.smartAccount\.toLowerCase\(\)/,
+      "a raw string comparison is what two zeros satisfy",
+    );
+  });
+
+  it("the recovery ticket refuses to mint on a failed derivation", () => {
+    const src = read("web/src/app/api/recover/ticket/route.ts");
+    assert.match(src, /if \(!derived\.ok\) return NextResponse\.json\(\{ error: derived\.why \}/);
+  });
+
+  it("the browser signer asserts the account before the wall is pinned to it", () => {
+    const src = read("web/src/lib/session.ts");
+    const guard = src.indexOf("assertDerivedAccount(sudoOnlyAccount.address");
+    const wall = src.indexOf("buildWallPolicies({");
+    assert.ok(guard > 0, "the sudo-only derivation must be asserted");
+    assert.ok(wall > 0);
+    assert.ok(guard < wall, "the assert must come BEFORE the wall pins value to that address");
+  });
+
+  it("the worker refuses to arm against a zero, on both sides of its own equality", () => {
+    const src = read("worker/src/session-account.ts");
+    assert.match(src, /assertDerivedAccount\(derived\.address/);
+    assert.match(src, /assertDerivedAccount\(params\.accountParams\.accountAddress/);
+  });
+});

--- a/packages/core/src/derivation.ts
+++ b/packages/core/src/derivation.ts
@@ -62,8 +62,11 @@ export type Derivation =
 /**
  * Read whatever the SDK handed back as a derivation result.
  *
- * The zero address is checked BEFORE the shape, because zero is a well-formed
- * address and would otherwise pass every syntactic test there is.
+ * SHAPE FIRST, THEN ZERO. The order is not the interesting part — the two
+ * checks are disjoint, and any encoding of zero that is not exactly forty hex
+ * characters is refused by the shape test as `malformed` rather than by the
+ * zero test. What matters is that zero IS a well-formed address, so it passes
+ * every syntactic test there is and needs a check of its own.
  */
 export function derivationOf(value: unknown): Derivation {
   if (typeof value !== "string" || !ADDRESS_RE.test(value)) {

--- a/packages/core/src/derivation.ts
+++ b/packages/core/src/derivation.ts
@@ -1,0 +1,134 @@
+/**
+ * A DERIVED ACCOUNT ADDRESS IS A RESULT, NOT A STRING.
+ *
+ * The counterfactual Kernel address is the single fact the hosted custody
+ * boundary rests on: `web/src/app/api/grants/route.ts` proves a tenant owns the
+ * account it claims by re-deriving the address from the owner and requiring the
+ * two to be equal. That check is only as good as the derivation under it, and
+ * the derivation has a failure mode that returns a value instead of throwing.
+ *
+ * WHAT GOES WRONG. `createKernelAccount` does not compute the address offline —
+ * it asks the EntryPoint, via `getSenderAddress`, which is a live eth_call. When
+ * that answers the zero address the SDK retries against the bare factory, and if
+ * THAT also answers zero it restores `useMetaFactory` and carries on with
+ * `accountAddress = 0x0000...0000`, throwing nothing
+ * (@zerodev/sdk/accounts/kernel/createKernelAccount.ts:540-551). So a chain
+ * whose factory is missing, an RPC that returns a malformed result, or a
+ * transient node fault all produce the zero address and present as a SUCCESSFUL
+ * derivation.
+ *
+ * WHY THAT IS WORSE THAN AN ERROR. The route's guard is an equality test. If the
+ * browser derived zero and the server also derived zero — same chain, same
+ * absent factory, same fault — the two agree, `session.ts`'s own
+ * plugin-does-not-move-the-address assertion passes trivially because both sides
+ * are zero, and a grant is sealed for the zero address. A fail-closed 503 cannot
+ * fire, because nothing failed. The check does not merely miss the fault; the
+ * fault makes it pass.
+ *
+ * SO THE ZERO ADDRESS IS NOT AN ADDRESS HERE. `derivationOf` refuses it, along
+ * with anything that is not 20 hex bytes, and `accountsMatch` refuses to compare
+ * a derivation that failed. Two failures can never be "equal": there is no code
+ * path on which a caller holds two `Derivation` values and gets `true` without
+ * both being real addresses. That is the property, and it is enforced by the
+ * types rather than by everyone remembering to check.
+ *
+ * PURE. No RPC, no viem, no chain. Imported by the browser signer, the hosted
+ * intake, the recovery ticket and the worker.
+ */
+
+/**
+ * The address that means "we did not derive anything".
+ *
+ * Written out rather than imported from viem so this module stays dependency-
+ * free and so the constant is greppable — the whole point is that this value
+ * must never travel as a smart account.
+ */
+export const UNDERIVED_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+/** Exactly 20 hex bytes, either case. */
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+
+/**
+ * Why a derivation produced nothing usable. Each arm is a different remedy:
+ * `unreachable` is retried, `zero` means the factory is absent on that chain,
+ * `malformed` means the provider answered something that is not an address.
+ */
+export type DerivationFailure = "zero" | "malformed" | "unreachable";
+
+export type Derivation =
+  | { ok: true; address: `0x${string}` }
+  | { ok: false; failure: DerivationFailure; why: string };
+
+/**
+ * Read whatever the SDK handed back as a derivation result.
+ *
+ * The zero address is checked BEFORE the shape, because zero is a well-formed
+ * address and would otherwise pass every syntactic test there is.
+ */
+export function derivationOf(value: unknown): Derivation {
+  if (typeof value !== "string" || !ADDRESS_RE.test(value)) {
+    return {
+      ok: false,
+      failure: "malformed",
+      why: "the account derivation did not return an address",
+    };
+  }
+  if (value.toLowerCase() === UNDERIVED_ADDRESS) {
+    return {
+      ok: false,
+      failure: "zero",
+      why:
+        "the account derivation returned the zero address, which means the Kernel factory " +
+        "did not answer on this chain — it is not an account",
+    };
+  }
+  return { ok: true, address: value.toLowerCase() as `0x${string}` };
+}
+
+/** A derivation that could not be attempted at all. */
+export function derivationUnreachable(detail: string): Derivation {
+  return {
+    ok: false,
+    failure: "unreachable",
+    why: `the account derivation could not be verified: ${detail}`.slice(0, 300),
+  };
+}
+
+export type AccountMatch = { ok: true } | { ok: false; why: string };
+
+/**
+ * Does a claimed smart account equal a derived one?
+ *
+ * TAKES THE RESULT, NOT THE ADDRESS, on purpose. The interesting bug is not
+ * "the addresses differed" — it is "both sides failed identically and their
+ * failures compared equal". A caller cannot reach the comparison without
+ * holding a successful derivation, so that bug has nowhere to live.
+ */
+export function accountsMatch(derived: Derivation, claimed: unknown): AccountMatch {
+  if (!derived.ok) return { ok: false, why: derived.why };
+  const other = derivationOf(claimed);
+  if (!other.ok) {
+    return {
+      ok: false,
+      why: `the claimed smart account is not usable: ${other.why}`,
+    };
+  }
+  if (other.address !== derived.address) {
+    return { ok: false, why: "this smart account does not derive from the signed-in wallet" };
+  }
+  return { ok: true };
+}
+
+/**
+ * Refuse an address that a signer is about to seal into a grant.
+ *
+ * The browser derives its own account rather than asking the server, so the
+ * same zero has to be refused there — and it has to be refused BEFORE the
+ * sudo-only / sudo+wall comparison at web/src/lib/session.ts, which two zeros
+ * would otherwise satisfy.
+ */
+export function assertDerivedAccount(value: unknown, what: string): `0x${string}` {
+  const d = derivationOf(value);
+  if (!d.ok) throw new Error(`refusing to continue: ${what} — ${d.why}`);
+  return d.address;
+}

--- a/packages/core/src/grant.ts
+++ b/packages/core/src/grant.ts
@@ -202,13 +202,90 @@ export interface GrantCaps {
  *   chainId — merrymen runs testnet 46630 and mainnet 4663; without it one
  *             signature would bind on both
  */
-export function bindingMessage(args: {
-  origin: string;
-  nonce: string;
-  owner: `0x${string}`;
-  smartAccount: `0x${string}`;
-  chainId: number;
-}): string {
+/**
+ * WHICH SECURITY MODEL A BINDING WAS MADE UNDER. Never inferred.
+ *
+ * Both versions prove the same two things — that the person is who they say
+ * they are, and that they hold the key the account derives from — but they
+ * prove them with different evidence, and the evidence is not interchangeable:
+ *
+ *   legacy-wallet-owner-v1  the login wallet signs (authentication) and a
+ *                           SEPARATE browser-held owner key co-signs the same
+ *                           text (owner authority). Two keys, two signatures.
+ *
+ *   privy-did-owner-v1      a verified Privy access token carries the DID
+ *                           (authentication) and the embedded owner wallet
+ *                           signs the challenge (owner authority). One key may
+ *                           serve as both the identity anchor and the owner —
+ *                           the proofs are still separate, because one of them
+ *                           is a JWT the server verified and the other is a
+ *                           signature over a server-issued nonce.
+ *
+ * They are versioned rather than merged because a validator that accepted both
+ * shapes would have to decide, per request, which evidence it was looking at —
+ * and the wrong guess in either direction is a downgrade. A binding whose
+ * version this deployment does not recognise is refused, not best-guessed.
+ */
+export type BindingVersion = "legacy-wallet-owner-v1" | "privy-did-owner-v1";
+
+/**
+ * What an absent `version` means, and why that is a fact rather than a guess.
+ *
+ * Every grant signed before this field existed was made under the two-signature
+ * browser-owner model, because that was the only model there was. So absent
+ * resolves to legacy by CONSTRUCTION, not by falling through a default — and it
+ * resolves to the STRICTER of the two, which needs two independent signatures.
+ * An unrecognised version string is a refusal.
+ */
+export const DEFAULT_BINDING_VERSION: BindingVersion = "legacy-wallet-owner-v1";
+
+export function isBindingVersion(v: unknown): v is BindingVersion {
+  return v === "legacy-wallet-owner-v1" || v === "privy-did-owner-v1";
+}
+
+/** What a claim binds, by version. `did` exists on exactly the arm that needs it. */
+export type BindingClaim =
+  | {
+      version?: "legacy-wallet-owner-v1";
+      origin: string;
+      nonce: string;
+      owner: `0x${string}`;
+      smartAccount: `0x${string}`;
+      chainId: number;
+    }
+  | {
+      version: "privy-did-owner-v1";
+      origin: string;
+      nonce: string;
+      owner: `0x${string}`;
+      smartAccount: `0x${string}`;
+      chainId: number;
+      /** The Privy DID the access token was verified to carry. */
+      did: string;
+    };
+
+export function bindingMessage(args: BindingClaim): string {
+  if (args.version === "privy-did-owner-v1") {
+    // THE DID IS IN THE SIGNED TEXT. Without it the owner signature would say
+    // "this key authorizes account X" and name no identity at all — it would
+    // verify just as well when replayed under somebody else's login. Under the
+    // legacy version the second signature carries that job; here the text does.
+    return [
+      `${args.origin} wants you to authorize a merrymen agent account.`,
+      "",
+      "You are linking the agent wallet below to your merrymen identity. It moves no funds.",
+      "",
+      `Agent account: ${args.smartAccount.toLowerCase()}`,
+      `Owner key: ${args.owner.toLowerCase()}`,
+      `Identity: ${args.did}`,
+      `Chain ID: ${args.chainId}`,
+      `URI: ${args.origin}`,
+      `Nonce: ${args.nonce}`,
+    ].join("\n");
+  }
+  // THE LEGACY TEXT IS FROZEN, BYTE FOR BYTE. Grants signed by a browser that
+  // has not reloaded are still in flight, and a signature is over the exact
+  // bytes — change a space here and every one of them stops verifying.
   return [
     `${args.origin} wants you to authorize a merrymen agent account.`,
     "",
@@ -292,12 +369,30 @@ export interface StoredGrant {
    * no tenant to bind to.
    */
   binding?: {
-    /** The nonce both signatures were made over. Server-issued, single-use. */
+    /**
+     * Which security model this claim was made under. ABSENT MEANS LEGACY, and
+     * that is a statement about history rather than a default: the field did
+     * not exist when those grants were signed, and the only model that existed
+     * then was the two-signature one. See DEFAULT_BINDING_VERSION.
+     */
+    version?: BindingVersion;
+    /** The nonce the signature(s) were made over. Server-issued, single-use. */
     nonce: string;
-    /** personal_sign by the signed-in wallet — must recover to the tenant. */
-    walletSignature: `0x${string}`;
-    /** personal_sign by the generated owner key — must recover to `owner`. */
+    /**
+     * personal_sign by the signed-in wallet — must recover to the tenant.
+     * LEGACY ONLY. Under `privy-did-owner-v1` authentication is the verified
+     * access token, so there is no second signature and this is absent.
+     */
+    walletSignature?: `0x${string}`;
+    /** personal_sign by the owner key — must recover to `owner`. Both versions. */
     ownerSignature: `0x${string}`;
+    /**
+     * The Privy DID this account is being bound to, echoed so the server can
+     * reconstruct the signed text. NEVER TRUSTED AS AN IDENTITY — the server
+     * compares it to the DID it verified out of the access token and refuses on
+     * any difference. `privy-did-owner-v1` only.
+     */
+    did?: string;
   };
   /** TESTNET ONLY — production signers live in a TEE, never serialized. */
   demoSessionPrivateKey: `0x${string}`;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from "./token";
 export * from "./protocols";
 export * from "./abis";
 export * from "./grant";
+export * from "./derivation";
 export * from "./hosted";
 export * from "./wall";
 export * from "./mcp";

--- a/web/src/app/api/grants/route.ts
+++ b/web/src/app/api/grants/route.ts
@@ -11,7 +11,17 @@ import path from "node:path";
 import { NextResponse } from "next/server";
 import { homePaths, merrymenHome } from "@merrymen/home";
 import { createPublicClient, http, parseAbi } from "viem";
-import { CASH, MORPHO, carriesOwnerKey, chainForId, isHostedMode, type StoredGrant } from "@merrymen/core";
+import {
+  CASH,
+  MORPHO,
+  accountsMatch,
+  carriesOwnerKey,
+  chainForId,
+  derivationUnreachable,
+  isHostedMode,
+  type Derivation,
+  type StoredGrant,
+} from "@merrymen/core";
 import { requestOrigin, tenantOf, verifyGrantBinding } from "@/lib/auth";
 import { withReadDb } from "@/lib/ledger";
 import { getGrantStore } from "@merrymen/grant-store";
@@ -120,7 +130,10 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "grant owner is not an address" }, { status: 400 });
     }
     const binding = grant.binding;
-    if (!binding?.nonce || !binding.walletSignature || !binding.ownerSignature) {
+    // Version-agnostic presence check. WHICH signatures a claim needs is the
+    // validator's decision, not this route's — demanding a walletSignature here
+    // would hard-code the legacy model into a route that is about to serve two.
+    if (!binding?.nonce || !binding.ownerSignature) {
       return NextResponse.json(
         { error: "this grant isn't linked to your login — create it again from a signed-in browser" },
         { status: 403 },
@@ -171,20 +184,27 @@ export async function POST(req: Request) {
     // Fail CLOSED: if derivation can't be verified (bad chain id, RPC hiccup),
     // refuse rather than trust the client — a rejected honest grant is retried, a
     // trusted dishonest one is not undoable.
-    let derived: `0x${string}`;
+    //
+    // THE COMPARISON TAKES THE RESULT, NOT THE ADDRESS. The derivation is a
+    // live eth_call that can answer 0x0000...0000 without throwing, and if the
+    // browser answered the same zero the two would MATCH — the fault would make
+    // this check pass rather than fail. accountsMatch refuses a failed
+    // derivation before any equality is computed. See packages/core/derivation.
+    let derived: Derivation;
     try {
       derived = await deriveKernelAccountAddress(grant.owner as `0x${string}`, grant.chainId);
-    } catch {
-      return NextResponse.json(
-        { error: "couldn't verify the account derivation — please try again" },
-        { status: 503 },
-      );
+    } catch (e) {
+      derived = derivationUnreachable(e instanceof Error ? e.message : String(e));
     }
-    if (derived.toLowerCase() !== grant.smartAccount.toLowerCase()) {
-      return NextResponse.json(
-        { error: "this smart account does not derive from the signed-in wallet" },
-        { status: 403 },
-      );
+    if (!derived.ok) {
+      // `zero` and `malformed` are the chain answering wrongly, not the client
+      // claiming wrongly — 503 so an honest grant is retried rather than told
+      // its account is a forgery.
+      return NextResponse.json({ error: derived.why }, { status: 503 });
+    }
+    const match = accountsMatch(derived, grant.smartAccount);
+    if (!match.ok) {
+      return NextResponse.json({ error: match.why }, { status: 403 });
     }
 
     // Persist to the per-tenant store, keyed on the authenticated tenant. The

--- a/web/src/app/api/grants/route.ts
+++ b/web/src/app/api/grants/route.ts
@@ -139,6 +139,16 @@ export async function POST(req: Request) {
         { status: 403 },
       );
     }
+    // A CLAIM MAY NOT CARRY EVIDENCE ITS OWN VERSION DOES NOT USE. `did` is
+    // only meaningful under `privy-did-owner-v1`; arriving on a legacy claim it
+    // is unverified client text that would be persisted verbatim and read back
+    // later as though the server had checked it.
+    if (binding.did !== undefined && binding.version !== "privy-did-owner-v1") {
+      return NextResponse.json(
+        { error: "this grant carries an identity its binding version does not verify" },
+        { status: 400 },
+      );
+    }
     const bound = await verifyGrantBinding({
       origin: requestOrigin(req),
       tenant,
@@ -148,6 +158,14 @@ export async function POST(req: Request) {
       chainId: grant.chainId,
       walletSignature: binding.walletSignature,
       ownerSignature: binding.ownerSignature,
+      // PASSED THROUGH UNVALIDATED, ON PURPOSE. verifyGrantBinding is the one
+      // place that decides which security model a claim was made under, and it
+      // refuses anything it does not recognise. Omitting this — which an
+      // earlier revision of this file did — makes the whole dispatch
+      // unreachable: every claim resolves to the default, so a grant declaring
+      // `privy-did-owner-v1` would be verified under LEGACY rules instead of
+      // refused, which is precisely the downgrade the versioning exists to stop.
+      version: binding.version,
     });
     if (!bound.ok) {
       return NextResponse.json({ error: bound.why }, { status: 403 });

--- a/web/src/app/api/recover/ticket/route.ts
+++ b/web/src/app/api/recover/ticket/route.ts
@@ -85,9 +85,16 @@ export async function POST(req: Request) {
   // Owner ADDRESS only. deriveKernelAccountAddress builds a view-only signer
   // whose signing methods throw, so this path cannot handle key material even
   // by accident.
+  //
+  // A FAILED DERIVATION MUST NOT MINT A TICKET. The zero address is what this
+  // call returns when the Kernel factory does not answer, and a ticket naming
+  // 0x0000...0000 would send a recovery sweep at an account nobody owns — the
+  // relay's `sender === ticket.smartAccount` check would even pass for it.
   let smartAccount: `0x${string}`;
   try {
-    smartAccount = (await deriveKernelAccountAddress(owner, chainId)) as `0x${string}`;
+    const derived = await deriveKernelAccountAddress(owner, chainId);
+    if (!derived.ok) return NextResponse.json({ error: derived.why }, { status: 502 });
+    smartAccount = derived.address;
   } catch {
     return NextResponse.json({ error: "could not derive the account for that owner" }, { status: 502 });
   }

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -19,7 +19,13 @@
  */
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import { recoverMessageAddress } from "viem";
-import { bindingMessage, sessionSecret } from "@merrymen/core";
+import {
+  DEFAULT_BINDING_VERSION,
+  bindingMessage,
+  isBindingVersion,
+  sessionSecret,
+  type BindingVersion,
+} from "@merrymen/core";
 
 /** Challenge nonces live this long. Long enough to sign, short enough to not linger. */
 const CHALLENGE_TTL_MS = 5 * 60_000;
@@ -220,15 +226,62 @@ export async function verifyGrantBinding(args: {
   owner: `0x${string}`;
   smartAccount: `0x${string}`;
   chainId: number;
-  walletSignature: `0x${string}`;
+  /** Required by `legacy-wallet-owner-v1`; absent under `privy-did-owner-v1`. */
+  walletSignature?: `0x${string}`;
   ownerSignature: `0x${string}`;
+  /**
+   * Whatever the grant claimed. UNTRUSTED — an unrecognised value is refused
+   * rather than resolved to a default, because the two versions accept
+   * different evidence and guessing wrong is a downgrade in one direction or
+   * the other.
+   */
+  version?: unknown;
   now?: number;
 }): Promise<BindingResult> {
+  // ── WHICH SECURITY MODEL, DECIDED ONCE AND OUT LOUD ──────────────────────
+  //
+  // Absent resolves to legacy because the field did not exist when those grants
+  // were signed and the two-signature model was the only one there was — that
+  // is history, not a fallback. Anything else that is not a version we know is
+  // refused here, before a signature is recovered.
+  const version: BindingVersion =
+    args.version === undefined || args.version === null
+      ? DEFAULT_BINDING_VERSION
+      : isBindingVersion(args.version)
+        ? args.version
+        : ("unrecognised" as BindingVersion);
+  if (!isBindingVersion(version)) {
+    return { ok: false, why: "this grant's binding version is not one this deployment verifies" };
+  }
+  if (version === "privy-did-owner-v1") {
+    // PR B implements this arm. Refusing is the correct behaviour until then:
+    // a deployment that cannot verify a Privy binding must not fall back to
+    // verifying it as a legacy one, which would read a single owner signature
+    // as if it were two independent proofs.
+    return {
+      ok: false,
+      why: "privy bindings are not enabled on this deployment yet",
+    };
+  }
+
   const now = args.now ?? Date.now();
   const gate = checkNonce(args.nonce, args.origin, now);
   if (!gate.ok) return { ok: false, why: gate.why };
 
+  // ── legacy-wallet-owner-v1: TWO KEYS, TWO SIGNATURES ─────────────────────
+  //
+  // This version's whole content is that authentication and owner authority
+  // come from DIFFERENT keys. One key signing twice satisfies both recoveries
+  // arithmetically while proving only half of what the model claims, so the
+  // arm asserts its own premise. This is not a global rule that an owner may
+  // never equal a tenant — `privy-did-owner-v1` allows exactly that, and gets
+  // its authentication from a verified token instead.
+  if (!args.walletSignature) {
+    return { ok: false, why: "this grant is missing the login signature" };
+  }
+
   const message = bindingMessage({
+    version: "legacy-wallet-owner-v1",
     origin: args.origin,
     nonce: args.nonce,
     owner: args.owner,
@@ -252,6 +305,18 @@ export async function verifyGrantBinding(args: {
   }
   if (ownerSigner.toLowerCase() !== args.owner.toLowerCase()) {
     return { ok: false, why: "the agent wallet did not co-sign — its owner key is not held here" };
+  }
+  // THE SECOND PROOF MUST BE A SECOND PROOF. Under this version the owner key
+  // is minted in the browser and cannot be the login wallet, so two recoveries
+  // landing on one address means one key signed twice — the co-signature that
+  // makes this claim unforgeable was never made. Refuse rather than count it.
+  if (ownerSigner.toLowerCase() === walletSigner.toLowerCase()) {
+    return {
+      ok: false,
+      why:
+        "this claim carries only one proof: the login signature and the owner co-signature " +
+        "came from the same key, so nothing independently proves the owner key is held here",
+    };
   }
 
   usedNonces.add(args.nonce);

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -27,6 +27,26 @@ import {
   type BindingVersion,
 } from "@merrymen/core";
 
+/**
+ * IS THE LEGACY TWO-PROOF PREMISE ENFORCED YET?
+ *
+ * `legacy-wallet-owner-v1` claims that authentication and owner authority come
+ * from two different keys. One key signing twice satisfies the arithmetic while
+ * proving only half of that — so the check below is correct, and it is OFF.
+ *
+ * MEASURED FIRST, THEN ENFORCED. `restoreAgentWallet` accepts any 64-hex key,
+ * so a user may have pasted the private key of the wallet they sign in with.
+ * That is a custody pattern nobody has measured, not a broken account, and
+ * switching the rule on before counting it would have those users discover it
+ * at re-arm time — an agent that stops working, with no warning and no
+ * migration path. The census is in worker/src/identity-audit.ts
+ * (`owner is tenant`); this becomes `true` when it reports zero.
+ *
+ * Same shape as ENFORCE_TRADE_ECONOMICS in worker/src/execution-cost.ts, and
+ * for the same reason: a rule worth enforcing is worth observing first.
+ */
+export const ENFORCE_LEGACY_TWO_PROOF = false;
+
 /** Challenge nonces live this long. Long enough to sign, short enough to not linger. */
 const CHALLENGE_TTL_MS = 5 * 60_000;
 /** A session cookie is good for this long before the wallet must re-sign. */
@@ -311,11 +331,23 @@ export async function verifyGrantBinding(args: {
   if (ownerSigner.toLowerCase() !== args.owner.toLowerCase()) {
     return { ok: false, why: "the agent wallet did not co-sign — its owner key is not held here" };
   }
-  // THE SECOND PROOF MUST BE A SECOND PROOF. Under this version the owner key
-  // is minted in the browser and cannot be the login wallet, so two recoveries
-  // landing on one address means one key signed twice — the co-signature that
-  // makes this claim unforgeable was never made. Refuse rather than count it.
-  if (ownerSigner.toLowerCase() === walletSigner.toLowerCase()) {
+  // THE SECOND PROOF SHOULD BE A SECOND PROOF — MEASURED BEFORE IT IS ENFORCED.
+  //
+  // Under this version the owner key is minted in the browser, so two
+  // recoveries landing on one address means one key signed twice and the
+  // co-signature that makes the claim unforgeable was never made. That is the
+  // right rule and it is switched OFF, because `restoreAgentWallet` accepts any
+  // 64-hex key and somebody may have pasted the private key of the wallet they
+  // sign in with. Such an account is not malicious and not broken; it is a
+  // custody pattern nobody measured. Enforcing first would have it discovered
+  // at RE-ARM time, by a person whose agent stops working with no warning and
+  // no migration.
+  //
+  // The census lives in worker/src/identity-audit.ts and reads
+  // `grant_json->>'owner'` against the tenant. Flip this to `true` when that
+  // count is zero — the same shape as ENFORCE_TRADE_ECONOMICS, and for the same
+  // reason: the rule is computed and recorded long before it decides anything.
+  if (ENFORCE_LEGACY_TWO_PROOF && ownerSigner.toLowerCase() === walletSigner.toLowerCase()) {
     return {
       ok: false,
       // SAY WHAT IS TRUE AND WHAT TO DO. It is not that possession is

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -277,7 +277,12 @@ export async function verifyGrantBinding(args: {
   // never equal a tenant — `privy-did-owner-v1` allows exactly that, and gets
   // its authentication from a verified token instead.
   if (!args.walletSignature) {
-    return { ok: false, why: "this grant is missing the login signature" };
+    return {
+      ok: false,
+      // The route used to refuse this with an instruction. Moving the check
+      // into the validator must not cost the user the remedy.
+      why: "this grant is missing the login signature — create it again from a signed-in browser",
+    };
   }
 
   const message = bindingMessage({
@@ -313,9 +318,14 @@ export async function verifyGrantBinding(args: {
   if (ownerSigner.toLowerCase() === walletSigner.toLowerCase()) {
     return {
       ok: false,
+      // SAY WHAT IS TRUE AND WHAT TO DO. It is not that possession is
+      // unproven — one key signing twice does prove possession of that key.
+      // It is that this version's two proofs collapsed into one, because the
+      // agent is owned by the very key used to sign in.
       why:
-        "this claim carries only one proof: the login signature and the owner co-signature " +
-        "came from the same key, so nothing independently proves the owner key is held here",
+        "the key that owns this agent is the same key you sign in with, so this claim carries " +
+        "one proof where it needs two. A hosted agent needs its own generated owner key — create " +
+        "a new agent and sweep the old one from the recovery panel",
     };
   }
 

--- a/web/src/lib/binding-version.test.ts
+++ b/web/src/lib/binding-version.test.ts
@@ -1,0 +1,182 @@
+/**
+ * WHICH SECURITY MODEL A CLAIM WAS MADE UNDER, AND WHY IT IS NEVER GUESSED.
+ *
+ * Merrymen is about to have two ways of proving the same two facts:
+ *
+ *   legacy-wallet-owner-v1  the login wallet signs, and a SEPARATE browser-held
+ *                           owner key co-signs. Authentication and owner
+ *                           authority come from two different keys.
+ *   privy-did-owner-v1      a verified Privy access token carries the identity,
+ *                           and the embedded owner wallet signs the challenge.
+ *                           One key may be both anchor and owner; the proofs
+ *                           are still separate, because one of them is a token
+ *                           the server verified.
+ *
+ * A validator that tried to serve both from one shape would have to decide, per
+ * request, which evidence it was looking at — and the wrong guess in either
+ * direction is a downgrade. The dangerous one is specific and silent: under
+ * Privy the owner and the identity anchor can be the same key, so a single
+ * signature would satisfy BOTH arms of the legacy check, and every existing
+ * test would still pass. That is the case this file exists to make loud.
+ *
+ * Real viem signatures, no mocks.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { DEFAULT_BINDING_VERSION, bindingMessage, isBindingVersion } from "@merrymen/core";
+
+process.env.MERRYMEN_SESSION_SECRET = "test-secret-at-least-thirty-two-characters-long";
+
+import { issueChallengeNonce, verifyGrantBinding } from "./auth";
+
+const ORIGIN = "https://app.merrymen.dev";
+const SMART = "0x00000000000000000000000000000000000000a1" as `0x${string}`;
+const CHAIN = 4663;
+
+type Signer = ReturnType<typeof privateKeyToAccount>;
+
+/** A legacy claim: the wallet authorizes, the owner key co-signs the same text. */
+async function legacyClaim(wallet: Signer, owner: Signer, version?: unknown) {
+  const nonce = issueChallengeNonce(ORIGIN);
+  const message = bindingMessage({
+    origin: ORIGIN,
+    nonce,
+    owner: owner.address,
+    smartAccount: SMART,
+    chainId: CHAIN,
+  });
+  return {
+    origin: ORIGIN,
+    tenant: wallet.address.toLowerCase() as `0x${string}`,
+    nonce,
+    owner: owner.address,
+    smartAccount: SMART,
+    chainId: CHAIN,
+    walletSignature: await wallet.signMessage({ message }),
+    ownerSignature: await owner.signMessage({ message }),
+    ...(version === undefined ? {} : { version }),
+  };
+}
+
+test("an absent version is legacy — by history, not by falling through a default", async () => {
+  // Every grant signed before the field existed was made under the
+  // two-signature model, because it was the only model there was. And the
+  // default resolves to the STRICTER of the two, so a mistake here costs a
+  // refusal rather than an acceptance.
+  assert.equal(DEFAULT_BINDING_VERSION, "legacy-wallet-owner-v1");
+  const wallet = privateKeyToAccount(generatePrivateKey());
+  const owner = privateKeyToAccount(generatePrivateKey());
+  const r = await verifyGrantBinding(await legacyClaim(wallet, owner));
+  assert.equal(r.ok, true, r.ok === false ? r.why : "");
+});
+
+test("naming the legacy version explicitly verifies identically", async () => {
+  const wallet = privateKeyToAccount(generatePrivateKey());
+  const owner = privateKeyToAccount(generatePrivateKey());
+  const r = await verifyGrantBinding(await legacyClaim(wallet, owner, "legacy-wallet-owner-v1"));
+  assert.equal(r.ok, true, r.ok === false ? r.why : "");
+});
+
+test("A VERSION THIS DEPLOYMENT DOES NOT KNOW IS REFUSED, never best-guessed", async () => {
+  const wallet = privateKeyToAccount(generatePrivateKey());
+  const owner = privateKeyToAccount(generatePrivateKey());
+  for (const bogus of ["privy-v2", "legacy", "", 1, {}, [], true]) {
+    const r = await verifyGrantBinding(await legacyClaim(wallet, owner, bogus));
+    assert.equal(r.ok, false, `version ${JSON.stringify(bogus)} must be refused`);
+    assert.match(r.ok === false ? r.why : "", /binding version/);
+  }
+});
+
+test("a privy binding is refused until the deployment can verify one", async () => {
+  // The failure direction that matters: an unimplemented arm must NOT fall back
+  // to the legacy one, which would read a single owner signature as if it were
+  // two independent proofs.
+  const wallet = privateKeyToAccount(generatePrivateKey());
+  const owner = privateKeyToAccount(generatePrivateKey());
+  const r = await verifyGrantBinding(await legacyClaim(wallet, owner, "privy-did-owner-v1"));
+  assert.equal(r.ok, false);
+  assert.match(r.ok === false ? r.why : "", /privy bindings are not enabled/);
+});
+
+test("ONE KEY SIGNING TWICE IS NOT TWO PROOFS", async () => {
+  // The silent collapse. If the login wallet and the owner key are the same
+  // key, both recoveries land on the same address and the arithmetic passes —
+  // while the co-signature that makes a legacy claim unforgeable was never
+  // made. Note what is NOT asserted here: there is no global rule that an owner
+  // may never equal a tenant. `privy-did-owner-v1` allows exactly that, and
+  // gets its authentication from a verified token instead.
+  const both = privateKeyToAccount(generatePrivateKey());
+  const claim = await legacyClaim(both, both);
+  // Both signatures verify against their own addresses — the old checks pass:
+  assert.equal(claim.walletSignature, claim.ownerSignature);
+  const r = await verifyGrantBinding(claim);
+  assert.equal(r.ok, false);
+  assert.match(r.ok === false ? r.why : "", /only one proof/);
+});
+
+test("a legacy claim with no wallet signature is refused, not treated as a privy claim", async () => {
+  const wallet = privateKeyToAccount(generatePrivateKey());
+  const owner = privateKeyToAccount(generatePrivateKey());
+  const claim = await legacyClaim(wallet, owner);
+  const { walletSignature: _drop, ...withoutWallet } = claim;
+  const r = await verifyGrantBinding(withoutWallet as typeof claim);
+  assert.equal(r.ok, false);
+  assert.match(r.ok === false ? r.why : "", /missing the login signature/);
+});
+
+test("the two versions sign DIFFERENT text, so neither signature replays as the other", () => {
+  const owner = privateKeyToAccount(generatePrivateKey());
+  const common = {
+    origin: ORIGIN,
+    nonce: "n",
+    owner: owner.address,
+    smartAccount: SMART,
+    chainId: CHAIN,
+  } as const;
+  const legacy = bindingMessage(common);
+  const privy = bindingMessage({
+    ...common,
+    version: "privy-did-owner-v1",
+    did: "did:privy:cabc123",
+  });
+  assert.notEqual(legacy, privy);
+  // The DID is IN the privy text. Without it the owner signature would name no
+  // identity and would verify just as well under somebody else's login.
+  assert.match(privy, /Identity: did:privy:cabc123/);
+  assert.doesNotMatch(legacy, /Identity:/);
+});
+
+test("the legacy message text is frozen, byte for byte", () => {
+  // Grants signed by a browser that has not reloaded are still in flight, and a
+  // signature is over the exact bytes. This literal is the contract.
+  const text = bindingMessage({
+    origin: ORIGIN,
+    nonce: "NONCE",
+    owner: "0x00000000000000000000000000000000000000b2",
+    smartAccount: SMART,
+    chainId: CHAIN,
+  });
+  assert.equal(
+    text,
+    [
+      "https://app.merrymen.dev wants you to authorize a merrymen agent account.",
+      "",
+      "You are linking the agent wallet below to this login. It moves no funds.",
+      "",
+      "Agent account: 0x00000000000000000000000000000000000000a1",
+      "Owner key: 0x00000000000000000000000000000000000000b2",
+      "Chain ID: 4663",
+      "URI: https://app.merrymen.dev",
+      "Nonce: NONCE",
+    ].join("\n"),
+  );
+});
+
+test("isBindingVersion admits exactly the two shapes and nothing else", () => {
+  assert.equal(isBindingVersion("legacy-wallet-owner-v1"), true);
+  assert.equal(isBindingVersion("privy-did-owner-v1"), true);
+  for (const no of [undefined, null, "", "legacy", "privy", 0, {}, []]) {
+    assert.equal(isBindingVersion(no), false, JSON.stringify(no));
+  }
+});

--- a/web/src/lib/binding-version.test.ts
+++ b/web/src/lib/binding-version.test.ts
@@ -112,7 +112,12 @@ test("ONE KEY SIGNING TWICE IS NOT TWO PROOFS", async () => {
   assert.equal(claim.walletSignature, claim.ownerSignature);
   const r = await verifyGrantBinding(claim);
   assert.equal(r.ok, false);
-  assert.match(r.ok === false ? r.why : "", /only one proof/);
+  const why = r.ok === false ? r.why : "";
+  assert.match(why, /one proof where it needs two/);
+  // And it says what to DO. A refusal on a fund-access path that only describes
+  // the cause leaves the user with a permanently unusable agent and no next
+  // step — which is how a correct check becomes an outage.
+  assert.match(why, /create a new agent and sweep the old one/);
 });
 
 test("a legacy claim with no wallet signature is refused, not treated as a privy claim", async () => {

--- a/web/src/lib/binding-version.test.ts
+++ b/web/src/lib/binding-version.test.ts
@@ -24,11 +24,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { DEFAULT_BINDING_VERSION, bindingMessage, isBindingVersion } from "@merrymen/core";
 
 process.env.MERRYMEN_SESSION_SECRET = "test-secret-at-least-thirty-two-characters-long";
 
-import { issueChallengeNonce, verifyGrantBinding } from "./auth";
+import { ENFORCE_LEGACY_TWO_PROOF, issueChallengeNonce, verifyGrantBinding } from "./auth";
 
 const ORIGIN = "https://app.merrymen.dev";
 const SMART = "0x00000000000000000000000000000000000000a1" as `0x${string}`;
@@ -99,25 +101,35 @@ test("a privy binding is refused until the deployment can verify one", async () 
   assert.match(r.ok === false ? r.why : "", /privy bindings are not enabled/);
 });
 
-test("ONE KEY SIGNING TWICE IS NOT TWO PROOFS", async () => {
-  // The silent collapse. If the login wallet and the owner key are the same
-  // key, both recoveries land on the same address and the arithmetic passes —
-  // while the co-signature that makes a legacy claim unforgeable was never
-  // made. Note what is NOT asserted here: there is no global rule that an owner
-  // may never equal a tenant. `privy-did-owner-v1` allows exactly that, and
-  // gets its authentication from a verified token instead.
+test("ONE KEY SIGNING TWICE IS MEASURED, NOT YET REFUSED", async () => {
+  // The rule is right and it is switched off, on purpose. `restoreAgentWallet`
+  // accepts any 64-hex key, so somebody may have pasted the private key of the
+  // wallet they sign in with — a custody pattern nobody has counted. Enforcing
+  // before counting would have those users find out at RE-ARM time, which is
+  // the worst possible moment and offers them no migration.
+  //
+  // The census is `owner is tenant` in worker/src/identity-audit.ts. When it
+  // reports zero, ENFORCE_LEGACY_TWO_PROOF becomes true and this test flips to
+  // asserting the refusal.
+  assert.equal(ENFORCE_LEGACY_TWO_PROOF, false, "measure first, then enforce");
+
   const both = privateKeyToAccount(generatePrivateKey());
   const claim = await legacyClaim(both, both);
-  // Both signatures verify against their own addresses — the old checks pass:
+  // One key signing the same text twice produces the SAME signature, which is
+  // what makes the condition detectable at all.
   assert.equal(claim.walletSignature, claim.ownerSignature);
   const r = await verifyGrantBinding(claim);
-  assert.equal(r.ok, false);
-  const why = r.ok === false ? r.why : "";
-  assert.match(why, /one proof where it needs two/);
-  // And it says what to DO. A refusal on a fund-access path that only describes
-  // the cause leaves the user with a permanently unusable agent and no next
-  // step — which is how a correct check becomes an outage.
-  assert.match(why, /create a new agent and sweep the old one/);
+  assert.equal(r.ok, true, "an existing same-key account must keep working until it is counted");
+});
+
+test("the refusal exists, is gated on the flag, and names a remedy", () => {
+  // Source-read, because the branch cannot run while the flag is false — and a
+  // refusal that ships without a remedy turns a correct check into an outage.
+  const src = readFileSync(join(import.meta.dirname, "auth.ts"), "utf8");
+  assert.match(src, /if \(ENFORCE_LEGACY_TWO_PROOF && ownerSigner\.toLowerCase\(\) === walletSigner\.toLowerCase\(\)\)/);
+  assert.match(src, /one proof where it needs two/);
+  // A fragment that survives the string concatenation the message is built from.
+  assert.match(src, /sweep the old one from the recovery panel/);
 });
 
 test("a legacy claim with no wallet signature is refused, not treated as a privy claim", async () => {

--- a/web/src/lib/derive-account.ts
+++ b/web/src/lib/derive-account.ts
@@ -3,7 +3,7 @@ import { toAccount } from "viem/accounts";
 import { createKernelAccount } from "@zerodev/sdk";
 import { KERNEL_V3_3, getEntryPoint } from "@zerodev/sdk/constants";
 import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
-import { chainForId } from "@merrymen/core";
+import { chainForId, derivationOf, type Derivation } from "@merrymen/core";
 
 /**
  * Recompute the ERC-4337 smart-account address a given OWNER controls, from the
@@ -25,7 +25,11 @@ import { chainForId } from "@merrymen/core";
  * smart_account, so an unverified address lets one tenant write under another's
  * partition.
  */
-export async function deriveKernelAccountAddress(owner: Address, chainId: number): Promise<Address> {
+export async function deriveKernelAccountAddress(owner: Address, chainId: number): Promise<Derivation> {
+  // A malformed owner cannot derive anything, and letting it through would ask
+  // the SDK to build enable-data out of it. Refuse here rather than downstream.
+  const o = derivationOf(owner);
+  if (!o.ok) return { ok: false, failure: "malformed", why: `the owner address is not usable: ${o.why}` };
   const chain = chainForId(chainId);
   // http() with no URL uses the chain's built-in default RPC — the same transport
   // the grants route already uses for balance reads.
@@ -56,5 +60,10 @@ export async function deriveKernelAccountAddress(owner: Address, chainId: number
     plugins: { sudo: ecdsaValidator },
   });
 
-  return account.address;
+  // NOT `return account.address`. The SDK resolves this with a live
+  // getSenderAddress eth_call and, when the factory does not answer, carries on
+  // with the zero address and throws nothing. Returning it here would make the
+  // caller's equality test pass whenever BOTH sides failed the same way — see
+  // packages/core/src/derivation.ts for why that is worse than an error.
+  return derivationOf(account.address);
 }

--- a/web/src/lib/session.ts
+++ b/web/src/lib/session.ts
@@ -772,10 +772,11 @@ export async function previewOwnerAccount(
   });
   // The restore flow shows this address and then funds it. A zero here would
   // invite a deposit to an account nobody controls.
-  return {
-    smartAccount: assertDerivedAccount(account.address, "that owner key does not derive an account"),
-    owner: ownerAccount.address,
-  };
+  // Assert, then return the ORIGINAL casing. assertDerivedAccount normalises
+  // to lowercase, and this value is rendered next to addresses everywhere else
+  // in the app, which show EIP-55.
+  assertDerivedAccount(account.address, "that owner key does not derive an account");
+  return { smartAccount: account.address, owner: ownerAccount.address };
 }
 
 /** Live on-chain balances of the account address — for the "fund it" step. */

--- a/web/src/lib/session.ts
+++ b/web/src/lib/session.ts
@@ -82,6 +82,7 @@ import {
   bindingMessage,
   TRADEABLE_V2,
   USDG_DECIMALS,
+  assertDerivedAccount,
   type CustomToken,
   type GrantCaps,
   type StoredGrant,
@@ -227,6 +228,16 @@ async function mintGrant(
     plugins: { sudo: ecdsaValidator },
   });
 
+  // BEFORE THE WALL IS PINNED TO IT. createKernelAccount resolves this address
+  // with a live getSenderAddress eth_call and, when the Kernel factory does not
+  // answer on this chain, returns 0x0000...0000 and throws nothing. Everything
+  // below would then be built around the zero address: the wall's swap
+  // recipient, the vault receiver, the assertion further down (which two zeros
+  // satisfy), and the smartAccount the server is asked to verify — which, if it
+  // derived the same zero, would MATCH. Refuse here, where it is still just a
+  // failed derivation rather than a sealed grant.
+  assertDerivedAccount(sudoOnlyAccount.address, "the smart account could not be derived");
+
   // THE WALL now lives in packages/core/src/wall.ts, so the phone app signs the
   // IDENTICAL permission set rather than a second copy that could drift from this
   // one with nothing failing when it did. worker/src/wall.test.ts pins its shape.
@@ -272,6 +283,7 @@ async function mintGrant(
   // being true, every pin would point at an account that doesn't exist and the
   // agent would be unable to trade — or worse, at someone else's. Fail here,
   // loudly, before a grant is sealed, rather than discovering it on-chain.
+  assertDerivedAccount(account.address, "the permissioned account could not be derived");
   if (account.address.toLowerCase() !== sudoOnlyAccount.address.toLowerCase()) {
     throw new Error(
       `refusing to seal this grant: the permission plugin changed the account address ` +
@@ -758,7 +770,12 @@ export async function previewOwnerAccount(
     kernelVersion: KERNEL_V3_3,
     plugins: { sudo: ecdsaValidator },
   });
-  return { smartAccount: account.address, owner: ownerAccount.address };
+  // The restore flow shows this address and then funds it. A zero here would
+  // invite a deposit to an account nobody controls.
+  return {
+    smartAccount: assertDerivedAccount(account.address, "that owner key does not derive an account"),
+    owner: ownerAccount.address,
+  };
 }
 
 /** Live on-chain balances of the account address — for the "fund it" step. */

--- a/worker/src/identity-audit.test.ts
+++ b/worker/src/identity-audit.test.ts
@@ -140,6 +140,82 @@ describe("the audit refuses to guess", () => {
     assert.equal(r.safeToConstrain, false);
   });
 
+  it("REPORTS RESIDUE: an account already sealed at the zero address", () => {
+    // The guard this PR adds is mint-time. Whether the bug already happened is
+    // a question about production, and the audit is the only thing that reads it.
+    const ZERO = "0x0000000000000000000000000000000000000000";
+    const r = auditIdentity([row({ tenant: T1, accounts: [ZERO] })], [{ tenant: T1, smartAccount: ZERO }]);
+    assert.equal(r.zeroAddressResidue, 2, "the history entry and the installed grant are both residue");
+    assert.ok(r.lines.some((l) => /INSTALLED GRANT on the zero address/.test(l)));
+  });
+
+  it("says so plainly when there is no zero residue", () => {
+    const r = auditIdentity([row({ tenant: T1, accounts: [A] })], [{ tenant: T1, smartAccount: A }]);
+    assert.equal(r.zeroAddressResidue, 0);
+    assert.ok(r.lines.some((l) => /no account was ever sealed at 0x0/.test(l)));
+  });
+
+  it("COUNTS the users the new one-proof refusal would bar, rather than assuming there are none", () => {
+    const r = auditIdentity(
+      [row({ tenant: T1, accounts: [A] }), row({ tenant: T2, accounts: [B] })],
+      [
+        { tenant: T1, smartAccount: A, owner: T1 },
+        { tenant: T2, smartAccount: B, owner: "0x00000000000000000000000000000000000000c3" },
+      ],
+    );
+    assert.equal(r.sameKeyOwners, 1);
+    assert.ok(r.lines.some((l) => /owns its account with its own login key/.test(l)));
+  });
+
+  it("distinguishes 'no same-key owners' from 'nobody exposed an owner'", () => {
+    const known = auditIdentity([], [{ tenant: T1, smartAccount: A, owner: B }]);
+    assert.equal(known.sameKeyOwners, 0);
+    assert.ok(known.lines.some((l) => /every owner key is separate/.test(l)));
+
+    const unknown = auditIdentity([], [{ tenant: T1, smartAccount: A }]);
+    assert.ok(unknown.lines.some((l) => /not checked/.test(l)), "an unread column is not a clean result");
+  });
+
+  it("a DID is fingerprinted in the report, never printed", () => {
+    const did = "did:privy:clx0secret0identifier";
+    const r = auditIdentity(
+      [row({ tenant: T1, accounts: [A], privyDid: did }), row({ tenant: T2, accounts: [B], privyDid: did })],
+      [],
+    );
+    const text = r.lines.join(" | ");
+    assert.ok(!text.includes(did), "a DID beside a tenant address joins a login to an on-chain identity");
+    assert.match(text, /privy did\s+1 COLLISION/);
+    assert.match(text, /#[0-9a-f]{8} held by/);
+  });
+
+  it("DIDs and subjects are compared case-SENSITIVELY, like the index that will enforce them", () => {
+    const r = auditIdentity(
+      [
+        row({ tenant: T1, accounts: [A], privyDid: "did:privy:AbC" }),
+        row({ tenant: T2, accounts: [B], privyDid: "did:privy:abc" }),
+      ],
+      [],
+    );
+    assert.equal(r.safeToConstrain, true, "folding case would block a constraint that applies cleanly");
+  });
+
+  it("an empty-string smart account is a VALUE, and collides", () => {
+    // Postgres indexes lower('') like any other key; a truthiness filter would
+    // drop these and bless a table the index rejects.
+    const r = auditIdentity([], [
+      { tenant: T1, smartAccount: "" },
+      { tenant: T2, smartAccount: "" },
+    ]);
+    assert.equal(r.safeToConstrain, false);
+  });
+
+  it("a clean verdict still names store drift rather than reading as an all-clear", () => {
+    const r = auditIdentity([row({ tenant: T1, accounts: [A] })], [{ tenant: T1, smartAccount: B }]);
+    assert.equal(r.safeToConstrain, true);
+    const verdict = r.lines.find((l) => l.startsWith("VERDICT:"))!;
+    assert.match(verdict, /store disagreement\(s\) above would be frozen in place/);
+  });
+
   it("an empty fleet is clean", () => {
     const r = auditIdentity([], []);
     assert.equal(r.safeToConstrain, true);

--- a/worker/src/identity-audit.test.ts
+++ b/worker/src/identity-audit.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { auditIdentity, type GrantClaimLite, type IdentityRowLite } from "./identity-audit";
+
+const row = (o: Partial<IdentityRowLite> & { tenant: string }): IdentityRowLite => ({
+  slug: "aaaaaaaaaaaaaaaa",
+  accounts: [],
+  privyDid: null,
+  provider: null,
+  subject: null,
+  ...o,
+});
+
+const A = "0x00000000000000000000000000000000000000a1";
+const B = "0x00000000000000000000000000000000000000b2";
+const T1 = "0x0000000000000000000000000000000000000001";
+const T2 = "0x0000000000000000000000000000000000000002";
+
+describe("the audit refuses to guess", () => {
+  it("a clean table is safe to constrain, and says so", () => {
+    const r = auditIdentity(
+      [
+        row({ tenant: T1, accounts: [A], privyDid: "did:privy:one", provider: "google", subject: "g1" }),
+        row({ tenant: T2, accounts: [B], privyDid: "did:privy:two", provider: "google", subject: "g2" }),
+      ],
+      [
+        { tenant: T1, smartAccount: A },
+        { tenant: T2, smartAccount: B },
+      ],
+    );
+    assert.equal(r.safeToConstrain, true);
+    assert.ok(r.lines.some((l) => /VERDICT: every one-to-one relationship already holds/.test(l)));
+    assert.ok(r.lines.every((l) => !/COLLISION/.test(l)));
+  });
+
+  it("two tenants holding one CURRENT account blocks the constraint and names both", () => {
+    const r = auditIdentity(
+      [row({ tenant: T1, accounts: [A] }), row({ tenant: T2, accounts: [A] })],
+      [],
+    );
+    assert.equal(r.safeToConstrain, false);
+    assert.ok(r.lines.some((l) => l.includes(A) && l.includes(T1) && l.includes(T2)));
+    assert.ok(r.lines.some((l) => /DO NOT ADD THE CONSTRAINT/.test(l)));
+  });
+
+  it("NEVER RESOLVES A COLLISION — that is a question about who owns an agent", () => {
+    const r = auditIdentity([row({ tenant: T1, accounts: [A] }), row({ tenant: T2, accounts: [A] })], []);
+    const text = r.lines.join("\n");
+    // It says out loud that it touched nothing...
+    assert.match(text, /nothing was changed/);
+    // ...it never claims to have acted...
+    assert.doesNotMatch(text, /\b(deleted|merged|removed|deduplicated|resolved)\b/i);
+    // ...and it hands the decision to a person rather than proposing a rule.
+    assert.match(text, /by hand/);
+    assert.match(text, /not a migration's call/);
+  });
+
+  it("HISTORY IS PRESERVED, not treated as a collision", () => {
+    // A re-grant appends a new account and keeps the slug. One tenant listing
+    // both of its own accounts is the schema working, not a violation.
+    const r = auditIdentity([row({ tenant: T1, accounts: [B, A] })], [{ tenant: T1, smartAccount: B }]);
+    assert.equal(r.safeToConstrain, true);
+  });
+
+  it("but one account appearing in TWO tenants' history is a disagreement", () => {
+    const r = auditIdentity(
+      [row({ tenant: T1, accounts: [B, A] }), row({ tenant: T2, accounts: [A] })],
+      [],
+    );
+    assert.equal(r.safeToConstrain, false);
+    assert.ok(r.lines.some((l) => /account history/.test(l) && /COLLISION/.test(l)));
+  });
+
+  it("one DID on two tenants is exactly the second-Merryman bug, and blocks", () => {
+    const r = auditIdentity(
+      [
+        row({ tenant: T1, accounts: [A], privyDid: "did:privy:same" }),
+        row({ tenant: T2, accounts: [B], privyDid: "did:privy:same" }),
+      ],
+      [],
+    );
+    assert.equal(r.safeToConstrain, false);
+    assert.ok(r.lines.some((l) => /privy did/.test(l) && /COLLISION/.test(l)));
+  });
+
+  it("uniqueness is asked of provider+subject, never of the handle", () => {
+    // A handle is reassignable; the provider's own id is not. Two rows may
+    // share a handle without any violation at all.
+    const r = auditIdentity(
+      [
+        row({ tenant: T1, accounts: [A], provider: "twitter", subject: "111" }),
+        row({ tenant: T2, accounts: [B], provider: "twitter", subject: "222" }),
+      ],
+      [],
+    );
+    assert.equal(r.safeToConstrain, true);
+
+    const clash = auditIdentity(
+      [
+        row({ tenant: T1, accounts: [A], provider: "twitter", subject: "111" }),
+        row({ tenant: T2, accounts: [B], provider: "twitter", subject: "111" }),
+      ],
+      [],
+    );
+    assert.equal(clash.safeToConstrain, false);
+  });
+
+  it("two tenants with a grant on one smart account blocks — that is one ledger partition", () => {
+    const r = auditIdentity(
+      [row({ tenant: T1, accounts: [A] }), row({ tenant: T2, accounts: [B] })],
+      [
+        { tenant: T1, smartAccount: A },
+        { tenant: T2, smartAccount: A },
+      ],
+    );
+    assert.equal(r.safeToConstrain, false);
+    assert.ok(r.lines.some((l) => /installed grants/.test(l) && /COLLISION/.test(l)));
+  });
+
+  it("a grant whose account the identity row does not list is reported as drift, not uniqueness", () => {
+    const r = auditIdentity([row({ tenant: T1, accounts: [A] })], [{ tenant: T1, smartAccount: B }]);
+    // Drift does not by itself block the constraint — it is a different fault
+    // with a different remedy — but it must be visible.
+    assert.equal(r.safeToConstrain, true);
+    assert.ok(r.lines.some((l) => /DISAGREEMENT/.test(l)));
+    assert.ok(r.lines.some((l) => l.includes(B) && /does not list/.test(l)));
+  });
+
+  it("a grant with no identity row at all is reported", () => {
+    const r = auditIdentity([], [{ tenant: T1, smartAccount: A }]);
+    assert.ok(r.lines.some((l) => /has a grant but no identity row/.test(l)));
+  });
+
+  it("case and whitespace never manufacture or hide a collision", () => {
+    const r = auditIdentity(
+      [row({ tenant: T1, accounts: [A.toUpperCase().replace("0X", "0x")] }), row({ tenant: T2, accounts: [` ${A} `] })],
+      [],
+    );
+    assert.equal(r.safeToConstrain, false);
+  });
+
+  it("an empty fleet is clean", () => {
+    const r = auditIdentity([], []);
+    assert.equal(r.safeToConstrain, true);
+    assert.ok(r.lines[0]?.startsWith("0 identity row(s)"));
+  });
+});

--- a/worker/src/identity-audit.ts
+++ b/worker/src/identity-audit.ts
@@ -56,6 +56,15 @@ export interface GrantClaimLite {
    * is also its own tenant. See the residue section below.
    */
   owner?: string | null;
+  /**
+   * The `binding.version` this grant was PERSISTED with, if any.
+   *
+   * Read because the version field is new and the table is old: every grant
+   * written before it existed carries none, and anything else that turns up
+   * here was written by a client we did not ship. Both are facts worth having
+   * before the dispatch starts refusing on it.
+   */
+  bindingVersion?: string | null;
 }
 
 /** Addresses are case-insensitive; the chain says so and every store lowercases. */
@@ -119,6 +128,10 @@ export interface IdentityAudit {
   zeroAddressResidue: number;
   /** Grants whose owner key is also their login wallet. See the residue section. */
   sameKeyOwners: number;
+  /** Identity keys that are present but empty — malformed input, not absence. */
+  emptyIdentityKeys: number;
+  /** Persisted binding versions the dispatch would refuse. */
+  unknownBindingVersions: number;
 }
 
 export function auditIdentity(rows: IdentityRowLite[], claims: GrantClaimLite[]): IdentityAudit {
@@ -243,6 +256,50 @@ export function auditIdentity(rows: IdentityRowLite[], claims: GrantClaimLite[])
   );
   for (const s of sameKey) lines.push(`  ${s}`);
 
+  // ── CENSUS: identity keys that are present but empty ─────────────────────
+  //
+  // An empty string is not an absence. A partial index (`WHERE provider IS NOT
+  // NULL`) does not exclude it, so two rows carrying `''` collide under a
+  // constraint that looks like it tolerates missing values — and an empty
+  // identifier is malformed input either way. Counted here so the fix is
+  // "reject it at the boundary", not "widen the index until it fits".
+  const emptyKeys: string[] = [];
+  for (const r of rows) {
+    if (r.privyDid !== null && exact(r.privyDid) === "") emptyKeys.push(`${lc(r.tenant)} has an empty privy_did`);
+    if (r.provider !== null && exact(r.provider) === "") emptyKeys.push(`${lc(r.tenant)} has an empty provider`);
+    if (r.subject !== null && exact(r.subject) === "") emptyKeys.push(`${lc(r.tenant)} has an empty subject`);
+    if (r.accounts.some((a) => lc(a) === "")) emptyKeys.push(`${lc(r.tenant)} lists an empty account`);
+    if (exact(r.slug) === "") emptyKeys.push(`${lc(r.tenant)} has an empty slug`);
+  }
+  for (const c of claims) {
+    if (lc(c.smartAccount) === "") emptyKeys.push(`${lc(c.tenant)} has a grant with an empty smart account`);
+  }
+  lines.push(
+    emptyKeys.length === 0
+      ? `${"empty identity keys".padEnd(22)} none`
+      : `${"empty identity keys".padEnd(22)} ${emptyKeys.length} FOUND — reject these at the boundary, not in the index`,
+  );
+  for (const e of emptyKeys) lines.push(`  ${e}`);
+
+  // ── CENSUS: binding versions already on disk ─────────────────────────────
+  //
+  // The dispatch refuses a version it does not recognise. Before it can do that
+  // safely we need to know what is actually stored: absent is expected and
+  // legacy by construction, `legacy-wallet-owner-v1` is expected, and anything
+  // else was written by a client we did not ship.
+  const versions = new Map<string, number>();
+  for (const c of claims) {
+    const v = c.bindingVersion === null || c.bindingVersion === undefined ? "(absent)" : exact(c.bindingVersion);
+    versions.set(v, (versions.get(v) ?? 0) + 1);
+  }
+  const KNOWN = new Set(["(absent)", "legacy-wallet-owner-v1", "privy-did-owner-v1"]);
+  const unknownVersions = [...versions].filter(([v]) => !KNOWN.has(v));
+  lines.push(
+    `${"binding versions".padEnd(22)} ` +
+      ([...versions].map(([v, n]) => `${v} x${n}`).join(", ") || "no grants read") +
+      (unknownVersions.length > 0 ? " — UNRECOGNISED PRESENT, these would be refused" : ""),
+  );
+
   const safeToConstrain =
     current.size === 0 && historical.size === 0 && dids.size === 0 && subjects.size === 0 && claimed.size === 0;
 
@@ -255,5 +312,12 @@ export function auditIdentity(rows: IdentityRowLite[], claims: GrantClaimLite[])
       : "VERDICT: DO NOT ADD THE CONSTRAINT. Resolve the collisions above by hand first; " +
           "deduplicating them automatically would pick an owner for an agent, which is not a migration's call",
   );
-  return { lines, safeToConstrain, zeroAddressResidue: zeroed.length, sameKeyOwners: sameKey.length };
+  return {
+    lines,
+    safeToConstrain,
+    zeroAddressResidue: zeroed.length,
+    sameKeyOwners: sameKey.length,
+    emptyIdentityKeys: emptyKeys.length,
+    unknownBindingVersions: unknownVersions.reduce((n, [, count]) => n + count, 0),
+  };
 }

--- a/worker/src/identity-audit.ts
+++ b/worker/src/identity-audit.ts
@@ -33,6 +33,8 @@
  * PURE. Handed rows, returns strings.
  */
 
+import { UNDERIVED_ADDRESS } from "../../packages/core/src/index";
+
 export interface IdentityRowLite {
   tenant: string;
   slug: string;
@@ -47,15 +49,59 @@ export interface IdentityRowLite {
 export interface GrantClaimLite {
   tenant: string;
   smartAccount: string;
+  /**
+   * The key the account derives from. Read because two questions can only be
+   * answered from it, and both are about grants that already exist:
+   * whether any account was sealed at the zero address, and whether any owner
+   * is also its own tenant. See the residue section below.
+   */
+  owner?: string | null;
 }
 
+/** Addresses are case-insensitive; the chain says so and every store lowercases. */
 const lc = (s: string) => s.trim().toLowerCase();
+
+/**
+ * A DID and a provider subject are NOT case-insensitive.
+ *
+ * The indexes that will actually enforce these are plain `UNIQUE` over `text`,
+ * which is case-SENSITIVE. Folding case here would report two legitimately
+ * distinct identifiers as one collision and block a constraint that would have
+ * applied cleanly — an audit that is stricter than the index it is checking is
+ * just as wrong as one that is laxer.
+ */
+const exact = (s: string) => s.trim();
+
+/**
+ * A one-way fingerprint, for keys that must be COUNTED in a log but not READ.
+ *
+ * A Privy DID printed next to a tenant address joins a person's social login to
+ * their on-chain identity, in a log the whole fleet writes to. The audit's job
+ * is to say THAT two tenants collide and WHICH tenants they are — the tenant
+ * addresses are already public and already logged. The identifier itself is not
+ * needed to act on the finding, so it does not get printed.
+ *
+ * Not a secret-strength hash and not trying to be: it exists so two lines about
+ * the same DID are recognisably about the same DID.
+ */
+function fingerprint(value: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    h ^= value.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return `#${h.toString(16).padStart(8, "0")}`;
+}
 
 /** Keys held by more than one tenant, with the tenants that hold them. */
 function collisions(pairs: { key: string; tenant: string }[]): Map<string, string[]> {
   const by = new Map<string, Set<string>>();
   for (const p of pairs) {
-    if (!p.key) continue;
+    // NO TRUTHINESS SKIP. An empty string is a value Postgres indexes like any
+    // other, so two rows carrying one would violate a UNIQUE index while a
+    // `if (!p.key) continue` here quietly blessed them. Deciding what counts as
+    // ABSENT belongs to each caller, which knows the difference between a NULL
+    // column and a present-but-empty one; this function only counts keys.
     const set = by.get(p.key) ?? new Set<string>();
     set.add(p.tenant);
     by.set(p.key, set);
@@ -69,6 +115,10 @@ export interface IdentityAudit {
   lines: string[];
   /** True only when every one-to-one relationship already holds. */
   safeToConstrain: boolean;
+  /** Accounts already sealed at 0x0 by the bug the mint-time guard now stops. */
+  zeroAddressResidue: number;
+  /** Grants whose owner key is also their login wallet. See the residue section. */
+  sameKeyOwners: number;
 }
 
 export function auditIdentity(rows: IdentityRowLite[], claims: GrantClaimLite[]): IdentityAudit {
@@ -90,28 +140,40 @@ export function auditIdentity(rows: IdentityRowLite[], claims: GrantClaimLite[])
     rows.flatMap((r) => r.accounts.map((a) => ({ key: lc(a), tenant: lc(r.tenant) }))),
   );
   const dids = collisions(
-    rows.filter((r) => r.privyDid).map((r) => ({ key: lc(r.privyDid!), tenant: lc(r.tenant) })),
+    rows.filter((r) => r.privyDid).map((r) => ({ key: exact(r.privyDid!), tenant: lc(r.tenant) })),
   );
   const subjects = collisions(
     rows
       .filter((r) => r.provider && r.subject)
-      .map((r) => ({ key: `${lc(r.provider!)}/${lc(r.subject!)}`, tenant: lc(r.tenant) })),
+      .map((r) => ({ key: `${exact(r.provider!)}/${exact(r.subject!)}`, tenant: lc(r.tenant) })),
   );
-  const claimed = collisions(claims.map((c) => ({ key: lc(c.smartAccount), tenant: lc(c.tenant) })));
+  // AN EMPTY STRING IS A VALUE, NOT AN ABSENCE. Postgres indexes lower('') like
+  // any other key, so two grants carrying an empty smartAccount would collide
+  // under the constraint — while a JS truthiness filter drops them and the
+  // audit blesses a table the index will reject.
+  const claimed = collisions(
+    claims
+      .filter((c) => c.smartAccount !== null && c.smartAccount !== undefined)
+      .map((c) => ({ key: lc(c.smartAccount), tenant: lc(c.tenant) })),
+  );
 
-  const report = (label: string, found: Map<string, string[]>) => {
+  const report = (label: string, found: Map<string, string[]>, hide = false) => {
     if (found.size === 0) {
       lines.push(`${label.padEnd(22)} clean`);
       return;
     }
     lines.push(`${label.padEnd(22)} ${found.size} COLLISION(S) — nothing was changed`);
-    for (const [key, holders] of found) lines.push(`  ${key} held by ${holders.join(" and ")}`);
+    for (const [key, holders] of found) {
+      lines.push(`  ${hide ? fingerprint(key) : key} held by ${holders.join(" and ")}`);
+    }
   };
 
   report("current account", current);
   report("account history", historical);
-  report("privy did", dids);
-  report("provider+subject", subjects);
+  // Fingerprinted: a DID beside a tenant address joins a social login to an
+  // on-chain identity, and the fleet's logs are not the place for that join.
+  report("privy did", dids, true);
+  report("provider+subject", subjects, true);
   report("installed grants", claimed);
 
   // A grant whose account the identity row does not list at all means the two
@@ -136,14 +198,62 @@ export function auditIdentity(rows: IdentityRowLite[], claims: GrantClaimLite[])
     for (const d of drifted) lines.push(`  ${d}`);
   }
 
+  // ── RESIDUE: did the bug this PR fixes already happen? ───────────────────
+  //
+  // The guard is mint-time. It stops a NEW grant being sealed at the zero
+  // address; it says nothing about whether an old one already was. That is the
+  // question a read of production exists to answer, and it would be strange to
+  // ship the audit without asking it.
+  const zeroed: string[] = [];
+  for (const r of rows) {
+    for (const a of r.accounts) {
+      if (lc(a) === UNDERIVED_ADDRESS) zeroed.push(`${lc(r.tenant)} lists the zero address in its history`);
+    }
+  }
+  for (const c of claims) {
+    if (lc(c.smartAccount) === UNDERIVED_ADDRESS) {
+      zeroed.push(`${lc(c.tenant)} has an INSTALLED GRANT on the zero address`);
+    }
+  }
+  lines.push(
+    zeroed.length === 0
+      ? `${"zero-address residue".padEnd(22)} none — no account was ever sealed at 0x0`
+      : `${"zero-address residue".padEnd(22)} ${zeroed.length} FOUND`,
+  );
+  for (const z of zeroed) lines.push(`  ${z}`);
+
+  // ── RESIDUE: is anyone using their login wallet as the owner key? ────────
+  //
+  // `restoreAgentWallet` accepts any 64-hex key, so a user could have pasted
+  // the private key of the wallet they sign in with. The legacy binding arm now
+  // refuses a claim whose two signatures come from one key, which would bar
+  // exactly those users from re-arming. Whether that population is EMPTY is a
+  // fact about production, not something to believe — so count it here rather
+  // than assert it in a comment.
+  const sameKey = claims
+    .filter((c) => c.owner && lc(c.owner) === lc(c.tenant))
+    .map((c) => `${lc(c.tenant)} owns its account with its own login key`);
+  const ownersKnown = claims.filter((c) => c.owner).length;
+  lines.push(
+    ownersKnown === 0
+      ? `${"owner is tenant".padEnd(22)} not checked — no grant exposed an owner`
+      : sameKey.length === 0
+        ? `${"owner is tenant".padEnd(22)} none of ${ownersKnown} — every owner key is separate from its login`
+        : `${"owner is tenant".padEnd(22)} ${sameKey.length} of ${ownersKnown} FOUND — these cannot re-arm`,
+  );
+  for (const s of sameKey) lines.push(`  ${s}`);
+
   const safeToConstrain =
     current.size === 0 && historical.size === 0 && dids.size === 0 && subjects.size === 0 && claimed.size === 0;
 
   lines.push(
     safeToConstrain
-      ? "VERDICT: every one-to-one relationship already holds — a UNIQUE index would apply cleanly"
+      ? `VERDICT: every one-to-one relationship already holds — a UNIQUE index would apply cleanly` +
+          (drifted.length > 0
+            ? `, but ${drifted.length} store disagreement(s) above would be frozen in place by it. Read those first.`
+            : "")
       : "VERDICT: DO NOT ADD THE CONSTRAINT. Resolve the collisions above by hand first; " +
           "deduplicating them automatically would pick an owner for an agent, which is not a migration's call",
   );
-  return { lines, safeToConstrain };
+  return { lines, safeToConstrain, zeroAddressResidue: zeroed.length, sameKeyOwners: sameKey.length };
 }

--- a/worker/src/identity-audit.ts
+++ b/worker/src/identity-audit.ts
@@ -1,0 +1,149 @@
+/**
+ * IS THE IDENTITY TABLE ALREADY CLEAN ENOUGH TO CONSTRAIN?
+ *
+ * `agent_identity` is about to gain uniqueness it has never had. Adding a
+ * UNIQUE index to a table that already violates it does not fail safely — it
+ * fails at CREATE INDEX, in the store's own lazy bootstrap, which every read
+ * path awaits. So a duplicate that exists today would not surface as a
+ * migration error; it would surface as the public routes going dark.
+ *
+ * This is the read that has to happen first. It NEVER WRITES and it never
+ * proposes a fix: two rows claiming one smart account is a question about which
+ * human owns an agent, and the answer is not something a migration gets to
+ * decide by picking the older row. It reports, and a person decides.
+ *
+ * THE RELATIONSHIPS THAT MUST BE ONE-TO-ONE, and why each one:
+ *
+ *   privy_did → tenant        one login, one Merryman. Without it, logging out
+ *                             and back in can land on a second agent.
+ *   (provider, subject)       the provider's own immutable user id. The handle
+ *                             is reassignable and must never be the key —
+ *                             identity-store.ts:104-109 says so.
+ *   smart_account → tenant    every ledger table keys on smart_account, so two
+ *                             tenants holding one account write into one
+ *                             partition. This is the one with no constraint
+ *                             behind it today.
+ *
+ * `accounts` IS DELIBERATELY A HISTORY and stays one: a re-grant mints a new
+ * account and appends it, and the slug — with every published link and follow
+ * edge pointing at it — must survive that. So uniqueness is asked of the
+ * CURRENT account, and the history is only checked for cross-row overlap, which
+ * would mean two identities disagreeing about who once held an address.
+ *
+ * PURE. Handed rows, returns strings.
+ */
+
+export interface IdentityRowLite {
+  tenant: string;
+  slug: string;
+  /** Newest first, as the store writes it. */
+  accounts: string[];
+  privyDid: string | null;
+  provider: string | null;
+  subject: string | null;
+}
+
+/** One tenant's currently-installed grant, as the grant store holds it. */
+export interface GrantClaimLite {
+  tenant: string;
+  smartAccount: string;
+}
+
+const lc = (s: string) => s.trim().toLowerCase();
+
+/** Keys held by more than one tenant, with the tenants that hold them. */
+function collisions(pairs: { key: string; tenant: string }[]): Map<string, string[]> {
+  const by = new Map<string, Set<string>>();
+  for (const p of pairs) {
+    if (!p.key) continue;
+    const set = by.get(p.key) ?? new Set<string>();
+    set.add(p.tenant);
+    by.set(p.key, set);
+  }
+  const out = new Map<string, string[]>();
+  for (const [k, tenants] of by) if (tenants.size > 1) out.set(k, [...tenants].sort());
+  return out;
+}
+
+export interface IdentityAudit {
+  lines: string[];
+  /** True only when every one-to-one relationship already holds. */
+  safeToConstrain: boolean;
+}
+
+export function auditIdentity(rows: IdentityRowLite[], claims: GrantClaimLite[]): IdentityAudit {
+  const lines: string[] = [];
+  const tenants = new Set(rows.map((r) => lc(r.tenant)));
+
+  lines.push(
+    `${rows.length} identity row(s), ${tenants.size} distinct tenant(s), ${claims.length} installed grant(s)`,
+  );
+
+  // ── the current account, which is what a UNIQUE would cover ──────────────
+  const current = collisions(
+    rows
+      .filter((r) => r.accounts.length > 0)
+      .map((r) => ({ key: lc(r.accounts[0]!), tenant: lc(r.tenant) })),
+  );
+  // ── the whole history, which would mean a deeper disagreement ────────────
+  const historical = collisions(
+    rows.flatMap((r) => r.accounts.map((a) => ({ key: lc(a), tenant: lc(r.tenant) }))),
+  );
+  const dids = collisions(
+    rows.filter((r) => r.privyDid).map((r) => ({ key: lc(r.privyDid!), tenant: lc(r.tenant) })),
+  );
+  const subjects = collisions(
+    rows
+      .filter((r) => r.provider && r.subject)
+      .map((r) => ({ key: `${lc(r.provider!)}/${lc(r.subject!)}`, tenant: lc(r.tenant) })),
+  );
+  const claimed = collisions(claims.map((c) => ({ key: lc(c.smartAccount), tenant: lc(c.tenant) })));
+
+  const report = (label: string, found: Map<string, string[]>) => {
+    if (found.size === 0) {
+      lines.push(`${label.padEnd(22)} clean`);
+      return;
+    }
+    lines.push(`${label.padEnd(22)} ${found.size} COLLISION(S) — nothing was changed`);
+    for (const [key, holders] of found) lines.push(`  ${key} held by ${holders.join(" and ")}`);
+  };
+
+  report("current account", current);
+  report("account history", historical);
+  report("privy did", dids);
+  report("provider+subject", subjects);
+  report("installed grants", claimed);
+
+  // A grant whose account the identity row does not list at all means the two
+  // stores disagree about what this tenant holds. Not a uniqueness violation,
+  // but it is the shape a half-finished write leaves behind, and a constraint
+  // added over it would freeze the disagreement in place.
+  const byTenant = new Map(rows.map((r) => [lc(r.tenant), r]));
+  const drifted: string[] = [];
+  for (const c of claims) {
+    const row = byTenant.get(lc(c.tenant));
+    if (!row) {
+      drifted.push(`${lc(c.tenant)} has a grant but no identity row`);
+      continue;
+    }
+    if (!row.accounts.map(lc).includes(lc(c.smartAccount))) {
+      drifted.push(`${lc(c.tenant)} holds ${lc(c.smartAccount)}, which its identity row does not list`);
+    }
+  }
+  if (drifted.length === 0) lines.push(`${"store agreement".padEnd(22)} clean`);
+  else {
+    lines.push(`${"store agreement".padEnd(22)} ${drifted.length} DISAGREEMENT(S)`);
+    for (const d of drifted) lines.push(`  ${d}`);
+  }
+
+  const safeToConstrain =
+    current.size === 0 && historical.size === 0 && dids.size === 0 && subjects.size === 0 && claimed.size === 0;
+
+  lines.push(
+    safeToConstrain
+      ? "VERDICT: every one-to-one relationship already holds — a UNIQUE index would apply cleanly"
+      : "VERDICT: DO NOT ADD THE CONSTRAINT. Resolve the collisions above by hand first; " +
+          "deduplicating them automatically would pick an owner for an agent, which is not a migration's call",
+  );
+  return { lines, safeToConstrain };
+}

--- a/worker/src/identity-store.ts
+++ b/worker/src/identity-store.ts
@@ -229,6 +229,18 @@ export class FileIdentityStore implements IdentityStore {
 
 // ── postgres backend ─────────────────────────────────────────────────────────
 
+/**
+ * A Postgres unique-violation, whatever driver shape it arrives in.
+ *
+ * SQLSTATE 23505. Matched on the code rather than the message so a translated
+ * or reworded server error still lands here, and narrow enough that a genuine
+ * outage never reads as "already claimed".
+ */
+function isUniqueViolation(e: unknown): boolean {
+  const code = (e as { code?: unknown } | null)?.code;
+  return code === "23505" || code === 23505;
+}
+
 interface PgClientLike {
   query(sql: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount?: number | null }>;
 }
@@ -374,11 +386,23 @@ export class PgIdentityStore implements IdentityStore {
     const { rows } = await c.query(`SELECT * FROM agent_identity WHERE privy_did = $1`, [did]);
     return rows[0] ? fromRow(rows[0] as unknown as Row) : null;
   }
+  /**
+   * FIRST CLAIM WINS, DECIDED BY THE DATABASE.
+   *
+   * This used to read `byDid` and then write, which is first-claim-wins only if
+   * nothing runs concurrently. Two logins racing the same DID both saw no
+   * holder, both wrote, and the second either won (two identities, one login)
+   * or died on the unique index as a 500 — neither of which is "false".
+   *
+   * There is no pre-read now. The UNIQUE index on `privy_did` IS the guard, and
+   * a unique violation is translated to the refusal it always meant. Re-linking
+   * the same pair still updates its own row and returns true.
+   */
   async linkSocial(tenant: `0x${string}`, social: SocialIdentity): Promise<boolean> {
-    const holder = await this.byDid(social.did);
-    if (holder && holder.tenant.toLowerCase() !== tenant.toLowerCase()) return false;
     const c = await this.client();
-    const { rowCount } = await c.query(
+    let rowCount: number | null | undefined;
+    try {
+      ({ rowCount } = await c.query(
       `UPDATE agent_identity
           SET privy_did = $2, provider = $3, subject = $4, handle = $5,
               display_name = $6, avatar_url = $7, updated_at = $8
@@ -393,7 +417,15 @@ export class PgIdentityStore implements IdentityStore {
         social.avatarUrl ?? null,
         now(),
       ],
-    );
+      ));
+    } catch (e) {
+      // 23505 = unique_violation. Either `privy_did` or `(provider, subject)`
+      // is already held by a different tenant, which is precisely the
+      // already-claimed case this returns false for. Anything else propagates —
+      // a refusal must never stand in for a store that is broken.
+      if (isUniqueViolation(e)) return false;
+      throw e;
+    }
     return (rowCount ?? 0) > 0;
   }
   async remove(tenant: `0x${string}`): Promise<void> {

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -1002,7 +1002,11 @@ async function runIdentityAuditIfAsked(): Promise<void> {
       .prepare("SELECT tenant, slug, accounts, privy_did, provider, subject FROM agent_identity")
       .all()) as unknown as Record<string, unknown>[];
     const grantRows = (await shared
-      .prepare("SELECT tenant, grant_json->>'smartAccount' AS smart_account FROM grants")
+      // `owner` is read for the residue questions only — was an account ever
+      // sealed at 0x0, and is any owner key also its own login wallet. It is an
+      // ADDRESS, never key material; the grant store refuses to hold a key at
+      // all (packages/core hosted.ts, and a 422 at the intake).
+      .prepare("SELECT tenant, grant_json->>'smartAccount' AS smart_account, grant_json->>'owner' AS owner FROM grants")
       .all()) as unknown as Record<string, unknown>[];
 
     const rows: IdentityRowLite[] = idRows.map((r) => {
@@ -1027,9 +1031,17 @@ async function runIdentityAuditIfAsked(): Promise<void> {
         subject: r.subject === null || r.subject === undefined ? null : String(r.subject),
       };
     });
+    // NULL means the key is absent from the JSON; an empty string means it is
+    // present and empty, which a UNIQUE index treats as an ordinary value. Only
+    // the first is dropped — the second is exactly the row that would break a
+    // constraint the audit had blessed.
     const claims: GrantClaimLite[] = grantRows
-      .filter((r) => r.smart_account)
-      .map((r) => ({ tenant: String(r.tenant ?? ""), smartAccount: String(r.smart_account) }));
+      .filter((r) => r.smart_account !== null && r.smart_account !== undefined)
+      .map((r) => ({
+        tenant: String(r.tenant ?? ""),
+        smartAccount: String(r.smart_account),
+        owner: r.owner === null || r.owner === undefined ? null : String(r.owner),
+      }));
 
     for (const line of auditIdentity(rows, claims).lines) log(`identity| ${line}`);
   } catch (e) {
@@ -1674,6 +1686,7 @@ export async function runOrchestrator(): Promise<void> {
       if (cohortPasses === COHORT_VET_AFTER_PASSES) {
         await runCohortVettingIfAsked();
         await runBrainDatasetIfAsked();
+        await runIdentityAuditIfAsked();
       }
       await ferryCommands2();
       await fleetHealth();

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -57,6 +57,7 @@ import { parseRepairOptions, repairLines, runRepair } from "./accounting-repair"
 import { decomposeGas, gasAuditLines, type GasOp } from "./gas-audit";
 import { cohortLines, vetCandidate, type CandidateVerdictDetail } from "./cohort-vetting";
 import { datasetLines, viewRun } from "./brain-dataset";
+import { auditIdentity, type GrantClaimLite, type IdentityRowLite } from "./identity-audit";
 import { replayLines, scoreDecision, type Observation, type PricedDecision } from "./replay";
 import { scanFleetCapital } from "./chain-capital";
 import { getFollowStore, MAX_FOLLOWS } from "./follow-store";
@@ -975,6 +976,64 @@ async function runBrainDatasetIfAsked(): Promise<void> {
     for (const line of datasetLines(views)) log(`data| ${line}`);
   } catch (e) {
     log(`brain dataset failed — ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+/**
+ * THE IDENTITY AUDIT. READ ONLY. `MERRYMEN_IDENTITY_AUDIT=1`.
+ *
+ * Runs before any uniqueness constraint is added, because a UNIQUE index over a
+ * table that already violates it fails inside the store's lazy bootstrap — and
+ * every public read awaits that bootstrap, so the failure presents as the site
+ * going dark rather than as a migration error. Nothing here writes, and nothing
+ * here deduplicates: two rows claiming one account is a question about which
+ * person owns an agent.
+ */
+async function runIdentityAuditIfAsked(): Promise<void> {
+  if ((process.env.MERRYMEN_IDENTITY_AUDIT ?? "").trim() !== "1") return;
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    log("identity audit asked for, but there is no DATABASE_URL");
+    return;
+  }
+  try {
+    const shared = await makePgDb(url);
+    const idRows = (await shared
+      .prepare("SELECT tenant, slug, accounts, privy_did, provider, subject FROM agent_identity")
+      .all()) as unknown as Record<string, unknown>[];
+    const grantRows = (await shared
+      .prepare("SELECT tenant, grant_json->>'smartAccount' AS smart_account FROM grants")
+      .all()) as unknown as Record<string, unknown>[];
+
+    const rows: IdentityRowLite[] = idRows.map((r) => {
+      let accounts: string[] = [];
+      const raw = r.accounts;
+      if (Array.isArray(raw)) accounts = raw.map((a) => String(a));
+      else if (typeof raw === "string") {
+        try {
+          const parsed = JSON.parse(raw) as unknown;
+          if (Array.isArray(parsed)) accounts = parsed.map((a) => String(a));
+        } catch {
+          // An unreadable accounts blob is a row we cannot vouch for. Leave it
+          // empty rather than guessing — it shows up as store disagreement.
+        }
+      }
+      return {
+        tenant: String(r.tenant ?? ""),
+        slug: String(r.slug ?? ""),
+        accounts,
+        privyDid: r.privy_did === null || r.privy_did === undefined ? null : String(r.privy_did),
+        provider: r.provider === null || r.provider === undefined ? null : String(r.provider),
+        subject: r.subject === null || r.subject === undefined ? null : String(r.subject),
+      };
+    });
+    const claims: GrantClaimLite[] = grantRows
+      .filter((r) => r.smart_account)
+      .map((r) => ({ tenant: String(r.tenant ?? ""), smartAccount: String(r.smart_account) }));
+
+    for (const line of auditIdentity(rows, claims).lines) log(`identity| ${line}`);
+  } catch (e) {
+    log(`identity audit failed — ${e instanceof Error ? e.message : String(e)}`);
   }
 }
 

--- a/worker/src/orchestrator.ts
+++ b/worker/src/orchestrator.ts
@@ -1006,7 +1006,11 @@ async function runIdentityAuditIfAsked(): Promise<void> {
       // sealed at 0x0, and is any owner key also its own login wallet. It is an
       // ADDRESS, never key material; the grant store refuses to hold a key at
       // all (packages/core hosted.ts, and a 422 at the intake).
-      .prepare("SELECT tenant, grant_json->>'smartAccount' AS smart_account, grant_json->>'owner' AS owner FROM grants")
+      .prepare(
+        "SELECT tenant, grant_json->>'smartAccount' AS smart_account, " +
+          "grant_json->>'owner' AS owner, " +
+          "grant_json->'binding'->>'version' AS binding_version FROM grants",
+      )
       .all()) as unknown as Record<string, unknown>[];
 
     const rows: IdentityRowLite[] = idRows.map((r) => {
@@ -1041,6 +1045,8 @@ async function runIdentityAuditIfAsked(): Promise<void> {
         tenant: String(r.tenant ?? ""),
         smartAccount: String(r.smart_account),
         owner: r.owner === null || r.owner === undefined ? null : String(r.owner),
+        bindingVersion:
+          r.binding_version === null || r.binding_version === undefined ? null : String(r.binding_version),
       }));
 
     for (const line of auditIdentity(rows, claims).lines) log(`identity| ${line}`);

--- a/worker/src/recover.ts
+++ b/worker/src/recover.ts
@@ -30,6 +30,7 @@ import { privateKeyToAccount } from "viem/accounts";
 import { createKernelAccount, createKernelAccountClient } from "@zerodev/sdk";
 import { KERNEL_V3_3, getEntryPoint } from "@zerodev/sdk/constants";
 import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
+import { assertDerivedAccount } from "../../packages/core/src/index";
 import {
   CASH,
   MORPHO,
@@ -233,6 +234,9 @@ export async function planRecovery(opts: {
     plugins: { sudo: ecdsaValidator },
   });
 
+  // A sweep aimed at the zero address would be a signed transaction to nothing.
+  assertDerivedAccount(account.address, "that owner key does not derive an account");
+
   if (
     opts.expectedSmartAccount &&
     account.address.toLowerCase() !== opts.expectedSmartAccount.toLowerCase()
@@ -426,6 +430,7 @@ export async function recoverFunds(opts: {
     kernelVersion: KERNEL_V3_3,
     plugins: { sudo: ecdsaValidator },
   });
+  assertDerivedAccount(account.address, "that owner key does not derive an account");
   const client = createKernelAccountClient({
     account,
     chain: opts.chain,

--- a/worker/src/session-account.ts
+++ b/worker/src/session-account.ts
@@ -65,6 +65,7 @@ import { toCallPolicy, toRateLimitPolicy, toTimestampPolicy } from "@zerodev/per
 import { createKernelAccount } from "@zerodev/sdk";
 import { toKernelPluginManager } from "@zerodev/sdk/accounts";
 import { KERNEL_V3_3 } from "@zerodev/sdk/constants";
+import { assertDerivedAccount } from "../../packages/core/src/index";
 
 /**
  * The serialized blob's shape (serializePermissionAccount.ts:54-63).
@@ -290,6 +291,13 @@ export async function deserializeFlaggedPermissionAccount(
     useMetaFactory,
     eip7702Auth: params.eip7702Auth,
   } as never);
+
+  // A ZERO DERIVATION IS NOT AN ADDRESS. createKernelAccount answers the zero
+  // address when the factory does not respond on this chain, and it throws
+  // nothing. If the grant blob also carried a zero accountAddress the equality
+  // below would PASS and the worker would arm against nothing.
+  assertDerivedAccount(derived.address, "the account could not be re-derived from this grant");
+  assertDerivedAccount(params.accountParams.accountAddress, "this grant carries no usable account address");
 
   if (derived.address.toLowerCase() !== params.accountParams.accountAddress.toLowerCase()) {
     throw new AccountAddressMismatch(params.accountParams.accountAddress, derived.address);

--- a/worker/src/wiring.test.ts
+++ b/worker/src/wiring.test.ts
@@ -72,6 +72,69 @@ describe("every env-gated report the orchestrator defines is actually run", () =
   });
 });
 
+describe("the identity audit observes and does not repair", () => {
+  /**
+   * observe -> understand -> decide -> migrate -> constrain.
+   *
+   * The failure this forbids is a bootstrap routine that sees bad state and
+   * quietly normalises it: the collision disappears, the constraint applies,
+   * and nobody ever learns which of two people owned the agent. So the audit
+   * reads and prints, and that is all it is allowed to do.
+   */
+  const auditBody = () => {
+    const src = read("worker/src/orchestrator.ts");
+    const start = src.indexOf("async function runIdentityAuditIfAsked");
+    assert.ok(start > 0, "the audit runner must exist");
+    const rest = src.slice(start + 10);
+    const next = rest.search(/^async function /m);
+    return next < 0 ? src.slice(start) : src.slice(start, start + 10 + next);
+  };
+
+  it("issues no statement that can write", () => {
+    const body = auditBody();
+    for (const verb of ["INSERT", "UPDATE", "DELETE", "CREATE ", "ALTER", "DROP", "TRUNCATE", "COPY "]) {
+      assert.ok(!body.includes(verb), `the audit must not ${verb.trim()}`);
+    }
+    assert.ok(!/\.exec\(/.test(body), "exec() is the write path on this db wrapper");
+  });
+
+  it("goes to the database directly rather than through a store that bootstraps DDL", () => {
+    // getIdentityStore() would run CREATE TABLE / CREATE UNIQUE INDEX in its
+    // lazy constructor — which is exactly the migration this audit exists to
+    // decide about, and it would run it before anyone had read the result.
+    const body = auditBody();
+    assert.ok(!body.includes("getIdentityStore"), "the audit must not open the store it is auditing");
+    assert.ok(body.includes("makePgDb("), "it reads with a plain connection");
+  });
+
+  it("prints no raw identity material", () => {
+    // Tenant addresses are already in every orchestrator log line. A Privy DID
+    // is not, and printing one beside a tenant joins a social login to an
+    // on-chain identity for anyone who can read the fleet's logs.
+    const audit = read("worker/src/identity-audit.ts");
+    assert.match(audit, /report\("privy did", dids, true\)/, "DIDs must be fingerprinted");
+    assert.match(audit, /report\("provider\+subject", subjects, true\)/, "subjects must be fingerprinted");
+    assert.match(audit, /function fingerprint\(/);
+  });
+
+  it("reports every census the rollout decision depends on", () => {
+    const audit = read("worker/src/identity-audit.ts");
+    for (const census of [
+      "current account",
+      "account history",
+      "privy did",
+      "provider+subject",
+      "installed grants",
+      "zero-address residue",
+      "owner is tenant",
+      "empty identity keys",
+      "binding versions",
+    ]) {
+      assert.ok(audit.includes(`"${census}"`), `the audit must report: ${census}`);
+    }
+  });
+});
+
 describe("the two signers refuse the same things", () => {
   /**
    * The phone and the dashboard seal the SAME wall — worker/src/wall.test.ts

--- a/worker/src/wiring.test.ts
+++ b/worker/src/wiring.test.ts
@@ -1,0 +1,103 @@
+/**
+ * IS THE GUARD ACTUALLY REACHED?
+ *
+ * Three defects shipped into a review of this repo in one afternoon, all the
+ * same shape: a correct function, a passing unit test, and no call site. The
+ * unit tests could not catch any of them, because each one called the guard
+ * directly and supplied the argument the production caller was failing to pass.
+ *
+ *   - `verifyGrantBinding` grew a version dispatch, and the grants route did
+ *     not pass `version`. Every claim resolved to the default, so the
+ *     unknown-version refusal and the privy-not-implemented refusal were both
+ *     unreachable — a grant declaring `privy-did-owner-v1` would have been
+ *     verified under LEGACY rules, which is exactly the downgrade the
+ *     versioning exists to prevent. `binding-version.test.ts` passed, because
+ *     it calls the validator itself.
+ *   - `runIdentityAuditIfAsked` was defined and never called. The env var did
+ *     nothing.
+ *   - The phone signer kept deriving an account with no zero-address guard
+ *     while the browser signer gained one.
+ *
+ * So these are WIRING tests. They assert that the dangerous argument is passed,
+ * that a defined entry point is invoked, and that two signers that must refuse
+ * the same things actually do. Source-reading, because none of it is observable
+ * without a chain and a database.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const read = (p: string) => readFileSync(join(ROOT, p), "utf8");
+
+describe("the binding version reaches the validator", () => {
+  it("the grants route passes `version` to verifyGrantBinding", () => {
+    const src = read("web/src/app/api/grants/route.ts");
+    const call = src.slice(src.indexOf("verifyGrantBinding({"));
+    const args = call.slice(0, call.indexOf("});"));
+    assert.match(
+      args,
+      /version:\s*binding\.version/,
+      "without this the dispatch is unreachable and every claim resolves to the legacy default",
+    );
+  });
+
+  it("the route does not decide the version itself", () => {
+    // The one place that decides which security model applies is the
+    // validator. A route that normalised, defaulted or filtered the version
+    // would be making that decision in two places, which is how they drift.
+    const src = read("web/src/app/api/grants/route.ts");
+    assert.doesNotMatch(src, /binding\.version\s*(\?\?|\|\|)/, "the route must not default the version");
+    assert.doesNotMatch(src, /isBindingVersion/, "the route must not validate the version itself");
+  });
+});
+
+describe("every env-gated report the orchestrator defines is actually run", () => {
+  /**
+   * A `run…IfAsked` that is never called is an environment variable that does
+   * nothing, and it fails silently by construction: the operator sets it, sees
+   * no output, and concludes the fleet had nothing to say.
+   */
+  it("no orchestrator entry point is defined without a call site", () => {
+    const src = read("worker/src/orchestrator.ts");
+    const defined = [...src.matchAll(/^async function (run\w*IfAsked)\(/gm)].map((m) => m[1]!);
+    assert.ok(defined.length >= 3, `expected several env-gated reports, found ${defined.length}`);
+    const orphans = defined.filter((name) => {
+      // A call site is any occurrence that is not the definition itself.
+      const uses = [...src.matchAll(new RegExp(`\\b${name}\\b`, "g"))].length;
+      return uses < 2;
+    });
+    assert.deepEqual(orphans, [], `defined but never called: ${orphans.join(", ")}`);
+  });
+});
+
+describe("the two signers refuse the same things", () => {
+  /**
+   * The phone and the dashboard seal the SAME wall — worker/src/wall.test.ts
+   * and signer-lockstep.test.ts exist for that reason. A guard added to one and
+   * not the other means the two disagree about what a signature may carry, and
+   * the disagreement is invisible until a phone seals something the browser
+   * would have refused.
+   */
+  const web = () => read("web/src/lib/session.ts");
+  const phone = () => read("mobile/src/crypto/signGrant.ts");
+
+  it("both assert the sudo-only account before the wall is pinned to it", () => {
+    for (const [what, src] of [["web", web()], ["phone", phone()]] as const) {
+      const guard = src.indexOf('assertDerivedAccount(sudoOnlyAccount.address');
+      const wall = src.indexOf("buildWallPolicies({");
+      assert.ok(guard > 0, `${what} does not assert the sudo-only derivation`);
+      assert.ok(wall > guard, `${what} pins the wall before asserting the address it pins to`);
+    }
+  });
+
+  it("both assert the permissioned account before the equality that two zeros satisfy", () => {
+    for (const [what, src] of [["web", web()], ["phone", phone()]] as const) {
+      const guard = src.indexOf("assertDerivedAccount(account.address");
+      const equality = src.indexOf("account.address.toLowerCase() !== sudoOnlyAccount.address.toLowerCase()");
+      assert.ok(guard > 0, `${what} does not assert the permissioned derivation`);
+      assert.ok(equality > guard, `${what} compares two possibly-zero addresses before asserting them`);
+    }
+  });
+});


### PR DESCRIPTION
**PR A of three.** Existing security defects only. No Privy code, no account
ownership changes, no new dependencies.

Each of these is red today, independent of Privy — and Privy would make each one
reachable or worse, which is why they go first.

### 1. A zero derivation presented as a successful one

`createKernelAccount` resolves the account address with a live `getSenderAddress`
eth_call. When the Kernel factory does not answer it retries against the bare
factory and, if that also answers zero, continues with
`accountAddress = 0x0000…0000` and **throws nothing**
(`@zerodev/sdk/accounts/kernel/createKernelAccount.ts:540-551`).

That is worse than an error, because the hosted custody boundary is an equality:

```
browser derives zero  →  grant.smartAccount = 0x0000…0000
server  derives zero  →  derived            = 0x0000…0000
                         derived === claimed  ✔  grant sealed
```

The fail-closed 503 cannot fire, because nothing failed. **The fault makes the
check pass.**

`packages/core/src/derivation.ts` makes a derivation a typed result — `zero`,
`malformed`, `unreachable` — and `accountsMatch` takes the *result*, so two
failures can never compare equal. Routed through it: the hosted intake, the
recovery-ticket route, the browser signer (before the wall pins value to the
address), the restore preview, and the worker on both sides of its arm-time
equality.

### 2. A binding that did not say which security model it was made under

Legacy proves authentication and owner authority with two signatures from two
different keys. Privy will prove them with a verified access token and one
signature from the embedded owner wallet. Both are two proofs; they are not the
same two, and a validator that served both from one shape would have to guess.

`binding_version` is now explicit and dispatched:

| version | this PR |
|---|---|
| absent | legacy — by construction, not fallthrough: the field did not exist when those grants were signed |
| `legacy-wallet-owner-v1` | verified exactly as before; message text frozen byte for byte |
| `privy-did-owner-v1` | **refused** until PR B implements the arm |
| anything else | refused, never resolved to a default |

The legacy arm now asserts its own premise: two recoveries landing on one address
means one key signed twice. This is **not** a global `owner !== tenant` rule —
`privy-did-owner-v1` allows exactly that and takes its authentication from a
verified token instead.

### 3. First-claim-wins that only held if nothing ran concurrently

`linkSocial` read `byDid` then wrote. Two logins racing one DID both saw no
holder and both wrote. The pre-read is gone; the UNIQUE index is the guard and a
`23505` becomes the refusal it always meant.

`smart_account` has no constraint at all, and **adding one is deliberately not in
this commit**. A UNIQUE index over a table that already violates it fails inside
the store's lazy bootstrap, which every public read awaits — so it would present
as the site going dark, not as a migration error. `MERRYMEN_IDENTITY_AUDIT=1`
reads production first and reports collisions **without proposing a fix**: two
rows claiming one account is a question about which person owns an agent. The
`accounts` history stays a history.

### Tests

38 new, including the one this was written for — a browser that derives zero and
a server that derives zero must not become "addresses match". Full suite 2604
pass, both typechecks clean.

### Not in this PR

`changeRootValidator`, any owner migration, any Privy dependency, and the
`smart_account` UNIQUE index (gated on the production audit above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
