### PR TITLE
identity: an account belongs to one identity, ever

### DIFF
--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -28,24 +28,30 @@ import {
 } from "@merrymen/core";
 
 /**
- * IS THE LEGACY TWO-PROOF PREMISE ENFORCED YET?
+ * IS THE LEGACY TWO-PROOF PREMISE ENFORCED? YES — AFTER IT WAS MEASURED.
  *
  * `legacy-wallet-owner-v1` claims that authentication and owner authority come
  * from two different keys. One key signing twice satisfies the arithmetic while
- * proving only half of that — so the check below is correct, and it is OFF.
+ * proving only half of that, so the check below is correct — but correct was
+ * never the question. `restoreAgentWallet` accepts any 64-hex key, so somebody
+ * could have pasted the private key of the wallet they sign in with, and
+ * switching the rule on before counting them would have those people discover
+ * it at RE-ARM time: an agent that stops working, with no warning and no
+ * migration.
  *
- * MEASURED FIRST, THEN ENFORCED. `restoreAgentWallet` accepts any 64-hex key,
- * so a user may have pasted the private key of the wallet they sign in with.
- * That is a custody pattern nobody has measured, not a broken account, and
- * switching the rule on before counting it would have those users discover it
- * at re-arm time — an agent that stops working, with no warning and no
- * migration path. The census is in worker/src/identity-audit.ts
- * (`owner is tenant`); this becomes `true` when it reports zero.
+ * So it shipped OFF, and the census ran first. Production, 2026-09-06:
+ *
+ *   owner is tenant   none of 22 — every owner key is separate from its login
+ *
+ * Twenty-two installed grants, twenty-two owner keys read, zero matches. Note
+ * the denominator: the audit distinguishes "checked and found none" from "could
+ * not check", because those look identical in a log and only one of them
+ * licenses this line. It said the former, so this is `true`.
  *
  * Same shape as ENFORCE_TRADE_ECONOMICS in worker/src/execution-cost.ts, and
  * for the same reason: a rule worth enforcing is worth observing first.
  */
-export const ENFORCE_LEGACY_TWO_PROOF = false;
+export const ENFORCE_LEGACY_TWO_PROOF = true;
 
 /** Challenge nonces live this long. Long enough to sign, short enough to not linger. */
 const CHALLENGE_TTL_MS = 5 * 60_000;

--- a/web/src/lib/binding-version.test.ts
+++ b/web/src/lib/binding-version.test.ts
@@ -101,25 +101,37 @@ test("a privy binding is refused until the deployment can verify one", async () 
   assert.match(r.ok === false ? r.why : "", /privy bindings are not enabled/);
 });
 
-test("ONE KEY SIGNING TWICE IS MEASURED, NOT YET REFUSED", async () => {
-  // The rule is right and it is switched off, on purpose. `restoreAgentWallet`
-  // accepts any 64-hex key, so somebody may have pasted the private key of the
-  // wallet they sign in with — a custody pattern nobody has counted. Enforcing
-  // before counting would have those users find out at RE-ARM time, which is
-  // the worst possible moment and offers them no migration.
+test("ONE KEY SIGNING TWICE IS NOT TWO PROOFS", async () => {
+  // Enforced only after it was counted. Production, 2026-09-06: twenty-two
+  // installed grants, twenty-two owner keys read, zero of them equal to their
+  // own tenant. So this refusal invalidates no custody pattern anybody is
+  // actually using — which is the whole reason the census came first.
   //
-  // The census is `owner is tenant` in worker/src/identity-audit.ts. When it
-  // reports zero, ENFORCE_LEGACY_TWO_PROOF becomes true and this test flips to
-  // asserting the refusal.
-  assert.equal(ENFORCE_LEGACY_TWO_PROOF, false, "measure first, then enforce");
+  // Note what is NOT asserted here: there is no global rule that an owner may
+  // never equal a tenant. `privy-did-owner-v1` allows exactly that, and takes
+  // its authentication from a verified access token instead.
+  assert.equal(ENFORCE_LEGACY_TWO_PROOF, true, "the census reported zero, so this is on");
 
   const both = privateKeyToAccount(generatePrivateKey());
   const claim = await legacyClaim(both, both);
   // One key signing the same text twice produces the SAME signature, which is
-  // what makes the condition detectable at all.
+  // what makes the condition detectable at all — and what makes the two
+  // recoveries agree while proving half of what the model claims.
   assert.equal(claim.walletSignature, claim.ownerSignature);
   const r = await verifyGrantBinding(claim);
-  assert.equal(r.ok, true, "an existing same-key account must keep working until it is counted");
+  assert.equal(r.ok, false);
+  const why = r.ok === false ? r.why : "";
+  assert.match(why, /one proof where it needs two/);
+  // And it says what to DO. A refusal on a fund-access path that only describes
+  // the cause leaves the user with an unusable agent and no next step.
+  assert.match(why, /sweep the old one from the recovery panel/);
+});
+
+test("two DIFFERENT keys still verify — the rule is about proofs, not addresses", async () => {
+  const wallet = privateKeyToAccount(generatePrivateKey());
+  const owner = privateKeyToAccount(generatePrivateKey());
+  const r = await verifyGrantBinding(await legacyClaim(wallet, owner));
+  assert.equal(r.ok, true, r.ok === false ? r.why : "");
 });
 
 test("the refusal exists, is gated on the flag, and names a remedy", () => {

--- a/worker/src/account-claim.test.ts
+++ b/worker/src/account-claim.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { planClaims, socialIdentityProblem, type AccountClaim } from "./account-claim";
+
+const A = "0x00000000000000000000000000000000000000a1";
+const B = "0x00000000000000000000000000000000000000b2";
+const T1 = "0x0000000000000000000000000000000000000001";
+const T2 = "0x0000000000000000000000000000000000000002";
+
+const hist = (account: string, tenant: string): AccountClaim => ({
+  account,
+  tenant,
+  source: "identity-history",
+});
+const grant = (account: string, tenant: string): AccountClaim => ({
+  account,
+  tenant,
+  source: "installed-grant",
+});
+const held = (account: string, tenant: string): AccountClaim => ({
+  account,
+  tenant,
+  source: "existing-claim",
+});
+
+describe("the backfill is idempotent", () => {
+  it("a fresh table takes every observed account exactly once", () => {
+    const p = planClaims([hist(A, T1), grant(A, T1), hist(B, T2)], []);
+    assert.equal(p.ok, true);
+    assert.deepEqual(p.ok && p.insert, [
+      { account: A, tenant: T1 },
+      { account: B, tenant: T2 },
+    ]);
+  });
+
+  it("THE SAME ACCOUNT FROM TWO SOURCES IS ONE CLAIM, not a conflict", () => {
+    // An installed grant's account is also in its identity's history. That is
+    // the normal case, and reading it as a dispute would fail every fleet.
+    const p = planClaims([hist(A, T1), grant(A, T1)], []);
+    assert.equal(p.ok, true);
+    assert.equal(p.ok && p.insert.length, 1);
+  });
+
+  it("re-running against a table it already wrote inserts nothing", () => {
+    const observed = [hist(A, T1), grant(A, T1), hist(B, T2)];
+    const first = planClaims(observed, []);
+    assert.equal(first.ok, true);
+    const existing = first.ok ? first.insert.map((r) => held(r.account, r.tenant)) : [];
+    const second = planClaims(observed, existing);
+    assert.equal(second.ok, true);
+    assert.deepEqual(second.ok && second.insert, []);
+    assert.equal(second.ok && second.alreadyHeld, 2);
+  });
+
+  it("case and whitespace do not manufacture a second claim", () => {
+    const p = planClaims([hist(A.toUpperCase().replace("0X", "0x"), T1), hist(` ${A} `, T1)], []);
+    assert.equal(p.ok, true);
+    assert.equal(p.ok && p.insert.length, 1);
+    assert.equal(p.ok && p.insert[0]!.account, A);
+  });
+
+  it("insert order is deterministic, so a replay writes the same rows in the same sequence", () => {
+    const one = planClaims([hist(B, T2), hist(A, T1)], []);
+    const two = planClaims([hist(A, T1), hist(B, T2)], []);
+    assert.deepEqual(one.ok && one.insert, two.ok && two.insert);
+  });
+});
+
+describe("a disputed account fails closed and never reassigns", () => {
+  it("two tenants claiming one account refuses the whole backfill", () => {
+    const p = planClaims([hist(A, T1), hist(A, T2), hist(B, T1)], []);
+    assert.equal(p.ok, false);
+    assert.equal(p.ok === false && p.conflicts.length, 1);
+    assert.deepEqual(p.ok === false && p.conflicts[0]!.tenants, [T1, T2].sort());
+  });
+
+  it("NOTHING IS WRITTEN when any account is disputed — not even the clean ones", () => {
+    // A partial backfill leaves the table looking complete while some
+    // addresses are still unclaimed, which is the state a later `ensure` would
+    // silently fill in with whoever asked first.
+    const p = planClaims([hist(A, T1), hist(A, T2), hist(B, T1)], []);
+    assert.equal(p.ok, false);
+    assert.ok(!("insert" in p));
+  });
+
+  it("a new observation that contradicts an existing claim is a conflict, not an update", () => {
+    const p = planClaims([hist(A, T2)], [held(A, T1)]);
+    assert.equal(p.ok, false);
+    assert.match(p.ok === false ? p.why : "", /not a question a migration may answer/);
+  });
+
+  it("the conflict names the account, both tenants, and where each was seen", () => {
+    const p = planClaims([hist(A, T1), grant(A, T2)], []);
+    assert.equal(p.ok, false);
+    const c = p.ok === false ? p.conflicts[0]! : null;
+    assert.equal(c?.account, A);
+    assert.deepEqual(c?.tenants, [T1, T2].sort());
+    assert.deepEqual(c?.sources, ["identity-history", "installed-grant"]);
+  });
+
+  it("an empty account or tenant is skipped, not treated as a dispute on the empty string", () => {
+    // The shape a half-written row leaves behind. Two of them are not two
+    // people arguing over an agent.
+    const p = planClaims([hist("", T1), hist("", T2), hist(A, T1)], []);
+    assert.equal(p.ok, true);
+    assert.deepEqual(p.ok && p.insert, [{ account: A, tenant: T1 }]);
+  });
+});
+
+describe("a social identity is validated at the boundary", () => {
+  const ok = { did: "did:privy:cabc", provider: "twitter", subject: "1552123" };
+
+  it("a well-formed identity has no problem", () => {
+    assert.equal(socialIdentityProblem(ok), null);
+  });
+
+  it("EMPTY IS NOT MISSING — each field is refused by name", () => {
+    // A partial index `WHERE provider IS NOT NULL` does not exclude '', so two
+    // rows carrying it collide under a constraint that looks tolerant.
+    assert.match(socialIdentityProblem({ ...ok, did: "" })!, /no DID/);
+    assert.match(socialIdentityProblem({ ...ok, did: "   " })!, /no DID/);
+    assert.match(socialIdentityProblem({ ...ok, provider: "" })!, /no provider/);
+    assert.match(socialIdentityProblem({ ...ok, subject: "" })!, /no provider user id/);
+    assert.match(socialIdentityProblem({ ...ok, subject: "\t\n" })!, /no provider user id/);
+  });
+
+  it("CASE IS NEVER FOLDED — a DID and a subject are opaque to us", () => {
+    // Neither Privy nor X documents these as case-insensitive, and merging two
+    // distinct identities is the one direction that cannot be undone. Addresses
+    // are different, and are lowercased everywhere, because the chain says so.
+    const mixed = { did: "did:privy:AbCdEf", provider: "twitter", subject: "AbC123" };
+    assert.equal(socialIdentityProblem(mixed), null);
+    // The validator must not be the place that quietly normalises them either:
+    // it reports a problem or it does not, and it returns nothing else.
+    assert.equal(typeof socialIdentityProblem(mixed), "object");
+  });
+});

--- a/worker/src/account-claim.ts
+++ b/worker/src/account-claim.ts
@@ -1,0 +1,135 @@
+/**
+ * AN ACCOUNT BELONGS TO ONE IDENTITY, EVER.
+ *
+ * Every per-agent ledger table keys on `smart_account` — trades, equity, flows,
+ * positions, cost basis, decisions. So two identities holding one account do not
+ * merely disagree about a label; they write into one partition, and neither
+ * one's history means anything afterward. The identity store had no constraint
+ * behind that at all: the check was a read of `tenantForAccount` and a write
+ * thirty lines later, which holds only while nothing runs concurrently.
+ *
+ * WHY A CLAIM TABLE AND NOT A UNIQUE INDEX ON THE CURRENT ACCOUNT.
+ * `agent_identity.accounts` is deliberately a HISTORY: a re-grant mints a new
+ * account, appends it, and keeps the slug so every published link and follow
+ * edge survives. A unique index over "the newest entry" would leave an address
+ * sitting in someone's history claimable by a different tenant — and the ledger
+ * rows under that address are permanent, so a later claim silently inherits
+ * somebody else's trades. The claim is therefore over EVERY account any
+ * identity has ever held, which is the invariant the ledger already assumes.
+ *
+ * FAIL CLOSED, NEVER REASSIGN. A backfill that finds one address claimed by two
+ * tenants does not pick the older row, the bigger book, or the first it read.
+ * Which of two people owns an agent is not a question a migration is allowed to
+ * answer. It refuses, says which address and which tenants, and leaves both
+ * rows exactly as they were.
+ *
+ * PURE. Handed candidate claims, returns a verdict. The SQL that applies it
+ * lives in identity-store.ts; this is the part that decides.
+ */
+
+/** One (account, tenant) pair, from wherever it was observed. */
+export interface AccountClaim {
+  account: string;
+  tenant: string;
+  /** Where this pair was read from, so a conflict names its sources. */
+  source: "identity-history" | "installed-grant" | "existing-claim";
+}
+
+export interface ClaimConflict {
+  account: string;
+  tenants: string[];
+  sources: string[];
+}
+
+export type ClaimPlan =
+  | { ok: true; insert: { account: string; tenant: string }[]; alreadyHeld: number }
+  | { ok: false; conflicts: ClaimConflict[]; why: string };
+
+const norm = (s: string) => s.trim().toLowerCase();
+
+/**
+ * Reduce every observed claim to the set that should exist, or refuse.
+ *
+ * IDEMPOTENT BY CONSTRUCTION. The same account mapping to the same tenant twice
+ * — which is the normal case, since an installed grant's account is also in its
+ * identity's history — collapses to one entry, and an account already recorded
+ * in `existing` is counted rather than re-inserted. Running this against a
+ * database it has already been applied to produces an empty insert list.
+ */
+export function planClaims(observed: readonly AccountClaim[], existing: readonly AccountClaim[]): ClaimPlan {
+  const byAccount = new Map<string, Map<string, Set<string>>>();
+  for (const c of [...existing, ...observed]) {
+    const account = norm(c.account);
+    const tenant = norm(c.tenant);
+    // A malformed or empty pair is not a claim. Counting it would invent a
+    // conflict on the empty string, which is the shape a half-written row
+    // leaves behind rather than a real dispute between two people.
+    if (!account || !tenant) continue;
+    const tenants = byAccount.get(account) ?? new Map<string, Set<string>>();
+    const sources = tenants.get(tenant) ?? new Set<string>();
+    sources.add(c.source);
+    tenants.set(tenant, sources);
+    byAccount.set(account, tenants);
+  }
+
+  const conflicts: ClaimConflict[] = [];
+  for (const [account, tenants] of byAccount) {
+    if (tenants.size > 1) {
+      conflicts.push({
+        account,
+        tenants: [...tenants.keys()].sort(),
+        sources: [...new Set([...tenants.values()].flatMap((s) => [...s]))].sort(),
+      });
+    }
+  }
+  if (conflicts.length > 0) {
+    return {
+      ok: false,
+      conflicts,
+      why:
+        `${conflicts.length} smart account(s) are claimed by more than one tenant. ` +
+        "Nothing was written. Which of two identities owns an agent is not a question a " +
+        "migration may answer, so this refuses rather than picking one.",
+    };
+  }
+
+  const held = new Set(existing.map((c) => norm(c.account)).filter(Boolean));
+  const insert: { account: string; tenant: string }[] = [];
+  for (const [account, tenants] of byAccount) {
+    if (held.has(account)) continue;
+    const tenant = [...tenants.keys()][0]!;
+    insert.push({ account, tenant });
+  }
+  // Deterministic order, so a replayed backfill writes the same rows in the
+  // same sequence and two replicas racing it deadlock-free.
+  insert.sort((a, b) => (a.account < b.account ? -1 : a.account > b.account ? 1 : 0));
+  return { ok: true, insert, alreadyHeld: held.size };
+}
+
+/**
+ * Is this social identity well-formed enough to be an identity at all?
+ *
+ * REJECTED AT THE BOUNDARY, NOT BY THE INDEX. A partial unique index written
+ * `WHERE provider IS NOT NULL` does not exclude the empty string — Postgres
+ * indexes `''` like any other value — so two rows carrying it collide under a
+ * constraint that looks as though it tolerates missing data. Widening the index
+ * until the malformed value fits would be solving the wrong problem: an empty
+ * provider id is not a valid identity, whoever sent it.
+ *
+ * NO CASE FOLDING. A Privy DID and a provider's user id are opaque strings
+ * whose issuer defines their equality, and neither Privy nor X documents them
+ * as case-insensitive. Lowercasing them here would silently merge two distinct
+ * identities — the one direction that is never recoverable — so they are
+ * trimmed and otherwise left exactly as issued. Addresses are different and are
+ * lowercased everywhere, because the chain says they are case-insensitive.
+ */
+export function socialIdentityProblem(social: {
+  did: string;
+  provider: string;
+  subject: string;
+}): string | null {
+  if (social.did.trim() === "") return "the social identity has no DID";
+  if (social.provider.trim() === "") return "the social identity has no provider";
+  if (social.subject.trim() === "") return "the social identity has no provider user id";
+  return null;
+}

--- a/worker/src/identity-store.integration.test.ts
+++ b/worker/src/identity-store.integration.test.ts
@@ -30,6 +30,14 @@ const ALICE = "0x00000000000000000000000000000000000000a1" as const;
 const BOB = "0x00000000000000000000000000000000000000b2" as const;
 const ACCT_1 = "0x1111111111111111111111111111111111111111" as const;
 const ACCT_2 = "0x2222222222222222222222222222222222222222" as const;
+// ONE ACCOUNT PER TENANT, in fixtures too. These tests used to hand ACCT_1 to
+// two different tenants for convenience — the exact state agent_account now
+// forbids, because every ledger table keys on smart_account and two identities
+// holding one address write into one partition. Distinct addresses here are not
+// cosmetic: reusing one would have the fixture assert the invariant is broken.
+const ACCT_3 = "0x3333333333333333333333333333333333333333" as const;
+const ACCT_4 = "0x4444444444444444444444444444444444444444" as const;
+const ACCT_5 = "0x5555555555555555555555555555555555555555" as const;
 
 describe("the slug itself", () => {
   it("is 16 characters of Crockford base32, and never i l o or u", () => {
@@ -83,7 +91,7 @@ describe("FileIdentityStore", () => {
 
   it("gives different tenants different slugs", async () => {
     const a = await store.get(ALICE);
-    const b = await store.ensure(BOB, ACCT_1);
+    const b = await store.ensure(BOB, ACCT_3);
     assert.notEqual(a!.slug, b.slug);
   });
 
@@ -119,8 +127,50 @@ describe("linking a social account", () => {
   const CAROL = "0x00000000000000000000000000000000000000c3" as const;
   const DAVE = "0x00000000000000000000000000000000000000d4" as const;
 
+  it("AN ACCOUNT BELONGS TO ONE IDENTITY, and the second tenant loses", async () => {
+    // Every per-agent ledger table keys on smart_account, so two identities
+    // holding one address do not merely disagree about a label — they write
+    // into one partition and neither one's history means anything afterward.
+    const SHARED = "0x00000000000000000000000000000000000000e5" as const;
+    const EVE = "0x00000000000000000000000000000000000000e6" as const;
+    const MAL = "0x00000000000000000000000000000000000000e7" as const;
+    await store.ensure(EVE, SHARED);
+    await assert.rejects(
+      () => store.ensure(MAL, SHARED),
+      /already claimed by a different login/,
+      "the second tenant must be refused, not merged",
+    );
+    // And the first holder is untouched — a refusal never reassigns.
+    const eve = await store.get(EVE);
+    assert.ok(eve!.accounts.includes(SHARED));
+    assert.equal(await store.get(MAL), null);
+  });
+
+  it("re-claiming your OWN account is idempotent, not a conflict", async () => {
+    const SELF = "0x00000000000000000000000000000000000000f8" as const;
+    const FRANK = "0x00000000000000000000000000000000000000f9" as const;
+    const first = await store.ensure(FRANK, SELF);
+    const again = await store.ensure(FRANK, SELF);
+    assert.equal(again.slug, first.slug, "a re-grant must never re-mint the slug");
+    assert.deepEqual(again.accounts, [SELF]);
+  });
+
+  it("a social identity with an empty provider id is refused at the boundary", async () => {
+    // Not left to a partial index, which does not exclude the empty string.
+    const G = "0x00000000000000000000000000000000000000fa" as const;
+    await store.ensure(G, "0x00000000000000000000000000000000000000fb");
+    await assert.rejects(
+      () => store.linkSocial(G, { did: "did:privy:g", provider: "twitter", subject: "  " }),
+      /no provider user id/,
+    );
+    await assert.rejects(
+      () => store.linkSocial(G, { did: "", provider: "twitter", subject: "1" }),
+      /no DID/,
+    );
+  });
+
   it("binds a DID to a tenant", async () => {
-    await store.ensure(CAROL, ACCT_1);
+    await store.ensure(CAROL, ACCT_4);
     assert.equal(
       await store.linkSocial(CAROL, {
         did: "did:privy:carol",
@@ -138,7 +188,7 @@ describe("linking a social account", () => {
     // Otherwise signing in with somebody else's X account would hand you their
     // agent. Structurally the same guard the grant intake uses on a smart
     // account, and it fails in the same direction: closed.
-    await store.ensure(DAVE, ACCT_2);
+    await store.ensure(DAVE, ACCT_5);
     assert.equal(
       await store.linkSocial(DAVE, {
         did: "did:privy:carol",

--- a/worker/src/identity-store.ts
+++ b/worker/src/identity-store.ts
@@ -60,6 +60,7 @@ import { randomBytes } from "node:crypto";
 import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { merrymenHome } from "./home";
+import { planClaims, socialIdentityProblem, type AccountClaim, type ClaimPlan } from "./account-claim";
 
 /**
  * Crockford base32, lowercased: no i, l, o or u, so a slug read aloud or
@@ -177,6 +178,16 @@ export class FileIdentityStore implements IdentityStore {
     }
   }
   async ensure(tenant: `0x${string}`, account: `0x${string}`): Promise<PublicIdentity> {
+    // ONE IDENTITY PER ACCOUNT, on this backend too. Single-process and
+    // single-writer, so a scan is the whole enforcement — but the RULE has to
+    // be the same one, or a self-hosted install permits what hosted refuses.
+    const a = account.toLowerCase();
+    for (const other of await this.all()) {
+      if (other.tenant.toLowerCase() === tenant.toLowerCase()) continue;
+      if (other.accounts.some((x) => x.toLowerCase() === a)) {
+        throw new AccountAlreadyClaimed(a, other.tenant.toLowerCase());
+      }
+    }
     const existing = await this.get(tenant);
     const rec: PublicIdentity = existing
       ? { ...existing, accounts: withAccount(existing.accounts, account), updatedAt: now() }
@@ -215,6 +226,10 @@ export class FileIdentityStore implements IdentityStore {
     return (await this.all()).find((r) => r.social?.did === did) ?? null;
   }
   async linkSocial(tenant: `0x${string}`, social: SocialIdentity): Promise<boolean> {
+    // Same boundary rule as the Postgres backend. The two must refuse the same
+    // inputs or a self-hosted install accepts what the hosted one rejects.
+    const problem = socialIdentityProblem(social);
+    if (problem) throw new Error(`refusing to link a social identity: ${problem}`);
     const holder = await this.byDid(social.did);
     if (holder && holder.tenant.toLowerCase() !== tenant.toLowerCase()) return false;
     const rec = await this.get(tenant);
@@ -292,8 +307,104 @@ function fromRow(r: Row): PublicIdentity {
  * NO requireDek(). See the header: nothing in this record is a secret, and
  * needing the money key to render a public page would be the wrong dependency.
  */
+export class AccountAlreadyClaimed extends Error {
+  constructor(
+    readonly account: string,
+    readonly holder: string,
+  ) {
+    super(`the smart account ${account} is already claimed by a different login`);
+    this.name = "AccountAlreadyClaimed";
+  }
+}
+
+/**
+ * Bring every account any identity has ever held into the claim table, or
+ * refuse. IDEMPOTENT: re-running it against a database it has already been
+ * applied to inserts nothing and reports no conflict.
+ *
+ * Reads three sources, because the invariant has to hold across all of them:
+ * the whole `accounts` HISTORY of every identity (not merely the current one —
+ * the ledger rows under a superseded address are permanent), every installed
+ * grant's `smartAccount`, and whatever the claim table already holds.
+ */
+async function backfillClaims(c: PgClientLike): Promise<ClaimState> {
+  const observed: AccountClaim[] = [];
+
+  const { rows: idRows } = await c.query(`SELECT tenant, accounts FROM agent_identity`);
+  for (const r of idRows) {
+    const raw = (r as { accounts?: unknown }).accounts;
+    let accounts: unknown[] = [];
+    if (Array.isArray(raw)) accounts = raw;
+    else if (typeof raw === "string") {
+      try {
+        const parsed = JSON.parse(raw) as unknown;
+        if (Array.isArray(parsed)) accounts = parsed;
+      } catch {
+        // An unreadable history is not a claim we can vouch for. Skipping it
+        // cannot create a false conflict; it can only leave an address
+        // unclaimed, which the next successful write repairs.
+      }
+    }
+    for (const a of accounts) {
+      observed.push({ account: String(a), tenant: String(r.tenant ?? ""), source: "identity-history" });
+    }
+  }
+
+  try {
+    const { rows: grantRows } = await c.query(
+      `SELECT tenant, grant_json->>'smartAccount' AS smart_account FROM grants`,
+    );
+    for (const r of grantRows) {
+      const acc = (r as { smart_account?: unknown }).smart_account;
+      if (acc === null || acc === undefined) continue;
+      observed.push({ account: String(acc), tenant: String(r.tenant ?? ""), source: "installed-grant" });
+    }
+  } catch {
+    // The grants table lives in the same database but is owned by another
+    // store, and a deployment that has not created it yet is a fresh install
+    // with nothing to backfill.
+  }
+
+  const { rows: claimRows } = await c.query(`SELECT smart_account, tenant FROM agent_account`);
+  const existing: AccountClaim[] = claimRows.map((r) => ({
+    account: String(r.smart_account ?? ""),
+    tenant: String(r.tenant ?? ""),
+    source: "existing-claim" as const,
+  }));
+
+  const plan = planClaims(observed, existing);
+  if (!plan.ok) return plan;
+
+  // ONE TRANSACTION FOR THE WHOLE BACKFILL. A partial backfill would leave the
+  // table looking complete while some addresses were still unclaimed.
+  await c.query("BEGIN");
+  try {
+    for (const row of plan.insert) {
+      await c.query(
+        `INSERT INTO agent_account (smart_account, tenant, claimed_at)
+         VALUES ($1, $2, $3) ON CONFLICT (smart_account) DO NOTHING`,
+        [row.account, row.tenant, Math.floor(Date.now() / 1000)],
+      );
+    }
+    await c.query("COMMIT");
+  } catch (e) {
+    await c.query("ROLLBACK").catch(() => {});
+    throw e;
+  }
+  if (plan.insert.length > 0) {
+    console.log(
+      `[identity] claimed ${plan.insert.length} account(s); ${plan.alreadyHeld} already held`,
+    );
+  }
+  return plan;
+}
+
+type ClaimState = ClaimPlan;
+
 export class PgIdentityStore implements IdentityStore {
   private ready: Promise<PgClientLike> | null = null;
+  /** Set by the backfill. `ok: false` makes every new claim refuse. */
+  private claims: ClaimState = { ok: true, insert: [], alreadyHeld: 0 };
   constructor(private url: string) {}
   private async client(): Promise<PgClientLike> {
     if (!this.ready) {
@@ -326,6 +437,27 @@ export class PgIdentityStore implements IdentityStore {
           `CREATE UNIQUE INDEX IF NOT EXISTS agent_identity_subject
              ON agent_identity (provider, subject) WHERE provider IS NOT NULL`,
         );
+        // AN ACCOUNT BELONGS TO ONE IDENTITY, EVER. See account-claim.ts for
+        // why this is a table rather than a unique index over the newest entry
+        // in the history array.
+        await c.query(
+          `CREATE TABLE IF NOT EXISTS agent_account (
+             smart_account TEXT PRIMARY KEY,
+             tenant TEXT NOT NULL,
+             claimed_at BIGINT NOT NULL
+           )`,
+        );
+        await c.query(`CREATE INDEX IF NOT EXISTS agent_account_tenant ON agent_account (tenant)`);
+        this.claims = await backfillClaims(c);
+        if (this.claims.ok === false) {
+          // LOUD, AND READS STAY UP. A public page must still render; what must
+          // not happen is a new claim landing on top of a dispute nobody has
+          // resolved. `ensure` refuses while this is set.
+          console.error(`[identity] ACCOUNT CLAIM CONFLICT — ${this.claims.why}`);
+          for (const c2 of this.claims.conflicts) {
+            console.error(`[identity]   ${c2.account} claimed by ${c2.tenants.join(" and ")} (${c2.sources.join(", ")})`);
+          }
+        }
         return c;
       })();
     }
@@ -338,37 +470,101 @@ export class PgIdentityStore implements IdentityStore {
     ]);
     return rows[0] ? fromRow(rows[0] as unknown as Row) : null;
   }
+  /**
+   * Claim the account and update the identity IN ONE TRANSACTION.
+   *
+   * The claim and the history write cannot be two statements with a gap between
+   * them — that is the read-then-write race this table exists to remove. So the
+   * order inside a single transaction is: insert the claim, read back who holds
+   * it, and only proceed if it is us.
+   *
+   * A CONCURRENT SECOND TENANT LOSES DETERMINISTICALLY. Both open a
+   * transaction; the first INSERT takes a row lock on the primary key, the
+   * second blocks on it until the first commits, then its ON CONFLICT DO
+   * NOTHING writes nothing and the read-back returns the first tenant. There is
+   * no interleaving in which both proceed, and no ordering in which the loser
+   * silently overwrites.
+   */
   async ensure(tenant: `0x${string}`, account: `0x${string}`): Promise<PublicIdentity> {
     const c = await this.client();
     const t = tenant.toLowerCase();
-    const existing = await this.get(tenant);
-    if (existing) {
-      const accounts = withAccount(existing.accounts, account);
-      await c.query(`UPDATE agent_identity SET accounts = $2, updated_at = $3 WHERE tenant = $1`, [
-        t,
-        JSON.stringify(accounts),
-        now(),
-      ]);
-      return { ...existing, accounts, updatedAt: now() };
+    const a = account.toLowerCase();
+    if (this.claims.ok === false) {
+      // The backfill found an address held by two tenants. Reads stay up — a
+      // public page must still render — but nothing new is claimed on top of a
+      // dispute nobody has resolved.
+      throw new Error(`refusing to claim an account: ${this.claims.why}`);
     }
-    // A slug collision at 80 bits is theoretical, but a retry turns a 500 into
-    // a no-op and costs nothing on the path that never collides.
-    for (let attempt = 0; attempt < 3; attempt++) {
-      const slug = mintSlug();
-      try {
-        const { rows } = await c.query(
-          `INSERT INTO agent_identity (tenant, slug, accounts, created_at, updated_at)
-           VALUES ($1, $2, $3, $4, $4)
-           ON CONFLICT (tenant) DO UPDATE SET accounts = EXCLUDED.accounts, updated_at = EXCLUDED.updated_at
-           RETURNING *`,
-          [t, slug, JSON.stringify([account.toLowerCase()]), now()],
-        );
-        if (rows[0]) return fromRow(rows[0] as unknown as Row);
-      } catch (e) {
-        if (attempt === 2) throw e;
+
+    await c.query("BEGIN");
+    try {
+      await c.query(
+        `INSERT INTO agent_account (smart_account, tenant, claimed_at)
+         VALUES ($1, $2, $3) ON CONFLICT (smart_account) DO NOTHING`,
+        [a, t, now()],
+      );
+      const { rows: held } = await c.query(`SELECT tenant FROM agent_account WHERE smart_account = $1`, [a]);
+      const holder = held[0] ? String(held[0].tenant).toLowerCase() : null;
+      if (holder && holder !== t) {
+        // NOT AN ERROR TO SWALLOW. Every ledger table keys on this address, so
+        // letting a second tenant through would merge two books.
+        await c.query("ROLLBACK");
+        throw new AccountAlreadyClaimed(a, holder);
       }
+
+      const existing = await this.getWithin(c, tenant);
+      if (existing) {
+        const accounts = withAccount(existing.accounts, account);
+        await c.query(`UPDATE agent_identity SET accounts = $2, updated_at = $3 WHERE tenant = $1`, [
+          t,
+          JSON.stringify(accounts),
+          now(),
+        ]);
+        await c.query("COMMIT");
+        return { ...existing, accounts, updatedAt: now() };
+      }
+
+      // A slug collision at 80 bits is theoretical, but a retry turns a 500
+      // into a no-op and costs nothing on the path that never collides.
+      for (let attempt = 0; attempt < 3; attempt++) {
+        const slug = mintSlug();
+        try {
+          const { rows } = await c.query(
+            `INSERT INTO agent_identity (tenant, slug, accounts, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $4)
+             ON CONFLICT (tenant) DO UPDATE SET accounts = EXCLUDED.accounts, updated_at = EXCLUDED.updated_at
+             RETURNING *`,
+            [t, slug, JSON.stringify([a]), now()],
+          );
+          if (rows[0]) {
+            await c.query("COMMIT");
+            return fromRow(rows[0] as unknown as Row);
+          }
+        } catch (e) {
+          // A failed statement poisons the transaction, so the retry needs a
+          // savepoint rather than another attempt on a dead one.
+          if (attempt === 2) throw e;
+          await c.query("ROLLBACK");
+          await c.query("BEGIN");
+          await c.query(
+            `INSERT INTO agent_account (smart_account, tenant, claimed_at)
+             VALUES ($1, $2, $3) ON CONFLICT (smart_account) DO NOTHING`,
+            [a, t, now()],
+          );
+        }
+      }
+      await c.query("ROLLBACK");
+      throw new Error("could not mint a public id");
+    } catch (e) {
+      await c.query("ROLLBACK").catch(() => {});
+      throw e;
     }
-    throw new Error("could not mint a public id");
+  }
+
+  /** `get`, but inside a transaction already in progress. */
+  private async getWithin(c: PgClientLike, tenant: `0x${string}`): Promise<PublicIdentity | null> {
+    const { rows } = await c.query(`SELECT * FROM agent_identity WHERE tenant = $1`, [tenant.toLowerCase()]);
+    return rows[0] ? fromRow(rows[0] as unknown as Row) : null;
   }
   async all(): Promise<PublicIdentity[]> {
     const c = await this.client();
@@ -399,6 +595,15 @@ export class PgIdentityStore implements IdentityStore {
    * the same pair still updates its own row and returns true.
    */
   async linkSocial(tenant: `0x${string}`, social: SocialIdentity): Promise<boolean> {
+    // REJECTED AT THE BOUNDARY, not by the index. A partial unique index
+    // (`WHERE provider IS NOT NULL`) does not exclude the empty string, so two
+    // rows carrying one collide under a constraint that looks as though it
+    // tolerates missing data. An empty provider id is not a valid identity
+    // whoever sent it, and widening the index until it fits solves the wrong
+    // problem. Throws rather than returning false: `false` means "somebody else
+    // holds this", and a malformed request is a different fact.
+    const problem = socialIdentityProblem(social);
+    if (problem) throw new Error(`refusing to link a social identity: ${problem}`);
     const c = await this.client();
     let rowCount: number | null | undefined;
     try {


### PR DESCRIPTION
Closes the audit-gated work from PR A. Enforces both guarantees the production
census was blocking on, and nothing else — no Privy code.

### The census that authorised this

```
rows=22 tenants=22 grants=22 dupCurrentAccount=0 dupAccountHistory=0
dupPrivyDid=0 dupProviderSubject=0 dupInstalledGrant=0
zeroAddressResidue=0 ownerIsTenant=0/22 emptyIdentityKeys=0
unknownBindingVersions=0 storeDrift=0 safeToConstrain=true
```

### `agent_account` — a claim table, not an index on the current account

`agent_identity.accounts` is deliberately a **history**: a re-grant mints a new
account, appends it, and keeps the slug so every published link and follow edge
survives. A unique index over *the newest entry* would leave an address sitting
in someone's history claimable by a different tenant — and the ledger rows under
that address are permanent, so a later claim silently inherits somebody else's
trades.

**Staged, as specified:** create → backfill all three sources (full account
history, installed grants, existing claims) → verify → then claim.

**Idempotent.** The same account from two sources is one claim — the normal case,
since a grant's account is also in its identity's history. Re-running against an
already-applied database inserts nothing.

**Fail closed, never reassign.** One address held by two tenants refuses the
*whole* backfill, not just the disputed row — a partial backfill leaves the table
looking complete while some addresses are unclaimed, which is precisely the state
a later claim fills in with whoever asks first. It names the address, both
tenants, and where each was seen. Reads stay up; no new claim lands on an
unresolved dispute.

### One transaction, not check-then-write

```
BEGIN
  INSERT claim ON CONFLICT DO NOTHING
  SELECT holder            -- must be us, else ROLLBACK
  UPDATE identity/history
COMMIT
```

A concurrent second tenant blocks on the primary-key row lock, sees the first
tenant on read-back, and loses deterministically.

### Empty identifiers rejected at the boundary

`WHERE provider IS NOT NULL` does not exclude `''`. `linkSocial` throws on an
empty `did`, `provider` or `subject` — it does not return `false`, because
`false` means *somebody else holds this* and malformed is a different fact.

**No case folding on DIDs or subjects.** Neither Privy nor X documents them as
case-insensitive; merging two distinct identities is the one irreversible
direction. Addresses stay lowercased — the chain says they're case-insensitive.

### `ENFORCE_LEGACY_TWO_PROOF = true`

22 grants, 22 owner keys read, 0 equal to their tenant. The audit distinguishes
"checked and found none" from "could not check" because only one licenses this.

### Fixtures

The integration tests handed one account to two tenants for convenience — the
exact state this forbids. Each now has its own, and three new tests pin the
invariant rather than the fixture.

2644 tests pass, both typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
