### PR TITLE
privy: the embedded wallet becomes the Kernel owner

### DIFF
--- a/web/src/app/api/grants/route.ts
+++ b/web/src/app/api/grants/route.ts
@@ -23,6 +23,7 @@ import {
   type StoredGrant,
 } from "@merrymen/core";
 import { requestOrigin, tenantOf, verifyGrantBinding } from "@/lib/auth";
+import { privyTokenOf, verifyPrivyToken } from "@/lib/privy";
 import { withReadDb } from "@/lib/ledger";
 import { getGrantStore } from "@merrymen/grant-store";
 import { getIdentityStore } from "@merrymen/identity-store";
@@ -143,12 +144,32 @@ export async function POST(req: Request) {
     // only meaningful under `privy-did-owner-v1`; arriving on a legacy claim it
     // is unverified client text that would be persisted verbatim and read back
     // later as though the server had checked it.
+    if (binding.version === "privy-did-owner-v1" && typeof binding.did !== "string") {
+      return NextResponse.json(
+        { error: "this grant claims a privy binding but names no identity" },
+        { status: 400 },
+      );
+    }
     if (binding.did !== undefined && binding.version !== "privy-did-owner-v1") {
       return NextResponse.json(
         { error: "this grant carries an identity its binding version does not verify" },
         { status: 400 },
       );
     }
+    // ── the privy arm needs a VERIFIED token, and this is where it is read ──
+    //
+    // verifyGrantBinding holds no Privy credential and does no token
+    // verification: it is handed the DID or it refuses. So a grant declaring
+    // `privy-did-owner-v1` must arrive with its access token, and a deployment
+    // that cannot verify one cannot accept the binding — which is the correct
+    // failure, not a fallback to the legacy check.
+    let verifiedDid: string | null = null;
+    if (binding.version === "privy-did-owner-v1") {
+      const token = await verifyPrivyToken(privyTokenOf(req));
+      if (!token.ok) return NextResponse.json({ error: token.why }, { status: 401 });
+      verifiedDid = token.identity.did;
+    }
+
     const bound = await verifyGrantBinding({
       origin: requestOrigin(req),
       tenant,
@@ -166,6 +187,8 @@ export async function POST(req: Request) {
       // `privy-did-owner-v1` would be verified under LEGACY rules instead of
       // refused, which is precisely the downgrade the versioning exists to stop.
       version: binding.version,
+      did: binding.did,
+      verifiedDid,
     });
     if (!bound.ok) {
       return NextResponse.json({ error: bound.why }, { status: 403 });

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -262,6 +262,20 @@ export async function verifyGrantBinding(args: {
    * the other.
    */
   version?: unknown;
+  /**
+   * The DID the grant CLAIMS, echoed so the signed text can be rebuilt.
+   * UNTRUSTED — it is compared against `verifiedDid` and is never an identity.
+   */
+  did?: unknown;
+  /**
+   * The DID the ROUTE verified out of a Privy access token.
+   *
+   * This function performs no token verification of its own and holds no Privy
+   * credential; it is handed the result. The privy arm refuses outright when
+   * there is none, so a caller that forgot to verify gets a refusal rather than
+   * a binding checked with its authentication half missing.
+   */
+  verifiedDid?: string | null;
   now?: number;
 }): Promise<BindingResult> {
   // ── WHICH SECURITY MODEL, DECIDED ONCE AND OUT LOUD ──────────────────────
@@ -279,18 +293,66 @@ export async function verifyGrantBinding(args: {
   if (!isBindingVersion(version)) {
     return { ok: false, why: "this grant's binding version is not one this deployment verifies" };
   }
+  const now = args.now ?? Date.now();
+
   if (version === "privy-did-owner-v1") {
-    // PR B implements this arm. Refusing is the correct behaviour until then:
-    // a deployment that cannot verify a Privy binding must not fall back to
-    // verifying it as a legacy one, which would read a single owner signature
-    // as if it were two independent proofs.
-    return {
-      ok: false,
-      why: "privy bindings are not enabled on this deployment yet",
-    };
+    // ── privy-did-owner-v1: A VERIFIED TOKEN AND ONE SIGNATURE ─────────────
+    //
+    // Still two proofs, made of different evidence. Authentication is the
+    // access token the ROUTE verified — this function never sees a token and
+    // never decides whether one is valid; it is handed the DID that came out
+    // of one, and refuses if the caller has none. Owner authority is a
+    // signature over a challenge whose text CONTAINS that DID, so a signature
+    // captured under one identity cannot be replayed under another.
+    if (!args.verifiedDid) {
+      // The route did not verify a token. Refusing is the only safe reading:
+      // accepting would make the owner signature the sole proof, and that is
+      // the legacy model with its authentication half removed.
+      return { ok: false, why: "this claim needs a verified privy identity and none was supplied" };
+    }
+    if (typeof args.did !== "string" || args.did !== args.verifiedDid) {
+      // The grant echoes the DID so the signed text can be reconstructed. It is
+      // never an identity — it is compared to the verified one and any
+      // difference is a refusal.
+      return { ok: false, why: "this grant names a different identity than the one that signed in" };
+    }
+    // THE EMBEDDED WALLET IS BOTH THE LOGIN AND THE OWNER, and that is the
+    // model — not an accident to be tolerated. It is why this version exists
+    // separately: the legacy arm's premise is two keys, and asserting that here
+    // would refuse every Privy grant. What must hold instead is that the owner
+    // is the tenant the DID resolved to, or a verified login could install a
+    // grant on an owner it does not control.
+    if (args.owner.toLowerCase() !== args.tenant.toLowerCase()) {
+      return {
+        ok: false,
+        why: "this agent's owner is not the wallet you signed in with",
+      };
+    }
+    const privyGate = checkNonce(args.nonce, args.origin, now);
+    if (!privyGate.ok) return { ok: false, why: privyGate.why };
+
+    const privyMessage = bindingMessage({
+      version: "privy-did-owner-v1",
+      origin: args.origin,
+      nonce: args.nonce,
+      owner: args.owner,
+      smartAccount: args.smartAccount,
+      chainId: args.chainId,
+      did: args.verifiedDid,
+    });
+    let privyOwner: `0x${string}`;
+    try {
+      privyOwner = await recoverMessageAddress({ message: privyMessage, signature: args.ownerSignature });
+    } catch {
+      return { ok: false, why: "binding signature did not recover" };
+    }
+    if (privyOwner.toLowerCase() !== args.owner.toLowerCase()) {
+      return { ok: false, why: "the agent wallet did not sign — its owner key is not held here" };
+    }
+    usedNonces.add(args.nonce);
+    return { ok: true, tenant: args.tenant.toLowerCase() as `0x${string}` };
   }
 
-  const now = args.now ?? Date.now();
   const gate = checkNonce(args.nonce, args.origin, now);
   if (!gate.ok) return { ok: false, why: gate.why };
 

--- a/web/src/lib/binding-version.test.ts
+++ b/web/src/lib/binding-version.test.ts
@@ -90,15 +90,110 @@ test("A VERSION THIS DEPLOYMENT DOES NOT KNOW IS REFUSED, never best-guessed", a
   }
 });
 
-test("a privy binding is refused until the deployment can verify one", async () => {
-  // The failure direction that matters: an unimplemented arm must NOT fall back
-  // to the legacy one, which would read a single owner signature as if it were
-  // two independent proofs.
+test("A PRIVY BINDING WITHOUT A VERIFIED TOKEN IS REFUSED", async () => {
+  // The validator holds no Privy credential and verifies no token — it is
+  // HANDED the DID by the route that did. So a caller that forgot to verify
+  // gets a refusal, never a binding checked with its authentication half
+  // missing. That is the failure direction that matters: the privy arm must
+  // not degrade into "one owner signature was enough".
   const wallet = privateKeyToAccount(generatePrivateKey());
   const owner = privateKeyToAccount(generatePrivateKey());
-  const r = await verifyGrantBinding(await legacyClaim(wallet, owner, "privy-did-owner-v1"));
+  const r = await verifyGrantBinding({
+    ...(await legacyClaim(wallet, owner, "privy-did-owner-v1")),
+    did: "did:privy:someone",
+    // verifiedDid deliberately absent — the route did not verify a token.
+  });
   assert.equal(r.ok, false);
-  assert.match(r.ok === false ? r.why : "", /privy bindings are not enabled/);
+  assert.match(r.ok === false ? r.why : "", /needs a verified privy identity/);
+});
+
+test("a privy binding whose claimed DID differs from the verified one is refused", async () => {
+  // The grant echoes the DID so the signed text can be rebuilt. It is never an
+  // identity — it is compared, and any difference is a refusal.
+  const wallet = privateKeyToAccount(generatePrivateKey());
+  const owner = privateKeyToAccount(generatePrivateKey());
+  const r = await verifyGrantBinding({
+    ...(await legacyClaim(wallet, owner, "privy-did-owner-v1")),
+    did: "did:privy:attacker",
+    verifiedDid: "did:privy:victim",
+  });
+  assert.equal(r.ok, false);
+  assert.match(r.ok === false ? r.why : "", /different identity than the one that signed in/);
+});
+
+test("a privy binding whose owner is not the signed-in tenant is refused", async () => {
+  // Under this version the embedded wallet is BOTH the login and the owner —
+  // that is the model, and it is why the version exists separately. What must
+  // hold is that the owner IS the tenant the DID resolved to, or a verified
+  // login could install a grant on an owner it does not control.
+  const wallet = privateKeyToAccount(generatePrivateKey());
+  const owner = privateKeyToAccount(generatePrivateKey());
+  const did = "did:privy:same";
+  const r = await verifyGrantBinding({
+    ...(await legacyClaim(wallet, owner, "privy-did-owner-v1")),
+    did,
+    verifiedDid: did,
+  });
+  assert.equal(r.ok, false);
+  assert.match(r.ok === false ? r.why : "", /not the wallet you signed in with/);
+});
+
+test("A COMPLETE PRIVY BINDING VERIFIES — token, matching DID, owner-is-tenant", async () => {
+  const embedded = privateKeyToAccount(generatePrivateKey());
+  const did = "did:privy:clbeta0001";
+  const nonce = issueChallengeNonce(ORIGIN);
+  const message = bindingMessage({
+    version: "privy-did-owner-v1",
+    origin: ORIGIN,
+    nonce,
+    owner: embedded.address,
+    smartAccount: SMART,
+    chainId: CHAIN,
+    did,
+  });
+  const r = await verifyGrantBinding({
+    origin: ORIGIN,
+    // tenant IS the embedded wallet: what the auth route minted the session for.
+    tenant: embedded.address.toLowerCase() as `0x${string}`,
+    nonce,
+    owner: embedded.address,
+    smartAccount: SMART,
+    chainId: CHAIN,
+    ownerSignature: await embedded.signMessage({ message }),
+    version: "privy-did-owner-v1",
+    did,
+    verifiedDid: did,
+  });
+  assert.equal(r.ok, true, r.ok === false ? r.why : "");
+});
+
+test("a privy signature cannot be replayed under a different identity", async () => {
+  // The DID is INSIDE the signed bytes, so a signature made under one identity
+  // reconstructs to different text under another and fails to recover.
+  const embedded = privateKeyToAccount(generatePrivateKey());
+  const nonce = issueChallengeNonce(ORIGIN);
+  const signedUnder = bindingMessage({
+    version: "privy-did-owner-v1",
+    origin: ORIGIN,
+    nonce,
+    owner: embedded.address,
+    smartAccount: SMART,
+    chainId: CHAIN,
+    did: "did:privy:first",
+  });
+  const r = await verifyGrantBinding({
+    origin: ORIGIN,
+    tenant: embedded.address.toLowerCase() as `0x${string}`,
+    nonce,
+    owner: embedded.address,
+    smartAccount: SMART,
+    chainId: CHAIN,
+    ownerSignature: await embedded.signMessage({ message: signedUnder }),
+    version: "privy-did-owner-v1",
+    did: "did:privy:second",
+    verifiedDid: "did:privy:second",
+  });
+  assert.equal(r.ok, false);
 });
 
 test("ONE KEY SIGNING TWICE IS NOT TWO PROOFS", async () => {

--- a/web/src/lib/clear-grant.test.ts
+++ b/web/src/lib/clear-grant.test.ts
@@ -52,11 +52,40 @@ test("clearGrant ARCHIVES before it removes — the key survives a kill", () => 
 test("the server copy still omits the owner key — the reason this matters", () => {
   // If this ever stops being true the severity changes completely, so the two
   // facts are pinned together rather than in separate files that could drift.
+  //
+  // The condition gained a SECOND arm when Privy became a possible owner: a
+  // Privy-owned grant has no key to omit, because merrymen never holds one.
+  // Both arms are asserted, because either going missing is a different
+  // disaster — dropping `hostedAs` posts a key to the server, and dropping the
+  // binding check makes a Privy grant read `privateKey` off a signer that has
+  // no such field.
   assert.match(
     SESSION,
-    /hostedAs \? \{\} : \{ demoOwnerPrivateKey: ownerPrivateKey \}/,
-    "hosted grants must not send the owner key to the server",
+    /hostedAs \|\| ownerSigner\.binding !== "legacy-wallet-owner-v1"/,
+    "hosted grants must not send the owner key, and a privy owner has none to send",
   );
+  assert.match(
+    SESSION,
+    /demoOwnerPrivateKey: ownerSigner\.privateKey/,
+    "the browser copy of a browser-generated owner still carries its key",
+  );
+});
+
+test("A PRIVY-OWNED GRANT HAS NO OWNER KEY ANYWHERE — and the trade-off is stated", () => {
+  // The custody this file exists to protect changes shape rather than
+  // disappearing. There is no localStorage key to destroy on a kill, which
+  // removes that whole class of irreversible loss — and equally means merrymen
+  // cannot sweep such an account from a backed-up key, because none exists.
+  // Recovery for a Privy-owned Merryman is signer-based and NOT yet built, so
+  // the code must say so where somebody will read it.
+  const at = SESSION.indexOf("export async function createPrivyOwnedWallet");
+  assert.notEqual(at, -1, "the privy-owned mint path must exist");
+  // Whitespace-normalised: a doc comment wraps, so a phrase that reads as one
+  // sentence is several lines with ` * ` between them. Matching the raw text
+  // would make this assertion fail on a reflow rather than on a real change.
+  const doc = SESSION.slice(Math.max(0, at - 1400), at).replace(/\s*\*\s*/g, " ").replace(/\s+/g, " ");
+  assert.match(doc, /no key for merrymen to hold/i);
+  assert.match(doc, /NOT yet built/i, "the recovery gap must be stated, not implied");
 });
 
 test("the archive helper is keyed by account, so a kill cannot clobber another wallet", () => {

--- a/web/src/lib/mint-options.test.ts
+++ b/web/src/lib/mint-options.test.ts
@@ -108,8 +108,12 @@ describe("the backup gate gets the copy with the key", () => {
     assert.match(SESSION_SRC, /local: Grant;/);
     assert.match(SESSION_SRC, /return \{ grant, local: localGrant, handoff:/);
     // And the server copy still omits the key when hosted — the property that
-    // made them different in the first place, and worth keeping.
-    assert.match(SESSION_SRC, /\.\.\.\(hostedAs \? \{\} : \{ demoOwnerPrivateKey: ownerPrivateKey \}\)/);
+    // made them different in the first place, and worth keeping. The condition
+    // gained a second arm: a PRIVY owner has no key to omit, because merrymen
+    // never holds one. Both arms must be present, or a Privy grant would try to
+    // attach a `privateKey` field that does not exist on its signer.
+    assert.match(SESSION_SRC, /hostedAs \|\| ownerSigner\.binding !== "legacy-wallet-owner-v1"/);
+    assert.match(SESSION_SRC, /demoOwnerPrivateKey: ownerSigner\.privateKey/);
   });
 
   it("every mint call site takes `local`, never the server copy", () => {

--- a/web/src/lib/session.ts
+++ b/web/src/lib/session.ts
@@ -43,7 +43,7 @@
  * is worker-enforced until the breaker contract ships (Phase 2).
  */
 
-import { createPublicClient, erc20Abi, http, parseAbi, type Address } from "viem";
+import { createPublicClient, erc20Abi, http, parseAbi, type Address, type LocalAccount } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { createKernelAccount } from "@zerodev/sdk";
 import { KERNEL_V3_3, getEntryPoint } from "@zerodev/sdk/constants";
@@ -153,8 +153,47 @@ const short = (a: string) => `${a.slice(0, 6)}…${a.slice(-4)}`;
  * the same owner key always reproduces the same smart account, so an existing
  * funded wallet can be re-armed with a brand-new session key.
  */
+/**
+ * WHO OWNS A MERRYMAN'S KERNEL ACCOUNT.
+ *
+ * This used to be a private key, because there was only one kind of owner: a
+ * keypair generated in this browser and kept in localStorage. Privy adds a
+ * second — an embedded wallet whose key merrymen never sees and cannot export
+ * — so the parameter had to become the thing both actually are, which is a
+ * SIGNER. The Kernel derivation, the wall and the session key are untouched by
+ * the change; only where the signature comes from differs.
+ *
+ * `binding` is carried alongside because the two owners prove themselves
+ * differently, and which model applies is never inferred: a browser key
+ * co-signs beside the login wallet, an embedded wallet signs once and its
+ * authentication is a verified access token.
+ */
+export type OwnerSigner =
+  | {
+      /**
+       * A viem LocalAccount. `privateKeyToAccount` for a browser-held key,
+       * `toViemAccount({ wallet })` for a Privy embedded wallet — Privy returns
+       * a LocalAccount precisely so it drops into code like this one.
+       *
+       * NOT an EIP-1193 provider. ZeroDev's `toSigner` resolves a provider's
+       * address with `Promise.any([eth_requestAccounts, eth_accounts])` and
+       * takes [0] — whichever RPC answers first. The owner address decides the
+       * ACCOUNT address, so that race would decide which Merryman you get.
+       */
+      account: LocalAccount;
+      binding: "legacy-wallet-owner-v1";
+      /** The key that controls the funds. Present ONLY for a browser-generated owner. */
+      privateKey: `0x${string}`;
+    }
+  | {
+      account: LocalAccount;
+      binding: "privy-did-owner-v1";
+      /** The verified DID this owner signs under. Appears in the signed text. */
+      did: string;
+    };
+
 async function mintGrant(
-  ownerPrivateKey: `0x${string}`,
+  ownerSigner: OwnerSigner,
   caps: GrantCaps,
   onStatus: (status: string) => void,
   chainId: number,
@@ -202,7 +241,7 @@ async function mintGrant(
   const entryPoint = getEntryPoint("0.7");
   const kernelVersion = KERNEL_V3_3;
 
-  const ownerAccount = privateKeyToAccount(ownerPrivateKey);
+  const ownerAccount = ownerSigner.account;
   const owner = ownerAccount.address;
 
   onStatus("deriving your smart account…");
@@ -350,7 +389,12 @@ async function mintGrant(
     // custodian of a single owner key. The owner key still lives in this
     // browser's localStorage below, which is what makes client-side recovery
     // work with no server involvement.
-    ...(hostedAs ? {} : { demoOwnerPrivateKey: ownerPrivateKey }),
+    // ONLY A BROWSER-GENERATED OWNER HAS A KEY TO OMIT. A Privy owner has none
+    // to carry in the first place, which is the point: there is no copy of it
+    // anywhere in merrymen to leak, back up, or forget to strip.
+    ...(hostedAs || ownerSigner.binding !== "legacy-wallet-owner-v1"
+      ? {}
+      : { demoOwnerPrivateKey: ownerSigner.privateKey }),
   };
 
   // HOSTED: prove this account belongs to the signed-in wallet before offering
@@ -363,7 +407,7 @@ async function mintGrant(
       owner,
       smartAccount: account.address,
       chainId,
-      ownerAccount,
+      ownerSigner,
       tenant: hostedAs,
     });
     grant.binding = binding;
@@ -385,7 +429,10 @@ async function mintGrant(
   // a named local so it can be returned as well as stored -- the UI needs the
   // copy with the key, and reading it back off localStorage to find that out
   // was the bug.
-  const localGrant: Grant = { ...grant, demoOwnerPrivateKey: ownerPrivateKey };
+  const localGrant: Grant =
+    ownerSigner.binding === "legacy-wallet-owner-v1"
+      ? { ...grant, demoOwnerPrivateKey: ownerSigner.privateKey }
+      : { ...grant };
   localStorage.setItem(STORAGE_KEY, JSON.stringify(localGrant));
 
   // Hand the grant to the worker. Self-hosted: a localhost file handoff.
@@ -419,7 +466,7 @@ async function signBinding(args: {
   owner: Address;
   smartAccount: Address;
   chainId: number;
-  ownerAccount: ReturnType<typeof privateKeyToAccount>;
+  ownerSigner: OwnerSigner;
   /** The wallet the session belongs to — what the server will check against. */
   tenant: Address;
 }): Promise<NonNullable<Grant["binding"]>> {
@@ -427,6 +474,36 @@ async function signBinding(args: {
     if (!r.ok) throw new Error("couldn't start the account link — please sign in again.");
     return r.json();
   })) as { origin: string; nonce: string };
+
+  // ── privy-did-owner-v1: ONE SIGNATURE, AND THE DID IS IN THE TEXT ────────
+  //
+  // No injected provider is consulted, and that is the fix for the error this
+  // path used to throw: it compared the browser wallet's ACTIVE account against
+  // the session, which under Privy is an embedded wallet MetaMask has never
+  // heard of. The comparison was right for a model where the login is an
+  // injected wallet, and simply does not apply to this one.
+  //
+  // Authentication here is the access token the server verifies at intake; this
+  // signature is the owner half. The DID is inside the signed bytes, so a
+  // signature captured under one identity cannot be replayed under another.
+  if (args.ownerSigner.binding === "privy-did-owner-v1") {
+    const did = args.ownerSigner.did;
+    const privyMessage = bindingMessage({
+      version: "privy-did-owner-v1",
+      origin: ch.origin,
+      nonce: ch.nonce,
+      owner: args.owner,
+      smartAccount: args.smartAccount,
+      chainId: args.chainId,
+      did,
+    });
+    return {
+      version: "privy-did-owner-v1",
+      nonce: ch.nonce,
+      ownerSignature: await args.ownerSigner.account.signMessage({ message: privyMessage }),
+      did,
+    };
+  }
 
   const message = bindingMessage({
     origin: ch.origin,
@@ -460,9 +537,9 @@ async function signBinding(args: {
   })) as `0x${string}`;
 
   // Local, no popup: the generated owner key vouches for itself.
-  const ownerSignature = await args.ownerAccount.signMessage({ message });
+  const ownerSignature = await args.ownerSigner.account.signMessage({ message });
 
-  return { nonce: ch.nonce, walletSignature, ownerSignature };
+  return { version: "legacy-wallet-owner-v1", nonce: ch.nonce, walletSignature, ownerSignature };
 }
 
 /** Where a superseded grant is parked, keyed by the account it controls. */
@@ -605,11 +682,32 @@ export function refusalMessage(status: number, serverError?: string): string {
   }
 }
 
+/**
+ * How the browser proves a Privy identity when handing over a grant.
+ *
+ * Set by the Privy sign-in once, read here. The access token is NOT stored —
+ * this is a getter, so the token is fetched fresh at the moment it is needed
+ * and Privy refreshes it near expiry. Holding one would mean holding a
+ * credential past the moment it was useful.
+ */
+let privyTokenSource: (() => Promise<string | null>) | null = null;
+export function setPrivyTokenSource(fn: (() => Promise<string | null>) | null): void {
+  privyTokenSource = fn;
+}
+
 async function postGrant(grant: Grant): Promise<GrantHandoff> {
   try {
+    // A PRIVY BINDING CARRIES ITS TOKEN. The server cannot verify the identity
+    // half of that binding without one, and it refuses rather than falling back
+    // to the legacy check — so a missing header is a 401, not a downgrade.
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (grant.binding?.version === "privy-did-owner-v1" && privyTokenSource) {
+      const token = await privyTokenSource();
+      if (token) headers.Authorization = `Bearer ${token}`;
+    }
     const res = await fetch("/api/grants", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       credentials: "same-origin",
       body: JSON.stringify(grant),
     });
@@ -660,8 +758,44 @@ export interface MintOptions {
 
 export async function createAgentWallet(o: MintOptions): Promise<MintedGrant> {
   o.onStatus("minting your agent's owner key…");
+  const key = generatePrivateKey();
   return mintGrant(
-    generatePrivateKey(),
+    { account: privateKeyToAccount(key), binding: "legacy-wallet-owner-v1", privateKey: key },
+    o.caps,
+    o.onStatus,
+    o.chainId ?? robinhoodChain.id,
+    o.extraTokens ?? [],
+    o.v4AdapterAddress,
+    o.ponsAdapterAddress,
+    o.hostedAs,
+  );
+}
+
+/**
+ * CREATE A MERRYMAN OWNED BY A PRIVY EMBEDDED WALLET.
+ *
+ * Everything downstream is the SAME code the browser-key path runs: the same
+ * Kernel v3.3 derivation, the same permission wall, the same session key, the
+ * same serialization. Only the owner differs, and only in where its signature
+ * comes from. There is no second smart-account implementation, no alternative
+ * executor, and no Privy account abstraction anywhere in the path.
+ *
+ * WHAT IS GONE, DELIBERATELY: `demoOwnerPrivateKey`. A Privy owner has no key
+ * for merrymen to hold, back up, strip at the boundary, or lose — which
+ * removes the localStorage custody this file's header has always flagged as
+ * the weak point, and replaces it with Privy's own recovery. The consequence
+ * to be honest about is the mirror image: merrymen cannot sweep this account
+ * from a backed-up key, because there is no such key. Recovery for a
+ * Privy-owned Merryman is signer-based and is NOT yet built.
+ */
+export async function createPrivyOwnedWallet(
+  owner: LocalAccount,
+  did: string,
+  o: MintOptions,
+): Promise<MintedGrant> {
+  o.onStatus("deriving your smart account…");
+  return mintGrant(
+    { account: owner, binding: "privy-did-owner-v1", did },
     o.caps,
     o.onStatus,
     o.chainId ?? robinhoodChain.id,
@@ -689,7 +823,11 @@ export async function restoreAgentWallet(
 ): Promise<MintedGrant> {
   o.onStatus("re-deriving your smart account from the owner key…");
   return mintGrant(
-    ownerPrivateKey,
+    {
+      account: privateKeyToAccount(ownerPrivateKey),
+      binding: "legacy-wallet-owner-v1",
+      privateKey: ownerPrivateKey,
+    },
     o.caps,
     o.onStatus,
     o.chainId ?? robinhoodChain.id,

--- a/web/src/terminal/screens/CreateAgent.tsx
+++ b/web/src/terminal/screens/CreateAgent.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from "react";
 import { ArrowLeft, ArrowRight, Check, Eye, EyeOff } from "lucide-react";
 import { isValidCustomToken, type CustomToken } from "@merrymen/core";
-import { createAgentWallet, loadGrant, type Grant, type GrantCaps } from "@/lib/session";
+import { createAgentWallet, createPrivyOwnedWallet, loadGrant, type Grant, type GrantCaps } from "@/lib/session";
+import { usePrivyOwner } from "@/terminal/usePrivyOwner";
 import { verifiedAdapter } from "@/lib/verified-adapter";
 import { requestJson, SignIn, type AccountState } from "../HostedControls";
 import { Face } from "../ui";
@@ -26,6 +27,9 @@ export function CreateAgent({account,onRefresh,onBack,onDone,onFund}:{account:Ac
   const [step,setStep]=useState<"agent"|"limits"|"backup"|"fund">("agent");
   const [name,setName]=useState("");
   const [strategy,setStrategy]=useState("steady-basket");
+  // Null on a legacy session — which is what keeps an existing Merryman on
+  // its existing owner key.
+  const privyOwner=usePrivyOwner();
   const [paper,setPaper]=useState(true);
   const [trade,setTrade]=useState("10");
   const [day,setDay]=useState("50");
@@ -68,7 +72,11 @@ export function CreateAgent({account,onRefresh,onBack,onDone,onFund}:{account:Ac
       const address=(value?:string)=>value&&/^0x[0-9a-fA-F]{40}$/.test(value) ? value as `0x${string}` : undefined;
       const pons=await verifiedAdapter(address(settings.values.ponsAdapterAddress),4663,setStatus);
       await requestJson("/api/settings",{method:"PUT",headers:{"Content-Type":"application/json"},body:JSON.stringify({agentName:name.trim(),strategy,paperTradingEnabled:paper})});
-      const result=await createAgentWallet({caps:{...INITIAL_CAPS,perTradeUsdg:Number(trade),dailyUsdg:Number(day)},chainId:4663,extraTokens:(settings.values.customTokens??[]).filter(isValidCustomToken) as CustomToken[],v4AdapterAddress:address(settings.values.v4AdapterAddress),ponsAdapterAddress:pons,hostedAs:account?.session.hosted ? account.session.address as `0x${string}` : undefined,onStatus:setStatus});
+      const mintOptions={caps:{...INITIAL_CAPS,perTradeUsdg:Number(trade),dailyUsdg:Number(day)},chainId:4663,extraTokens:(settings.values.customTokens??[]).filter(isValidCustomToken) as CustomToken[],v4AdapterAddress:address(settings.values.v4AdapterAddress),ponsAdapterAddress:pons,hostedAs:account?.session.hosted ? account.session.address as `0x${string}` : undefined,onStatus:setStatus};
+      // WHO OWNS THIS MERRYMAN. A Privy session owns it with the embedded
+      // wallet it signed in with; everything else keeps the browser-generated
+      // key. Same Kernel, same wall, same session key either way.
+      const result=privyOwner ? await createPrivyOwnedWallet(privyOwner.account,privyOwner.did,mintOptions) : await createAgentWallet(mintOptions);
       setGrant(result.local);setArmed(result.handoff.ok);setStep("backup");setStatus("");
       if(!result.handoff.ok)setError(result.handoff.error ?? "Your wallet was created, but the service could not activate your agent. Save its recovery key before retrying.");
     }catch(e){setError(e instanceof Error ? e.message : "Could not create your agent. Try again.");}

--- a/web/src/terminal/usePrivyOwner.ts
+++ b/web/src/terminal/usePrivyOwner.ts
@@ -1,0 +1,83 @@
+"use client";
+
+/**
+ * THE PRIVY EMBEDDED WALLET, AS A KERNEL OWNER — or null.
+ *
+ * Null means "not a Privy session", and every caller treats that as "use the
+ * browser-generated owner key exactly as before". That is what keeps an
+ * existing Merryman on its existing owner: a legacy user who links a DID still
+ * gets null here, because their tenant is not this wallet.
+ *
+ * A LOCAL ACCOUNT, NOT AN EIP-1193 PROVIDER. `toViemAccount` returns a viem
+ * LocalAccount with a fixed address. Handing ZeroDev the raw provider instead
+ * would route through `toSigner`, which resolves the address with
+ * `Promise.any([eth_requestAccounts, eth_accounts])` and takes `[0]` —
+ * whichever RPC answers first. The owner address decides the ACCOUNT address,
+ * so that race would decide which Merryman somebody gets.
+ *
+ * `getEmbeddedConnectedWallet` and never `wallets[0]`: with the wallet login
+ * enabled, `useWallets()` returns a mixed list and index zero can be the user's
+ * MetaMask. Deriving a Kernel account from THAT would hand them a different
+ * agent with a straight face.
+ */
+
+import { useEffect, useState } from "react";
+import {
+  getEmbeddedConnectedWallet,
+  toViemAccount,
+  usePrivy,
+  useWallets,
+} from "@privy-io/react-auth";
+import type { LocalAccount } from "viem";
+import { setPrivyTokenSource } from "@/lib/session";
+import { privyEnabled } from "@/lib/privy-client";
+
+export interface PrivyOwner {
+  account: LocalAccount;
+  /** The DID this owner signs under. Goes into the binding's signed text. */
+  did: string;
+}
+
+export function usePrivyOwner(): PrivyOwner | null {
+  const enabled = privyEnabled();
+  const { authenticated, user, getAccessToken } = usePrivy();
+  const { wallets, ready } = useWallets();
+  const [owner, setOwner] = useState<PrivyOwner | null>(null);
+
+  // The grant handoff needs a FRESH access token at the moment it posts, not
+  // one captured earlier — so publish the getter rather than a value.
+  useEffect(() => {
+    if (!enabled) return;
+    setPrivyTokenSource(authenticated ? getAccessToken : null);
+    return () => setPrivyTokenSource(null);
+  }, [authenticated, enabled, getAccessToken]);
+
+  useEffect(() => {
+    if (!enabled || !authenticated || !ready) {
+      setOwner(null);
+      return;
+    }
+    const wallet = getEmbeddedConnectedWallet(wallets);
+    const did = user?.id ?? "";
+    if (!wallet || !did) {
+      setOwner(null);
+      return;
+    }
+    let live = true;
+    void toViemAccount({ wallet })
+      .then((account) => {
+        if (live) setOwner({ account: account as unknown as LocalAccount, did });
+      })
+      .catch(() => {
+        // No owner rather than a wrong one. The caller falls back to the
+        // browser-key path, which refuses loudly rather than deriving an
+        // account from a signer it could not build.
+        if (live) setOwner(null);
+      });
+    return () => {
+      live = false;
+    };
+  }, [authenticated, enabled, ready, user?.id, wallets]);
+
+  return owner;
+}


### PR DESCRIPTION
PR C. The X login worked, then hit:

> Your wallet is on 0xa233…5908 but you signed in as 0xd55b…a9de. Switch back to that account in your wallet, or sign out and in again.

`signBinding` was comparing the **injected** wallet's active account against the session. Correct for a model where the login *is* an injected wallet; meaningless when the session belongs to an embedded wallet MetaMask has never heard of.

### An owner is a signer, not a private key

`mintGrant` took `0x`-hex; it now takes an `OwnerSigner` — a browser key **or** a Privy embedded wallet, tagged with the binding model it implies. Everything downstream is the same code: same Kernel v3.3 derivation, same permission wall, same session key, same serialization. No second smart-account implementation, no alternative executor, no Privy account abstraction.

### A LocalAccount, never the EIP-1193 provider

`toViemAccount({wallet})` returns a fixed-address LocalAccount. Handing ZeroDev the raw provider routes through `toSigner`, which resolves the address with `Promise.any([eth_requestAccounts, eth_accounts])` and takes `[0]`. The owner address decides the **account** address — that race would decide which Merryman somebody gets. Same reason `getEmbeddedConnectedWallet` is used and `wallets[0]` is not.

### The binding, verified end to end

One signature, with the **DID inside the signed bytes** — a signature made under one identity reconstructs to different text under another and fails to recover. Authentication is the access token, verified at grant intake. `verifyGrantBinding` holds no Privy credential and verifies no token itself: it is *given* the DID or it refuses. And the owner must **be** the tenant the DID resolved to, or a verified login could install a grant on an owner it does not control.

### What is gone, and the trade-off stated where it will be read

A Privy-owned grant has no `demoOwnerPrivateKey` — merrymen never holds one, which removes the localStorage custody this file has always flagged as the weak point. The mirror image: merrymen cannot sweep such an account from a backed-up key, because none exists. **Recovery for a Privy-owned Merryman is signer-based and is NOT yet built** — a test asserts that sentence is present rather than letting it be implied.

Existing Merrymen untouched: `usePrivyOwner` returns null on a legacy session, so CreateAgent takes the browser-key path exactly as before.

Five binding cases now covered that did not exist: no token, mismatched DID, owner-is-not-tenant, a complete valid binding, and a signature replayed under a different identity.

2666 tests pass, both typechecks clean, `next build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)